### PR TITLE
Debugging visibility time=0

### DIFF
--- a/content/pages/home.html
+++ b/content/pages/home.html
@@ -272,7 +272,7 @@ components:
             "eventCategory": "visible",
             "eventAction": "hero-image visible",
             "eventLabel": "visiblePercentageMin: 0",
-            "eventValue": "${totalVisibleTime}"
+            "eventValue": "0"
           }
         },
         "heroImageVisible1": {


### PR DESCRIPTION
It looks like GA discards any `ev=<empty string>` events. We'd like to debug why, but in meantime we want to see the numbers.