### PR TITLE
Revert "remove margin from h*:before pseudo classes"

### DIFF
--- a/assets/sass/_global.scss
+++ b/assets/sass/_global.scss
@@ -48,6 +48,8 @@ h5 {
   &:before {
     display: block;
     content: " ";
+    margin-top: -90px;
+    height: 90px;
     visibility: hidden;
   }
 


### PR DESCRIPTION
Reverts ampproject/docs#296. Broke anchor based navigation. Better fix is to do a z-index on the banner for now.