### PR TITLE
Expand the "How to Contribute" page to encourage more contributions

### DIFF
--- a/content/contribute/contribute.md
+++ b/content/contribute/contribute.md
@@ -25,13 +25,13 @@ To get started with contributing code to the AMP Project read through [the CONTR
 
 When you're ready to work on some code, [the DEVELOPING file](https://github.com/ampproject/amphtml/blob/master/DEVELOPING.md) has documentation of how to get the code and start developing.
 
-If you want to help out but aren't sure where to get started, we have a list of [starter bugs](https://github.com/ampproject/amphtml/blob/master/DEVELOPING.md#starter-issues) that you can use to learn more about the AMP Project code and make an immediate impact.
+If you want to help out but aren't sure where to get started, we have a list of [starter issues](https://github.com/ampproject/amphtml/blob/master/DEVELOPING.md#starter-issues) that you can use to learn more about the AMP Project code and make an immediate impact.
 
 #### Helping with documentation
 
 Documentation is important for the entire AMP community, and we would appreciate your help in making our documentation better!  We've got all sorts of documentation--examples for users of AMP, docs to help AMP Project contributors, etc.
 
-[ampproject.org](https://ampproject.org) is where most people get familiar with AMP.  You can contribute to documentation in the [ampproject docs GitHub project](https://github.com/ampproject/docs).  (You can even make the page you are reading better!)
+[ampproject.org](https://ampproject.org) is where most people get familiar with AMP.  You can contribute to documentation in the [ampproject docs GitHub project](https://github.com/ampproject/docs).  (You can even make [the page you are reading](https://github.com/ampproject/docs/blob/master/content/contribute/contribute.md) better!)
 
 [ampbyexample.com](https://ampbyexample.com) provides examples of how to use AMP.  You can improve it at the [amp-by-example GitHub project](https://github.com/ampproject/amp-by-example/).
 

--- a/content/contribute/contribute.md
+++ b/content/contribute/contribute.md
@@ -6,16 +6,37 @@ $localization:
   path: /{locale}/{base}/
 ---
 
-### AMP Issues
+The AMP Project would not be possible without help from all members of the community
+whether you are a developer, content creator or provider of services relevant to AMP.
+There are many ways for you to contribute.
 
-Please file any feedback you have about the actual project at the [amphtml issue tracker](https://github.com/ampproject/amphtml/issues).
+### Reporting issues with AMP
+If you have feedback or are experiencing technical issues with AMP, please file it using the [issue tracker](https://github.com/ampproject/amphtml/issues).  If you're having issues with [ampproject.org](https://ampproject.org), please use the [docs issue tracker](https://github.com/ampproject/docs/issues) instead.
 
-### Documentation Issues
+### Providing technical contributions to AMP
 
-For bugs or inconsistencies on this website, file a bug at the [docs issue tracker](https://github.com/ampproject/docs/issues) instead.
+The AMP Project strongly encourages technical contributions!
 
-### Contribute source code
+We hope you'll become an ongoing participant in our open source community, but we also welcome one-off contributions for the issues you're particularly passionate about. 
 
-Want to help fix bugs or make AMP even faster? We'd love your help.
+#### Helping with code
 
-Please see [the CONTRIBUTING file](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md) for information on contributing to the AMP Project, the [DEVELOPING file](https://github.com/ampproject/amphtml/blob/master/DEVELOPING.md) for documentation on the AMP library internals, and [hints on how to get started](https://github.com/ampproject/amphtml/blob/master/DEVELOPING.md#starter-issues).
+To get started with contributing code to the AMP Project read through [the CONTRIBUTING file](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md), which includes details of the process by which a feature or bug fix goes from concept to submission and how you can participate in technical designs and discussions.
+
+When you're ready to work on some code, [the DEVELOPING file](https://github.com/ampproject/amphtml/blob/master/DEVELOPING.md) has documentation of how to get the code and start developing.
+
+If you want to help out but aren't sure where to get started, we have a list of [starter bugs](https://github.com/ampproject/amphtml/blob/master/DEVELOPING.md#starter-issues) that you can use to learn more about the AMP Project code and make an immediate impact.
+
+#### Helping with documentation
+
+Documentation is important for the entire AMP community, and we would appreciate your help in making our documentation better!  We've got all sorts of documentation--examples for users of AMP, docs to help AMP Project contributors, etc.
+
+[ampproject.org](https://ampproject.org) is where most people get familiar with AMP.  You can contribute to documentation in the [ampproject docs GitHub project](https://github.com/ampproject/docs).  (You can even make the page you are reading better!)
+
+[ampbyexample.com](https://ampbyexample.com) provides examples of how to use AMP.  You can improve it at the [amp-by-example GitHub project](https://github.com/ampproject/amp-by-example/).
+
+You can also help make things better for other contributors to the AMP Project by improving our documentation in the [amphtml GitHub project](https://github.com/ampproject/amphtml).
+
+
+
+


### PR DESCRIPTION
Adds additional context to the "How to Contribute" page to expand on the AMP Project's appreciation of contributions and provide additional options for helping out.

This PR only contains the English version.