### PR TITLE
Fix build time issue and two other tiny cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,10 @@ $ grow run
 
 You can now open http://localhost:8080/ and continue working on the source files, then reload the page to see changes appear.
 
-### Deploy
+### Build
 
 ```sh
 $ grow build
-$ grow deploy
 ```
 
 This will generate a static, complete build of the site into the **build* folder.

--- a/views/base.html
+++ b/views/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html ⚡{% if doc.locale == "ar" %} dir="rtl" lang="ar"{% endif %}>
+<html ⚡{% if doc.locale.is_rtl %} dir="rtl" lang="ar"{% endif %}>
 {% include "/views/partials/head.html" %}
-<body class="{{doc.class}}{% if doc.locale == 'ar' %}rtl{% endif %}">
+<body class="{{doc.class}}{% if doc.locale.is_rtl %}rtl{% endif %}">
 <amp-analytics type="googleanalytics" id="analytics-ga">
   <script type="application/json">
   {

--- a/views/partials/nav.html
+++ b/views/partials/nav.html
@@ -1,6 +1,6 @@
 {% macro render_item(item) -%}
   {% set sub_collection = g.collection(item.collection.pod_path + '/' + item.base) %}
-  {% set open = sub_collection.pod_path == doc.pod_path[:-3] or doc in sub_collection %}
+  {% set open = sub_collection.pod_path in doc.pod_path[:-3] %}
 
   {% if doc == item %}
     <li class="current">


### PR DESCRIPTION
Hi @pbakaus, this fixes the build time issue. :) I was doing something very stupid and expensive when generating the nav menu (notice the removal of the `O(n)` check). The whole site (all locales) builds in about five minutes on my machine now, and I'm pretty happy with that time.

Next week I'll look into some additional caching or optimizations that can be done on the Grow side, but I think a five minute build for 3000 Markdown files is hopefully reasonable enough for now! [Still would like to make it faster though. ;)]

This PR also contains two minor other things
- Use `doc.locale.is_rtl` instead of checking a hardcoded `ar` locale.
- Update the README to remove `grow deploy` since it's not used in this workflow, nor does that command actually work without a destination anyway.

If you could double check the nav menu to ensure it's still being generated properly, that'd be great. I did a cursory check and I think it looks good.

Cheers!