### PR TITLE
Fix url so that login-requiring does not 404

### DIFF
--- a/content/docs/guides/login-paywalls.md
+++ b/content/docs/guides/login-paywalls.md
@@ -6,5 +6,5 @@ $order: 7
  Web pages may require to control the document viewing experience for logged in users, and in case of news pages, for subscribers, metered users and anonymous users. While publishing AMP pages, it's possible to hide sections of a page based on an authorization flow by using the [amp-access](https://www.ampproject.org/docs/reference/components/amp-access).
 
 {% call callout('Read on', type='success') %}
-Follow the tutorial on how to [implement a login flow with AMP](/docs/reference/content/docs/get_started/login_requiring.html)
+Follow the tutorial on how to [implement a login flow with AMP](/docs/get_started/login_requiring.html)
 {% endcall %}


### PR DESCRIPTION
The link[1] on the guide to login-paywalls is 404ing

[1] https://www.ampproject.org/docs/reference/content/docs/get_started/login_requiring.html