### PR TITLE
Add height + width to examples for amp-img

### DIFF
--- a/content/docs/guides/responsive_amp/art_direction.md
+++ b/content/docs/guides/responsive_amp/art_direction.md
@@ -18,7 +18,7 @@ of each image in the list:
 
 [sourcecode:html]
 <amp-img
-    src="wide.jpg"
+    src="wide.jpg" width="640" height="480"
     srcset="wide.jpg 640w,
            narrow.jpg 320w">
 </amp-img>
@@ -43,7 +43,7 @@ Consider the following example:
 
 [sourcecode:html]
 <amp-img
-    src="wide.jpg"
+    src="wide.jpg" width="640" height="480"
     srcset="wide.jpg 640w,
            narrow.jpg 320w"
     sizes="(min-width: 650px) 50vw, 100vw">


### PR DESCRIPTION
These snippets wouldn't validate without having width and height.  

to: @pbakaus 