### PR TITLE
Remove maximum-scale etc from how-it-works.

### DIFF
--- a/content/pages/how-it-works.html
+++ b/content/pages/how-it-works.html
@@ -8,7 +8,7 @@ $view: /views/blank.html
   <meta charset="utf-8">
   <title>Accelerated Mobile Pages – A new approach to web performance</title>
   <link rel="canonical" href="https://www.ampproject.org/how-it-works/">
-  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans|Roboto|Droid+Serif' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
   <script src="https://cdn.ampproject.org/v0.js" async></script>

--- a/pwa/pwa.html
+++ b/pwa/pwa.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>PWA</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,minimal-ui">
+  <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
   <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto">
 
   <!-- pwa.html should run at `/pwa` -->


### PR DESCRIPTION
It was decided these weren't needed in AMP some time ago, see
https://github.com/ampproject/amphtml/issues/592, and prevent
zooming in to read the text on the How It Works page.