### PR TITLE
Continue work on megamerge (localization and source highlighting)

### DIFF
--- a/content/docs/reference/_blueprint.yaml
+++ b/content/docs/reference/_blueprint.yaml
@@ -1,3 +1,5 @@
 $title@: Reference
 $path: /docs/reference/{base}.html
 $view: /views/doc.html
+$localization:
+  path: /{locale}/docs/reference/{base}.html

--- a/content/docs/support/_blueprint.yaml
+++ b/content/docs/support/_blueprint.yaml
@@ -1,3 +1,5 @@
 $title@: Support
 $path: /docs/support/{base}.html
 $view: /views/doc.html
+$localization:
+  path: /{locale}/docs/support/{base}.html

--- a/podspec.yaml
+++ b/podspec.yaml
@@ -1,4 +1,4 @@
-grow_version: ">=0.0.63"
+grow_version: ">=0.0.65"
 home: /content/pages/home.html
 
 localization:
@@ -27,6 +27,11 @@ static_dirs:
 
 preprocessors:
 - kind: gulp
+
+markdown:
+  extensions:
+  - kind: sourcecode
+    classes: true
 
 deployments:
   review:

--- a/views/partials/lang_switcher.html
+++ b/views/partials/lang_switcher.html
@@ -5,8 +5,8 @@
     </li>
     {% for locale in doc.locales if not locale == doc.locale  %}
     <li>
-        {% set lurl = g.url(doc.pod_path, locale=locale).path %}
-        <a href="{{ lurl }}" class="flag-{{locale}}"><span>{{locale.get_language_name()}}</span></a>
+        {% set localized_doc = doc.localize(locale) %}
+        <a href="{{ localized_doc.url.path }}" class="flag-{{locale}}"><span>{{locale.get_language_name()}}</span></a>
     </li>
     {% endfor %}
     </ul>

--- a/views/partials/nav.html
+++ b/views/partials/nav.html
@@ -11,7 +11,7 @@
   {% endif %}
 
   {% if open and sub_collection.exists %}
-    {{ render_children(item, sub_collection.docs()) }}
+    {{ render_children(item, sub_collection.docs(locale=doc.locale)) }}
   {% endif %}
   </li>
 {% endmacro %}
@@ -37,7 +37,7 @@
     <li>
       <h2>{{_(collection.title)}}</h2>
       <ul>
-        {% for item in collection.docs(recursive=false) %}
+        {% for item in collection.docs(recursive=false, locale=doc.locale) %}
           {{render_item(item)}}
         {% endfor %}
       </ul>


### PR DESCRIPTION
- Fix localized links in nav menu by verifying Reference and Support sections are localized.
- Use new Grow feature to switch sourcecode Markdown blocks to use classes instead of inline styles.
- Improve the durability of the locale switcher by using Grow APIs for localizing documents.
- Bump Grow version to 0.0.65 (not released yet).