### PR TITLE
Turn off red highlighting for error syntax (e.g. amp-form)

### DIFF
--- a/assets/sass/_syntax_highlighting.scss
+++ b/assets/sass/_syntax_highlighting.scss
@@ -72,7 +72,6 @@ pre {
 .highlight {
   .hll { background-color: #ffffcc }
   .c { color: #0099FF; font-style: italic } /* Comment */
-  .err { color: #AA0000; background-color: #FFAAAA } /* Error */
   .k { color: #006699; font-weight: bold } /* Keyword */
   .o { color: #555555 } /* Operator */
   .cm { color: #0099FF; font-style: italic } /* Comment.Multiline */


### PR DESCRIPTION
Red highlighting is distracting in code syntax (for example, using ellipses or the lightning bolt are considered errors).