### PR TITLE
fix vertical-align on header navigation

### DIFF
--- a/assets/sass/_header.scss
+++ b/assets/sass/_header.scss
@@ -154,6 +154,7 @@
       top: 25px;
       color: inherit;
       text-decoration: none;
+      vertical-align: top;
 
       &:after {
         display: inline-block;


### PR DESCRIPTION
Hi! 😸 
Since there is together alphabet font and Japanese characters(`ドキュメント`, `サポート`) font,  these height are not aligned.

### Screenshot

Here is a screenshot: on the top is current situation, on the bottom is with `vertical-align: top;`.

<img width="755" alt="2016-12-18 18 50 04" src="https://cloud.githubusercontent.com/assets/2628239/21292769/d2aeae70-c552-11e6-9ffd-d0d46766f0f9.png">

