### PR TITLE
remove margin from h*:before pseudo classes

### DIFF
--- a/assets/sass/_global.scss
+++ b/assets/sass/_global.scss
@@ -48,8 +48,6 @@ h5 {
   &:before {
     display: block;
     content: " ";
-    margin-top: -90px;
-    height: 90px;
     visibility: hidden;
   }
 


### PR DESCRIPTION
this causes the "learn more" link on the global note to be
unclickable.