### PR TITLE
Align globe icon on right for RTL Languages

### DIFF
--- a/assets/sass/_lang_switcher.scss
+++ b/assets/sass/_lang_switcher.scss
@@ -35,6 +35,10 @@ div.language {
     border-bottom: 1px solid rgb(231, 235, 236);
     box-sizing: border-box;
     height: 33px;
+    
+    body.rtl & {
+      background-position: calc(100% - 6px) 6px;
+    }
 
     &:hover {
       background-color: #0379c4;


### PR DESCRIPTION
Fixes an issue where the globe icon is placed over text in the language dropdown when the docs are rendered in RTL mode

I'll be honest, I've only tested this in CSS not SCSS so I'm unsure if this particular change will work.  I do not currently possess the capabilities to test this diff.
