### PR TITLE
Add landing page for Docs section

### DIFF
--- a/content/docs/build.md
+++ b/content/docs/build.md
@@ -5,7 +5,39 @@ $hidden: true
 $path: /docs/
 $localization:
   path: /{locale}/docs/
-$view: /views/grid_page.html
+$view: /views/grid_docs_page.html
 
 class: bg-triangle-primary
+
+cards:
+  - name@: Get Started
+    desc@: Learn how to create your first AMP page with this short beginner tutorial.
+    cta@: Create your First AMP
+    link@: get_started/create.html
+
+  - name@: Guides
+    desc@: View our in-depth guides for how to develop, debug, and deploy in AMP.
+    cta@: View Guides
+    link@: guides/author-develop/responsive_amp.html
+
+  - name@: Reference
+    desc@: Learn about each AMP component, including syntax and examples.
+    cta@: View AMP Components
+    link@: reference/components.html
+
+  - name@: Tutorials
+    desc@: Walk through how to use AMP features with our tutorials.
+    cta@: View Tutorials
+    link@: get_started/create.html
+
+  - name@: Examples
+    desc@: Try out the hands-on examples on AMP by Example.
+    cta@: View examples
+    link@: https://ampbyexample.com/
+
+  - name@: Templates
+    desc@: Create beautiful AMP pages with pre-styled page templates and components from AMP Start.
+    cta@: View templates
+    link@: https://ampstart.com/
+
 ---

--- a/content/includes/menu.yaml
+++ b/content/includes/menu.yaml
@@ -15,7 +15,7 @@ menu:
       - href: /content/learn/case-studies.html
         copy@: "Case Studies"
         collection: learn/case-studies
-  - href: /content/docs/get_started/general/create.md
+  - href: /content/docs/build.md
     copy@: Docs
     collection: docs
     children:

--- a/views/grid_docs_page.html
+++ b/views/grid_docs_page.html
@@ -1,0 +1,35 @@
+{% extends "/views/base.html" %}
+
+{% set navmarkup %}
+{% include "/views/partials/breadcrumb-nav.html" %}
+{% endset %}
+
+{% block main %}
+  {{ navmarkup|safe }}
+  <div class="container lg">
+    <div class="content">
+      <article class="post">
+        <h1 class="post-title">{{_(doc.title)}}</h1>
+        <div class="post-content">
+          {{doc.html|render|safe}}
+            <div class="card-container grid">
+              {% for card in doc.cards %}
+                {% set locale = doc.locale %}
+                {% set title = card.name %}
+                  {% include "/views/partials/grid-card-docs.html" %}
+              {% endfor %}
+            </div>
+        </div>
+      </article>
+    </div>
+  </div>
+
+  <div class="doc-footer">
+    {% set doc_data = g.doc('/content/includes/doc.yaml', locale=doc.locale) %}
+    {% with cta = doc_data.cta %}
+      {% include "/views/partials/footer-cta.html" %}
+    {% endwith %}
+    {% include "/views/partials/footer.html" %}
+  </div>
+
+{% endblock %}

--- a/views/partials/grid-card-docs.html
+++ b/views/partials/grid-card-docs.html
@@ -1,0 +1,11 @@
+<a class="card" href="{{card.link}}">
+  <div class="card-inner">
+    <div class="card-title">
+      <h2>{{card.name}}</h2>
+      <p>{{card.desc}}</p>
+    </div>
+    <div class="card-link">
+      <p class="text-label">{{card.cta}}</p>
+    </div>
+  </div>
+</a>


### PR DESCRIPTION
Created landing page to orient readers to various parts of docs and other valuable locations.
Fixes #390 

Looks like: 
![docs-landing](https://cloud.githubusercontent.com/assets/1012254/24162238/3728576a-0e3d-11e7-9a81-697054321a51.png)




