### PR TITLE
Remove <h2> border to give the text room to breathe

### DIFF
--- a/assets/sass/_content.scss
+++ b/assets/sass/_content.scss
@@ -36,7 +36,6 @@
   }
 
   h2 {
-    border-top: 3px solid $color-grey-lt;
     font-size: 30px;
     line-height: 40px;
     margin-top: 30px;


### PR DESCRIPTION
IMHO the border on top of the headings in the docs is unnecessary. The visual separation between blocks is already achieved with the top margin, and the border simply makes it seem more busy. Compare:

## with borders:
![image](https://cloud.githubusercontent.com/assets/43004/24383092/a4954944-130f-11e7-9c95-1bc5a2f562dc.png)


## without borders:
![image](https://cloud.githubusercontent.com/assets/43004/24383075/88857f8a-130f-11e7-8974-0cd6776d3c75.png)

WDYT @bpaduch @leeee ?
