### PR TITLE
Typos in analytics guides: browser substitution

### DIFF
--- a/content/docs/guides/analytics_amp.md
+++ b/content/docs/guides/analytics_amp.md
@@ -46,5 +46,5 @@ Key data points to consider:
 * Will you track only page views, or additional user engagement patterns
 (see also [amp-pixel or amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))?
 * What kinds of data will you capture about your users, your content,
-the device or brower (see also [Variable substition](/docs/guides/analytics/analytics_basics.html#variable-substition))?
+the device or browser (see also [Variable substitution](/docs/guides/analytics/analytics_basics.html#variable-substitution))?
 * How will you identify your users (see also [User identification](/docs/guides/analytics/analytics_basics.html#user-identification))?

--- a/content/docs/guides/analytics_amp/deep_dive_analytics.md
+++ b/content/docs/guides/analytics_amp/deep_dive_analytics.md
@@ -135,7 +135,7 @@ to the account value in the remote URL (`"account": "UA-XXXXX-Y"`):
 [/sourcecode]
 
 **Important:** AMP doesn’t validate against multiple uses of the same variable.
-Values get populated following a variable substition order of preference,
+Values get populated following a variable substitution order of preference,
 and values in remote URLs are top of that order
 (see [Variable substitution ordering](/docs/guides/analytics/deep_dive_analytics.html#variable-substitution-ordering)).
 

--- a/content/docs/guides/analytics_amp@ar.md
+++ b/content/docs/guides/analytics_amp@ar.md
@@ -45,5 +45,5 @@ $title: تهيئة Analytics
 * هل ستتبّع فقط مشاهدات الصفحة، أم أنماط تفاعل المستخدم الإضافية
 (انظر أيضًا [<span dir="ltr" class="nowrap">amp-pixel</span> أو <span dir="ltr" class="nowrap">amp-analytics</span>](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))؟
 * ما أنواع البيانات التي ستقوم بجمعها بشأن مستخدميك، أو محتواك،
-أو الجهاز، أو المتصفح (انظر أيضًا [استبدال المتغير](/docs/guides/analytics/analytics_basics.html#variable-substition))؟
+أو الجهاز، أو المتصفح (انظر أيضًا [استبدال المتغير](/docs/guides/analytics/analytics_basics.html#variable-substitution))؟
 * كيف ستتعرّف على هوية مستخدميك (انظر أيضًا [هوية المستخدم](/docs/guides/analytics/analytics_basics.html#user-identification))؟

--- a/content/docs/guides/analytics_amp@es.md
+++ b/content/docs/guides/analytics_amp@es.md
@@ -45,5 +45,5 @@ Puntos de datos claves que debes considerar:
 * ¿Realizarás un seguimiento solo de las vistas de la página o de otros patrones de captación de usuarios?
 (Consulta también la sección [¿amp-pixel o amp-analytics?](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics)).
 * ¿Qué tipos de datos puedes capturar acerca de tus usuarios, tu contenido,
-el dispositivo o el navegador (consulta también la sección sobre [sustitución de variables](/docs/guides/analytics/analytics_basics.html#variable-substition))?
+el dispositivo o el navegador (consulta también la sección sobre [sustitución de variables](/docs/guides/analytics/analytics_basics.html#variable-substitution))?
 * ¿Cómo identificarás a tus usuarios (consulta también [Identificación de usuarios](/docs/guides/analytics/analytics_basics.html#user-identification))?

--- a/content/docs/guides/analytics_amp@fr.md
+++ b/content/docs/guides/analytics_amp@fr.md
@@ -45,5 +45,5 @@ Points clés à prendre en compte concernant les données :
 * Allez-vous suivre uniquement les vues de page ou d'autres tendances sur l'engagement des utilisateurs
 (voir également [amp-pixel ou amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics)) ?
 * Quels types de données allez-vous capturer sur vos utilisateurs, votre contenu,
-le périphérique ou le navigateur (voir également [Substitution de variables](/docs/guides/analytics/analytics_basics.html#variable-substition)) ?
+le périphérique ou le navigateur (voir également [Substitution de variables](/docs/guides/analytics/analytics_basics.html#variable-substitution)) ?
 * Comment allez-vous identifier vos utilisateurs (voir également [Identification des utilisateurs](/docs/guides/analytics/analytics_basics.html#user-identification)) ?

--- a/content/docs/guides/analytics_amp@id.md
+++ b/content/docs/guides/analytics_amp@id.md
@@ -45,5 +45,5 @@ Butir-butir data utama yang harus dipertimbangkan:
 * Akankah Anda hanya melacak tampilan halaman saja, atau pola keterlibatan pengguna tambahan
 (lihat juga [amp-pixel atau amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))?
 * Jenis data apakah yang akan Anda tangkap dari pengguna, materi, 
-perangkat atau browser (lihat juga [Penggantian variabel](/docs/guides/analytics/analytics_basics.html#variable-substition)?
+perangkat atau browser (lihat juga [Penggantian variabel](/docs/guides/analytics/analytics_basics.html#variable-substitution)?
 * Bagaimana Anda akan mengidentifikasi pengguna Anda (lihat juga [Identifikasi pengguna](/docs/guides/analytics/analytics_basics.html#user-identification))?

--- a/content/docs/guides/analytics_amp@it.md
+++ b/content/docs/guides/analytics_amp@it.md
@@ -45,5 +45,5 @@ Fattori importanti relativi ai dati da prendere in considerazione:
 * Eseguirai solamente il monitoraggio delle visualizzazioni di pagina o anche di altri modelli di coinvolgimento dell’utente
 (vedi anche [amp-pixel o amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))?
 * Quali tipi di dati acquisirai relativamente ai tuoi utenti, ai tuoi contenuti,
-a dispositivi o browser (vedi anche [Sostituzione delle variabili](/docs/guides/analytics/analytics_basics.html#variable-substition))?
+a dispositivi o browser (vedi anche [Sostituzione delle variabili](/docs/guides/analytics/analytics_basics.html#variable-substitution))?
 * Come identificherai i tuoi utenti (vedi anche [Identificazione dell’utente](/docs/guides/analytics/analytics_basics.html#user-identification))?

--- a/content/docs/guides/analytics_amp@ja.md
+++ b/content/docs/guides/analytics_amp@ja.md
@@ -44,6 +44,6 @@ AMP アナリティクスは 1 回の計測で、複数の URL に結果を送�
 
 * ページビューのみトラックするか、その他のユーザー エンゲージメント パターンもトラックするか（[amp-pixel か amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics) についてもご覧ください）。
 
-* ユーザー、コンテンツ、端末やブラウザについて、何のデータを収集するか（[変数置換](/docs/guides/analytics/analytics_basics.html#variable-substition)についてもご覧ください）。
+* ユーザー、コンテンツ、端末やブラウザについて、何のデータを収集するか（[変数置換](/docs/guides/analytics/analytics_basics.html#variable-substitution)についてもご覧ください）。
 
 * ユーザの特定方法はどうするか（[ユーザーの識別](/docs/guides/analytics/analytics_basics.html#user-identification)についてもご覧ください）。

--- a/content/docs/guides/analytics_amp@ko.md
+++ b/content/docs/guides/analytics_amp@ko.md
@@ -45,5 +45,5 @@ AMP Analytics는 한 번의 측정으로 여러 곳에 보고하도록 특별히
 * 페이지 뷰만 추적하겠습니까 아니면 추가적인 사용자 참여
 패턴도 추적하겠습니까(참고 항목 [amp-pixel 또는 amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))?
 * 사용자, 콘텐츠 기기 또는 브라우저에 관한 어떤 데이터를 캡처하겠습니까
-(참고 항목 [변수 대체](/docs/guides/analytics/analytics_basics.html#variable-substition))?
+(참고 항목 [변수 대체](/docs/guides/analytics/analytics_basics.html#variable-substitution))?
 * 어떻게 사용자를 식별하겠습니까(참고 항목 [사용자 식별](/docs/guides/analytics/analytics_basics.html#user-identification))?

--- a/content/docs/guides/analytics_amp@nl.md
+++ b/content/docs/guides/analytics_amp@nl.md
@@ -45,5 +45,5 @@ Belangrijke punten om te overwegen:
 * Wilt u alleen paginaweergaven bijhouden of ook extra patronen in het betrokkenheid van gebruikers
 (zie ook [amp-pixel of amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))?
 * Wat voor soort gegevens wilt u vastleggen over uw gebruikers, uw content,
-het apparaat of de browser (zie ook [Vervanging van variabelen](/docs/guides/analytics/analytics_basics.html#variable-substition))?
+het apparaat of de browser (zie ook [Vervanging van variabelen](/docs/guides/analytics/analytics_basics.html#variable-substitution))?
 * Hoe gaat u gebruikers identificeren (zie ook [Gebruikersidentificatie](/docs/guides/analytics/analytics_basics.html#user-identification))?

--- a/content/docs/guides/analytics_amp@pl.md
+++ b/content/docs/guides/analytics_amp@pl.md
@@ -45,5 +45,5 @@ Kluczowe punkty danych, które trzeba wziąć pod uwagę:
 * Zamierzasz monitorować tylko wyświetlenia stron, czy wzorce czynności użytkowników
 (patrz także opis znaczników [amp-pixel lub amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))?
 * Jakie zamierzasz przechwytywać rodzaje danych o użytkownikach, treściach,
-o urządzeniu lub przeglądarce (patrz także [Podstawianie zmiennych](/docs/guides/analytics/analytics_basics.html#variable-substition))?
+o urządzeniu lub przeglądarce (patrz także [Podstawianie zmiennych](/docs/guides/analytics/analytics_basics.html#variable-substitution))?
 * Jak zamierzasz identyfikować swoich użytkowników (patrz także [Identyfikacja użytkownika](/docs/guides/analytics/analytics_basics.html#user-identification))?

--- a/content/docs/guides/analytics_amp@pt_BR.md
+++ b/content/docs/guides/analytics_amp@pt_BR.md
@@ -45,5 +45,5 @@ Os principais pontos a serem considerados:
 * Você pretende rastrear somente as visualizações de páginas ou outros padrões de envolvimento do usuário
 (consulte também [amp-pixel ou amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))?
 * Que tipos de dados você pretende capturar sobre seus usuários, seu conteúdo,
-o dispositivo ou navegador (consulte também [Substituição de variáveis](/docs/guides/analytics/analytics_basics.html#variable-substition))?
+o dispositivo ou navegador (consulte também [Substituição de variáveis](/docs/guides/analytics/analytics_basics.html#variable-substitution))?
 * Como você pretende identificar seus usuários (consulte também [Identificação de usuários](/docs/guides/analytics/analytics_basics.html#user-identification))?

--- a/content/docs/guides/analytics_amp@ru.md
+++ b/content/docs/guides/analytics_amp@ru.md
@@ -45,5 +45,5 @@ $title: Настройка Analytics
 * Будете ли вы отслеживать только просмотры страниц или учитывать также дополнительные модели заинтересованности пользователей
 (см. также [amp-pixel или amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))?
 * Какого рода данные вы собираетесь отслеживать о своих пользователях, своем контенте, устройстве или браузере
-(см. также [Подстановка переменных](/docs/guides/analytics/analytics_basics.html#variable-substition))?
+(см. также [Подстановка переменных](/docs/guides/analytics/analytics_basics.html#variable-substitution))?
 * Как вы будете идентифицировать своих пользователей (см. также [Идентификация пользователей](/docs/guides/analytics/analytics_basics.html#user-identification))?

--- a/content/docs/guides/analytics_amp@th.md
+++ b/content/docs/guides/analytics_amp@th.md
@@ -45,5 +45,5 @@ $title: กำหนดค่า Analytics
 * คุณจะติดตามเฉพาะการเข้าชมหน้าเว็บเพียงอย่างเดียวหรือการมีส่วนร่วมของผู้ใช้ในรูปแบบอื่นๆ เพิ่มเติม
 (ดูเพิ่มเติมเกี่ยวกับ [amp-pixel หรือ amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))
 * ข้อมูลประเภทใดที่คุณจะรวบรวมเกี่ยวกับผู้ใช้ของคุณ เนื้อหาของคุณ
-อุปกรณ์หรือเบราว์เซอร์ (ดูเพิ่มเติมเกี่ยวกับ[การแทนค่าตัวแปร](/docs/guides/analytics/analytics_basics.html#variable-substition))
+อุปกรณ์หรือเบราว์เซอร์ (ดูเพิ่มเติมเกี่ยวกับ[การแทนค่าตัวแปร](/docs/guides/analytics/analytics_basics.html#variable-substitution))
 * คุณจะระบุผู้ใช้ของคุณอย่างไร (ดูเพิ่มเติมเกี่ยวกับ[การระบุผู้ใช้](/docs/guides/analytics/analytics_basics.html#user-identification))

--- a/content/docs/guides/analytics_amp@tr.md
+++ b/content/docs/guides/analytics_amp@tr.md
@@ -45,5 +45,5 @@ Dikkate alınması gereken ana veri noktaları:
 * Yalnızca sayfa görünümlerini mi, yoksa ek kullanıcı katılım desenlerini mi izleyeceksiniz
 (ayrıca bkz. [amp-piksel ya da amp-analitik](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))?
 * Kullanıcılarınız, içeriğiniz,
-cihazınız veya tarayıcınız hakkında ne tür veriler toplayacaksınız (ayrıca bkz. [Değişken değiştirme](/docs/guides/analytics/analytics_basics.html#variable-substition))?
+cihazınız veya tarayıcınız hakkında ne tür veriler toplayacaksınız (ayrıca bkz. [Değişken değiştirme](/docs/guides/analytics/analytics_basics.html#variable-substitution))?
 * Kullanıcılarınızı nasıl tanımlayacaksınız (ayrıca bkz. [Kullanıcı tanımlama](/docs/guides/analytics/analytics_basics.html#user-identification))?

--- a/content/docs/guides/analytics_amp@zh_CN.md
+++ b/content/docs/guides/analytics_amp@zh_CN.md
@@ -44,6 +44,6 @@ AMP Analytics 经过专门设计，测量一次便可报告给多方。
 
 * 您是仅跟踪页面视图，还是跟踪其他用户互动模式（另请参阅 [amp-pixel 或 amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics)）？
 
-* 您将捕获哪些类型的用户相关数据，内容、设备还是浏览器（另请参阅[变量替代项](/docs/guides/analytics/analytics_basics.html#variable-substition)）？
+* 您将捕获哪些类型的用户相关数据，内容、设备还是浏览器（另请参阅[变量替代项](/docs/guides/analytics/analytics_basics.html#variable-substitution)）？
 
 * 您将如何识别用户（另请参阅[用户识别](/docs/guides/analytics/analytics_basics.html#user-identification)）？


### PR DESCRIPTION
* brower -> browser
* substition -> substitution (also affects navigation)

Fix navigation from the translations as well.

Signed-off-by: Dan Scott <dan@coffeecode.net>