### PR TITLE
Add 301 redirect for amp-ad.md

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -29,6 +29,11 @@
         "type": 301
       },
       {
+        "source": "/docs/reference/amp-ad.html",
+        "destination": "/docs/reference/extended/amp-ad.html",
+        "type": 301
+      },
+      {
         "source": "/faq",
         "destination": "/docs/support/faqs.html",
         "type": 301


### PR DESCRIPTION
We plan to remove the duplicated README files for amp-ad. This is a prerequisite.
See https://github.com/ampproject/amphtml/pull/4761