### PR TITLE
Fix script for triple braces in mustache

### DIFF
--- a/scripts/import_docs.js
+++ b/scripts/import_docs.js
@@ -83,7 +83,7 @@ function convertMarkdown(content, relativePath, headingToStrip) {
   });
 
   // replace mustache-style code elements
-  content = content.replace(/\`[^\s`]*(\{\{[^`]*\}\})[^`]*\`/g, '{% raw %}`$1`{% endraw %}');
+  content = content.replace(/\`[^\s{`]*(\{\{[^`]*\}\})[^`]*\`/g, '{% raw %}`$1`{% endraw %}');
 
   // horizontal rules like --- will break front matter
   content = content.replace(/\n---\n/gm, '\n- - -\n');


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/7449

The [amp-mustache](https://github.com/ampproject/amphtml/blob/master/extensions/amp-mustache/amp-mustache.md#restrictions) doc utilizes triple braces like so: "The triple-mustache `{{{var}}}`has to be used for these cases."  However, when the doc is imported to ampproject/docs, the first brace is dropped and renders like so: "The triple-mustache `{{var}}}` ...".

- Updated script to account for additional brace.
- Ran parallel test, comparing output, only amp-mustache affected and differences are as expected.