### PR TITLE
Remove hx:before tag blocking scroll

### DIFF
--- a/assets/sass/_global.scss
+++ b/assets/sass/_global.scss
@@ -270,3 +270,7 @@ figure {
 .center-content {
   text-align: center;
 }
+
+.code {
+  position: relative;
+}


### PR DESCRIPTION
I found that I can't scroll the script box below on [this pages](https://www.ampproject.org/learn/how-amp-works/#dont-let-extension-mechanisms-block-rendering).
> ```<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>```

I'm using Chrome 54. 
The ```::before``` components block scrolling. When I delete that, Anything changed but I could scroll.
What actually do ```h(n):before``` styles for?