### PR TITLE
Update discovery guidance to establish "paired" terminology

### DIFF
--- a/content/docs/get_started/create/prepare_for_discovery.md
+++ b/content/docs/get_started/create/prepare_for_discovery.md
@@ -3,11 +3,11 @@ $title: Prepare Your Page for Discovery and Distribution
 $order: 4
 ---
 
-In some cases, you might want to have both a non-AMP and an AMP version of the same page, for example, a news article. Consider this: If Google Search finds the non-AMP version of that page, *how does it know there’s an AMP version of it*?
+In some cases, you might want to have both a non-AMP and an AMP version of the same page, for example, a news article. Consider this: If Google Search finds the non-AMP version of that page, *how does it know there’s a "paired" AMP version of it*?
 
 ## Linking pages with `<link>`
 
-In order to solve this problem, we add information about the AMP page to the non-AMP page and vice versa, in the form of `<link>` tags in the `<head>`.
+In order to establish that a non-AMP page and an AMP page should be treated as being "paired" together, we add information about the AMP page to the non-AMP page and vice versa, in the form of `<link>` tags in the `<head>`.
 
 Add the following to the non-AMP page:
 


### PR DESCRIPTION
Using the keyword "paired" gives us a helpful way to reference one of the main AMP publishing models. This incorporates that terminology into our getting started guide.