### PR TITLE
Simplify HTML example

### DIFF
--- a/content/docs/guides/responsive_amp/style_pages.md
+++ b/content/docs/guides/responsive_amp/style_pages.md
@@ -137,9 +137,9 @@ so that many pages across the site can include embedded youtube videos.
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 
   <title>Accelerated Mobile Pages Project</title>
-  <link rel="shortcut icon" href="/static/img/amp_favicon.png">
+  <link rel="icon" href="/static/img/amp_favicon.png">
   <link rel="canonical" href="https://www.ampproject.org{{doc.url.path}}">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:200,300,400,500,700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:200,300,400,500,700" rel="stylesheet">
   <style amp-custom>
   {% include "/assets/css/main.min.css" %}
   </style>


### PR DESCRIPTION
Some minor nitpicks:

* `<link rel="icon">` is sufficient to specify a favicon in every modern browser. More info: https://mathiasbynens.be/notes/rel-shortcut-icon (It would be even better to not use any HTML at all and to place the favicon at `/favicon.ico` — even if it’s a PNG.)

* `type="text/css"` is implied for stylesheets. More info: https://mathiasbynens.be/notes/html5-levels#type-attributes