### PR TITLE
Fix broken link to add styles to a page

### DIFF
--- a/content/docs/guides/responsive_amp/style_pages.md
+++ b/content/docs/guides/responsive_amp/style_pages.md
@@ -11,7 +11,7 @@ Also certain styles are disallowed due to performance implications;
 inline style attributes aren't allowed.
 
 All styles must live in the head of the document
-(see [Add styles to a page](/docs/guides/validate.html#add-styles-to-a-page)).
+(see [Add styles to a page](/docs/guides/responsive_amp.html#add-styles-to-a-page)).
 But you can use CSS preprocessors and templating to build static pages
 to better manage your content.
 


### PR DESCRIPTION
The link to "Add styles to a page" at https://www.ampproject.org/docs/guides/responsive/style_pages is broken - it points to a page about validation.

BTW, why do we have both "responsive" and "responsive_amp" as a URL path element?

https://www.ampproject.org/docs/guides/responsive_amp
vs.
https://www.ampproject.org/docs/guides/responsive/style_pages