### PR TITLE
Fix links from the How to Contribute page

### DIFF
--- a/content/docs/contribute/contribute.md
+++ b/content/docs/contribute/contribute.md
@@ -21,17 +21,13 @@ We hope you'll become an ongoing participant in our open source community, but w
 
 #### Helping with code
 
-To get started with contributing code to the AMP Project read through [the CONTRIBUTING file](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md), which includes details of the process by which a feature or bug fix goes from concept to submission and how you can participate in technical designs and discussions.
-
-When you're ready to work on some code, [the DEVELOPING file](https://github.com/ampproject/amphtml/blob/master/DEVELOPING.md) has documentation of how to get the code and start developing.
-
-If you want to help out but aren't sure where to get started, we have a list of [starter issues](https://github.com/ampproject/amphtml/blob/master/DEVELOPING.md#starter-issues) that you can use to learn more about the AMP Project code and make an immediate impact.
+To get started with contributing code to the AMP Project read through [the CONTRIBUTING file](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md), which includes details of the process by which a feature or bug fix goes from concept to submission and how you can participate in technical designs and discussions.  If you're new to open source we have some [tips for getting started](https://github.com/ampproject/amphtml/blob/master/CONTRIBUTING.md#contributing-code).
 
 #### Helping with documentation
 
 Documentation is important for the entire AMP community, and we would appreciate your help in making our documentation better!  We've got all sorts of documentation--examples for users of AMP, docs to help AMP Project contributors, etc.
 
-[ampproject.org](https://ampproject.org) is where most people get familiar with AMP.  You can contribute to documentation in the [ampproject docs GitHub project](https://github.com/ampproject/docs).  (You can even make [the page you are reading](https://github.com/ampproject/docs/blob/master/content/contribute/contribute.md) better!)
+[ampproject.org](https://ampproject.org) is where most people get familiar with AMP.  You can contribute to documentation in the [ampproject docs GitHub project](https://github.com/ampproject/docs).  (You can even make [the page you are reading](https://github.com/ampproject/docs/blob/master/content/docs/contribute/contribute.md) better!)
 
 [ampbyexample.com](https://ampbyexample.com) provides examples of how to use AMP.  You can improve it at the [amp-by-example GitHub project](https://github.com/ampproject/amp-by-example/).
 


### PR DESCRIPTION
Fixes issue #339.

- Remove the link to DEVELOPING since it's not the main entry point any more anyway.
- Add a specific callout for new open source contributors.
- Fix the link for editing the page they are reading.

cc @adelinamart @pbakaus 