### PR TITLE
Make variables translatable + minor css

### DIFF
--- a/assets/sass/_syntax_highlighting.scss
+++ b/assets/sass/_syntax_highlighting.scss
@@ -92,7 +92,6 @@ pre {
 .highlight {
   .hll { background-color: #ffffcc }
   .c { color: #0099FF; font-style: italic } /* Comment */
-  .err { color: #AA0000; background-color: #FFAAAA } /* Error */
   .k { color: #006699; font-weight: bold } /* Keyword */
   .o { color: #555555 } /* Operator */
   .cm { color: #0099FF; font-style: italic } /* Comment.Multiline */

--- a/content/docs/contribute/file-a-bug.md
+++ b/content/docs/contribute/file-a-bug.md
@@ -1,5 +1,5 @@
 ---
-$title: File a bug
+$title@: File a bug
 $order: 2
 goto: https://github.com/ampproject/amphtml/issues/new
 ---

--- a/content/docs/contribute/github.md
+++ b/content/docs/contribute/github.md
@@ -1,5 +1,5 @@
 ---
-$title: GitHub
+$title@: GitHub
 $order: 3
 goto: https://github.com/ampproject/amphtml
 ---

--- a/content/docs/guides/author_develop.md
+++ b/content/docs/guides/author_develop.md
@@ -1,5 +1,5 @@
 ---
-$title: Author / Develop
+$title@: Author / Develop
 $order: 0
 goto_internal: /content/docs/guides/author_develop/responsive_amp.md
 ---

--- a/content/docs/guides/debug.md
+++ b/content/docs/guides/debug.md
@@ -1,5 +1,5 @@
 ---
-$title: Debug
+$title@: Debug
 $order: 1
 goto_internal: /content/docs/guides/debug/validate.md
 ---

--- a/content/docs/guides/deploy.md
+++ b/content/docs/guides/deploy.md
@@ -1,5 +1,5 @@
 ---
-$title: Deploy
+$title@: Deploy
 $order: 2
 goto_internal: /content/docs/guides/deploy/analytics_amp.md
 ---

--- a/content/latest/list-event.html
+++ b/content/latest/list-event.html
@@ -1,5 +1,5 @@
 ---
-$title: Events
+$title@: Events
 $path: /latest/event/
 $parent: /content/latest/latest.html
 

--- a/content/latest/list-past-event.html
+++ b/content/latest/list-past-event.html
@@ -1,5 +1,5 @@
 ---
-$title: Past Events
+$title@: Past Events
 $path: /latest/event/past-event
 $parent: /content/latest/list-event.html
 

--- a/content/learn/who-uses-amp.yaml
+++ b/content/learn/who-uses-amp.yaml
@@ -1,4 +1,4 @@
-$title: Who is AMP for?
+$title@: Who is AMP for?
 $order: 1
 class: about-who
 $view: /views/about-who.html

--- a/content/learn/who/ad-tech-platforms.yaml
+++ b/content/learn/who/ad-tech-platforms.yaml
@@ -1,4 +1,4 @@
-$title: AMP for Ad Tech Platforms
+$title@: AMP for Ad Tech Platforms
 class: about-who-vertical
 $order: 1
 $parent: /content/learn/who-uses-amp.yaml

--- a/content/learn/who/advertisers.yaml
+++ b/content/learn/who/advertisers.yaml
@@ -1,4 +1,4 @@
-$title: AMP for Advertisers
+$title@: AMP for Advertisers
 class: about-who-vertical
 $order: 2
 $parent: /content/learn/who-uses-amp.yaml

--- a/content/learn/who/amp-ads.yaml
+++ b/content/learn/who/amp-ads.yaml
@@ -1,4 +1,4 @@
-$title: AMP Ads
+$title@: AMP Ads
 class: about-who-vertical
 $order: 3
 $hidden: true

--- a/content/learn/who/publishers.yaml
+++ b/content/learn/who/publishers.yaml
@@ -1,4 +1,4 @@
-$title: AMP for Publishers
+$title@: AMP for Publishers
 class: about-who-vertical
 $order: 0
 $parent: /content/learn/who-uses-amp.yaml

--- a/content/support/developer/documentation-bug.md
+++ b/content/support/developer/documentation-bug.md
@@ -1,5 +1,5 @@
 ---
-$title: Report a documentation bug on Github
+$title@: Report a documentation bug on GitHub
 $order: 4
 goto: https://github.com/ampproject/docs/issues/new
 group: 1

--- a/content/support/developer/platform-bug.md
+++ b/content/support/developer/platform-bug.md
@@ -1,5 +1,5 @@
 ---
-$title: Report a platform bug on Github
+$title@: Report a platform bug on GitHub
 $order: 3
 goto: https://github.com/ampproject/amphtml/issues/new
 group: 1

--- a/content/support/developer/slack.md
+++ b/content/support/developer/slack.md
@@ -1,5 +1,5 @@
 ---
-$title: Slack Channel
+$title@: Slack Channel
 $order: 2
 goto: https://docs.google.com/a/google.com/forms/d/e/1FAIpQLSd83J2IZA6cdR6jPwABGsJE8YL4pkypAbKMGgUZZriU7Qu6Tg/viewform?fbzx=4406980310789882877
 group: 0

--- a/content/support/developer/stack-overflow.md
+++ b/content/support/developer/stack-overflow.md
@@ -1,5 +1,5 @@
 ---
-$title: Stack Overflow Community
+$title@: Stack Overflow Community
 $order: 0
 goto: https://stackoverflow.com/questions/tagged/amp-html
 group: 0


### PR DESCRIPTION
1.  Corrected elements in markdown and yaml files to make certain elements (mostly titles) pulled out for translation (add `@`).
1.  Fix CSS so that red highlighting doesn't display for syntax highlighting (like we had before in [PR 286](https://github.com/ampproject/docs/pull/286))

