### PR TITLE
Amend location for list of analytics vendors

### DIFF
--- a/scripts/update_platforms_page.js
+++ b/scripts/update_platforms_page.js
@@ -30,8 +30,8 @@ function addAds() {
 function addAnalytics() {
 
   // Read in amp-ad file, and the ad vendors
-  var ampAnalytics = fs.readFileSync('../content/docs/reference/components/ads-analytics/amp-analytics.md', { encoding: 'utf8' });
-  var supportPortion = (ampAnalytics.split('## Analytics vendors')[1]).split('\n## ')[0];
+  var ampAnalytics = fs.readFileSync('../content/docs/guides/deploy/analytics_amp/analytics-vendors.md', { encoding: 'utf8' });
+  var supportPortion = (ampAnalytics.split('## Vendors')[1]).split('\n## ')[0];
   var individualVendors = supportPortion.split('\n###');
   individualVendors.shift();
 


### PR DESCRIPTION
The list of analytics vendors is now in [guides/deploy/analytics_amp/analytics-vendors.md](https://github.com/ampproject/docs/blob/master/content/docs/guides/deploy/analytics_amp/analytics-vendors.md).

Tested locally and passed.