### PR TITLE
Darken the text in reference pages a bit.

### DIFF
--- a/assets/sass/_config.scss
+++ b/assets/sass/_config.scss
@@ -39,7 +39,6 @@ $color-black-87: #212121;
 
 // TODO: Legacy, remove these vars
 $color-lightgrey: $color-grey-100;
-$color-black-54: $color-grey-600;
 $color-text: $color-black-95;
 $color-link: #0360B5;
 

--- a/assets/sass/_global.scss
+++ b/assets/sass/_global.scss
@@ -116,6 +116,7 @@ code {
     font-size: 15px;
     border: 1px solid $color-lightgrey;
     border-radius: 3px;
+    color: $color-grey-800;
 }
 
 code {

--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -1,5 +1,5 @@
 @mixin text-body() {
-  color: $color-black-54;
+  color: $color-grey-800;
   font-size: 16px;
   font-weight: 300;
   line-height: 24px;

--- a/assets/sass/_syntax_highlighting.scss
+++ b/assets/sass/_syntax_highlighting.scss
@@ -33,7 +33,7 @@ pre {
 .highlight .gr { color: #aa0000 } /* Generic.Error */
 .highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
 .highlight .gi { color: #00aa00 } /* Generic.Inserted */
-.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .go { color: $color-grey-800 } /* Generic.Output */
 .highlight .gp { color: #555555 } /* Generic.Prompt */
 .highlight .gs { font-weight: bold } /* Generic.Strong */
 .highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */


### PR DESCRIPTION
For pages such as
https://www.ampproject.org/docs/guides/validate.html and
https://www.ampproject.org/docs/reference/amp-img.html,
the reader encounteres a fair amount of text. This is currently
configured to be displayed with $color-grey-600, also
known as $color-black-54, which is #757575. On less than optimal
screens and for people with less than optimal eyes, this is tiring
to read. I think my corrected vision is quite good and I wear
fancy computer glasses in front of a great 30" screen,
but even I notice it. So I'd like to crank this up a bit, to $424242
($color-grey-800).

Detailed changes:
- _config.css, can remove color-black-54, since I'm removing the
  last usage.
- _global.scss, set the color for code snippets (typically the things
  tagged with `single backtick`) to this new value.
- _mixins.scss, set the color for text to this new value; this affects
  the main text blocks, e.g. the paragraphs describing a feature or
  command or tag.
- _syntax_highlighting.scss, set the color for generic output to
  this new value; this is the color for stuff in the larger
  [sourcecode:shell-session] blocks.