### PR TITLE
Remove translation variables for urls; re-extracted translations

### DIFF
--- a/content/docs/build.md
+++ b/content/docs/build.md
@@ -13,31 +13,31 @@ cards:
   - name@: Get Started
     desc@: Learn how to create your first AMP page with this short beginner tutorial.
     cta@: Create your First AMP
-    link@: tutorials/create.html
+    link: tutorials/create.html
 
   - name@: Guides
     desc@: View our in-depth guides for how to develop, debug, and deploy in AMP.
     cta@: View Guides
-    link@: guides/responsive_amp.html
+    link: guides/responsive_amp.html
 
   - name@: Reference
     desc@: Learn about each AMP component, including syntax and examples.
     cta@: View AMP Components
-    link@: reference/components.html
+    link: reference/components.html
 
   - name@: Tutorials
     desc@: Walk through how to use AMP features with our tutorials.
     cta@: View Tutorials
-    link@: tutorials/create.html
+    link: tutorials/create.html
 
   - name@: Examples
     desc@: Try out the hands-on examples on AMP by Example.
     cta@: View examples
-    link@: https://ampbyexample.com/
+    link: https://ampbyexample.com/
 
   - name@: Templates
     desc@: Create beautiful AMP pages with pre-styled page templates and components from AMP Start.
     cta@: View templates
-    link@: https://ampstart.com/
+    link: https://ampstart.com/
 
 ---

--- a/content/includes/home.yaml
+++ b/content/includes/home.yaml
@@ -37,19 +37,19 @@ success_stories:
       img: /static/img/home/wapo_logo.png
       img_height: 197
       img_width: 1280
-      url@: /content/learn/case-studies/washingtonpost.md
+      url: /content/learn/case-studies/washingtonpost.md
       class: wapo
     - quote@: “AMP was the perfect addition to our business, giving us a new level of impact for our e-commerce clients.”
       img_height: 135
       img_width: 902
       img: /static/img/case-studies/wompmobile_logo.png
-      url@: /content/learn/case-studies/wompmobile.md
+      url: /content/learn/case-studies/wompmobile.md
       class: wired
     - quote@: “Across Teads’ publisher portfolio, video ads perform significantly better on AMP pages than on the traditional mobile web.”
       img_height: 28
       img_width: 75
       img: /static/img/home/teads_logo.svg
-      url@: /content/learn/case-studies/teads.md
+      url: /content/learn/case-studies/teads.md
       class: teads
 
 large_cta:

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "المستندات"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "الأدلة"
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "دور النشر"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "المراجع"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "الدعم"
 
@@ -815,9 +815,9 @@ msgstr "الدعم"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "ما المقصود بـ AMP"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr "Ein gemeinsames Projekt"
 
@@ -60,11 +48,13 @@ msgstr "AMP-Zertifizierung"
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr "AMP Übersicht"
 
@@ -72,7 +62,7 @@ msgstr "AMP Übersicht"
 msgid "AMP Roadmap"
 msgstr "AMP-Fahrplan"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -109,14 +99,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr "AMP bietet eine großartige Nutzererfahrung über viele Plattformen hinweg"
 
@@ -133,7 +123,7 @@ msgstr ""
 msgid "About"
 msgstr "Über"
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -145,11 +135,11 @@ msgstr ""
 msgid "Ads"
 msgstr "Anzeigen"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr "Anzeigen & Analytics"
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -157,8 +147,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr "Werbetreibende"
 
@@ -178,7 +168,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -227,7 +217,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr "Fallstudien"
 
@@ -239,8 +230,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr "Mithelfen"
 
@@ -253,11 +244,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr "Ihre erste AMP-Seite"
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -272,22 +263,23 @@ msgid "Create your First AMP"
 msgstr "Ihre erste AMP-Seite"
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr "Ihre erste AMP-Seite"
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr "Design Prinzipien"
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "Dokumentation"
 
@@ -314,11 +306,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -348,7 +340,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr "Veranstaltungen"
@@ -357,7 +349,8 @@ msgstr "Veranstaltungen"
 msgid "Examples"
 msgstr "Beispiele"
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr "Häufige Fragen"
 
@@ -381,11 +374,16 @@ msgstr ""
 msgid "Get Started"
 msgstr "Erste Schritte"
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -409,8 +407,9 @@ msgstr "GitHub"
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "Leitfäden"
 
@@ -426,14 +425,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr "Bessere Performance und mehr Engagement"
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr "Wie AMP funktioniert"
 
@@ -457,7 +456,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -471,19 +470,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr "Infos"
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -511,21 +510,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr "Erfahren Sie, wer AMP bereits verwendet"
 
@@ -541,11 +540,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -554,7 +553,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -567,11 +566,9 @@ msgid "News"
 msgstr "Neuigkeiten"
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -582,18 +579,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr "Übersicht"
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -602,22 +599,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr "Video abspielen"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -635,8 +632,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Verlagen"
 
@@ -658,7 +655,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -670,8 +667,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "Referenz"
 
@@ -683,7 +680,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -705,21 +702,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr "Finden Sie heraus, was AMP für Sie bewirken kann"
 
@@ -743,11 +740,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -787,8 +784,9 @@ msgid "Start Building"
 msgstr "Starten Sie die Entwicklung"
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -800,21 +798,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "Support"
 
@@ -822,9 +822,9 @@ msgstr "Support"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -856,17 +856,17 @@ msgstr ""
 "und Anzeigen, die durchgehend schnell, schön und leistungsstark sind - und  "
 "das über alle Geräte und Vertriebsplattformen hinweg."
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr "Neuigkeiten"
 
@@ -919,8 +919,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -930,9 +930,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -948,7 +950,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -978,10 +980,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1038,14 +1036,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr "Was AMP bietet"
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "Was ist AMP"
 
@@ -1074,12 +1072,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1087,29 +1085,13 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
 msgstr "oder"
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
-msgstr ""
 
 #: /content/includes/home.yaml
 msgid ""

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr "Un esfuerzo de colaboración"
 
@@ -72,11 +60,13 @@ msgstr "Certificación AMP"
 msgid "AMP Conf. March 7/8."
 msgstr "AMP Conf. Marzo 7/8."
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr "Especificación AMP HTML"
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -84,7 +74,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr "Componentes AMP"
 
@@ -128,14 +118,14 @@ msgstr ""
 "más propensos a tomar las acciones que están guiándolos hacia completar una "
 "compra. "
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr "AMP brinda una gran experiencia de usuario a través de muchas plataformas"
 
@@ -152,7 +142,7 @@ msgstr ""
 msgid "About"
 msgstr "Acerca de"
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr "Plataformas de Anuncios"
 
@@ -164,11 +154,11 @@ msgstr "Agregar al Calendario"
 msgid "Ads"
 msgstr "Anuncios"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr "Anuncios y Analíticas"
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr "Anuncios y Analíticas - AMP componentes"
 
@@ -176,8 +166,8 @@ msgstr "Anuncios y Analíticas - AMP componentes"
 msgid "Adtech success stories"
 msgstr "Historias de éxito de Adtech"
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr "Editores"
 
@@ -197,7 +187,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr "Mejor publicidad en una web más rápida."
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -246,7 +236,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr "Casos de Estudio"
 
@@ -258,8 +249,8 @@ msgstr "Recursos de la Comunidad"
 msgid "Content Platforms"
 msgstr "Plataformas de Contenido"
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr "Contribuye"
 
@@ -272,11 +263,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr "Crear tu primer página AMP"
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr "Crea una página AMP con login requerido"
 
@@ -293,22 +284,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr "Crear tu primer página AMP"
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr "Principios de Diseño"
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr "Soporte a Desarrolladores"
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "Documentos"
 
@@ -338,11 +330,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr "Descargar Caso de Estudio en PDF"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr "Contenido Dinámico"
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr "Contenido Dinámico - AMP componentes"
 
@@ -372,7 +364,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr "Eventos"
@@ -381,7 +373,8 @@ msgstr "Eventos"
 msgid "Examples"
 msgstr "Ejemplos"
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr "Preguntas Frecuentes"
 
@@ -405,11 +398,16 @@ msgstr "Seguinos en Twitter"
 msgid "Get Started"
 msgstr "Empezar"
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr "Empezar armando"
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr "Empezar armando"
 
@@ -435,8 +433,9 @@ msgstr ""
 "Aumentar el compromiso y aumentar las conversiones con experiencias más "
 "rápidas"
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "Guías"
 
@@ -452,14 +451,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr "Alto Rendimiento y Compromiso"
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr "Cómo funciona AMP"
 
@@ -483,7 +482,7 @@ msgstr "Aumenta tu alcance"
 msgid "Join Now"
 msgstr "Unete Ahora"
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -497,19 +496,19 @@ msgstr "Únete a la iniciativa de anuncios de AMP"
 msgid "Keep your audience engaged with AMP pages"
 msgstr "Manten a tu audiencia comprometida con páginas AMP"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr "Diseño"
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr "Diseño - AMP componentes"
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr "Aprender"
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -541,21 +540,21 @@ msgstr ""
 "Aprende más sobre los Anuncios AMP y construye páginas AMP para tus campañas "
 "y sitios web."
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr "Aprende quién usa AMP"
 
@@ -571,11 +570,11 @@ msgstr "Maximice el ROI en todas partes"
 msgid "Maximize your revenue"
 msgstr "Maximice sus ingresos"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr "Media - AMP componentes"
 
@@ -584,8 +583,8 @@ msgid "More Past Events"
 msgstr "Más Eventos Pasados"
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
-msgstr "¿Necesitas Soporte Dev?"
+msgid "Need more help?"
+msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
 msgid "New Video"
@@ -597,12 +596,10 @@ msgid "News"
 msgstr "Noticias"
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
 msgstr "Próximo FAQ"
-
-#: /content/docs/reference/components
-msgid "Next Reference"
-msgstr "Próximo Tutorial"
 
 #: /content/learn/amp-design-principles.yaml
 msgid "No whitelists."
@@ -612,18 +609,18 @@ msgstr "Sin 'WhiteLists'."
 msgid "Only do things if they can be made fast."
 msgstr "Sólo haz las cosas si se pueden hacer rápido."
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr "Eventos Pasados"
@@ -632,22 +629,22 @@ msgstr "Eventos Pasados"
 msgid "Platform Support"
 msgstr "Soporte de Plataforma"
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr "Reproducir Video"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr "Presentación"
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr "Presentación - AMP componentes"
 
@@ -665,8 +662,8 @@ msgstr ""
 msgid "Privacy"
 msgstr "Privacidad"
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Editores"
 
@@ -688,7 +685,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr "Leer casos de estudio"
 
@@ -700,8 +697,8 @@ msgstr "Leer el Caso de Estudio"
 msgid "Reduce complexity in your operations."
 msgstr "Reducir la complejidad en tus operaciones"
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "Referencia"
 
@@ -713,7 +710,7 @@ msgstr "Reportar error de documentación en GitHub"
 msgid "Report a platform bug on GitHub"
 msgstr "Reportar un error de plataforma en GitHub"
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -735,21 +732,21 @@ msgstr "Ver todos los posts"
 msgid "See how other publishers have found success with AMP"
 msgstr "Ver cómo otros editores encontraron el éxito con AMP"
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr "Ver lo que puedes hacer con AMP"
 
@@ -775,11 +772,11 @@ msgstr "Canal de Slack"
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr "Anuncios inteligentes y coordinados aumentan el ROI de la campaña"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr "Social - AMP componentes"
 
@@ -819,8 +816,9 @@ msgid "Start Building"
 msgstr "Empieza a Construir"
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr "Empieza a construir ahora"
 
@@ -832,21 +830,23 @@ msgstr "¡Manténganse al tanto!"
 msgid "Strengthen your business while maintaining control"
 msgstr "Fortalezca su negocio manteniendo el control"
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr "Historias de Éxito"
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr "Historias de Éxito de dominios publicando páginas AMP"
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "Soporte"
 
@@ -854,9 +854,9 @@ msgstr "Soporte"
 msgid "Support Forum"
 msgstr "Foro de Soporte"
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr "Plataformas, Proveedores y Socios Soportados"
 
@@ -888,17 +888,17 @@ msgstr ""
 "consistentemente rápidos, bellos y de alto rendimiento en dispositivos y "
 "plataformas de distribución."
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr "Lo último"
 
@@ -953,8 +953,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -964,9 +964,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr "Pruebe los ejemplos prácticos de 'AMP by Example'."
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr "Tutoriales"
 
@@ -984,7 +986,7 @@ msgstr ""
 "Experiencia de Usuario > Experiencia de Desarrollador > Facilidad de "
 "Implementación."
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr "Soporte de Proveedores"
 
@@ -1017,10 +1019,6 @@ msgstr ""
 #: /content/docs/build.md
 msgid "View templates"
 msgstr "Ver diseños"
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
-msgstr "Visita nuestro FAQ"
 
 #: /content/docs/build.md
 msgid "Walk through how to use AMP features with our tutorials."
@@ -1076,14 +1074,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr "Lo que provee AMP"
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "¿Qué es AMP?"
 
@@ -1112,12 +1110,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr "Quién usa AMP"
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr "¿Para quién es AMP?"
 
@@ -1125,29 +1123,13 @@ msgstr "¿Para quién es AMP?"
 msgid "Why AMP Ads"
 msgstr "Por qué Anuncios AMP"
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
 msgstr "o"
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
-msgstr ""
 
 #: /content/includes/home.yaml
 msgid ""

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "Documents"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "Guides"
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Éditeurs"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "Référence"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "Assistance"
 
@@ -815,9 +815,9 @@ msgstr "Assistance"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "Qu'est-ce qu'AMP"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "Dokumen"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "Panduan"
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Penerbit"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "Referensi"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "Dukungan"
 
@@ -815,9 +815,9 @@ msgstr "Dukungan"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "Apa yang dimaksud dengan AMP"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "Documentazione"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "Guide"
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Publisher"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "Riferimenti"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "Assistenza"
 
@@ -815,9 +815,9 @@ msgstr "Assistenza"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "Che cos’è AMP"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "ドキュメント"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr ""
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "サイト運営者"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "リファレンス"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "サポート"
 
@@ -815,9 +815,9 @@ msgstr "サポート"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "AMP とは"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr "협력"
 
@@ -66,11 +54,13 @@ msgstr "AMP 인증"
 msgid "AMP Conf. March 7/8."
 msgstr "3월 7~8일 AMP 컨퍼런스"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr "AMP HTML 스펙"
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr "AMP 살펴보기"
 
@@ -78,7 +68,7 @@ msgstr "AMP 살펴보기"
 msgid "AMP Roadmap"
 msgstr "AMP 로드맵"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr "AMP 컴포넌트"
 
@@ -115,14 +105,14 @@ msgstr ""
 "AMP 페이지는 일반적으로 1초 이내에 로딩됩니다. 즉 타겟 고객이 AMP 페이지에 도달했을 때 원하는 순간에 원하는 정보를 얻게됩니다. "
 "이 결과, 브랜드 메시지에 적극적으로 참여하고,구매를 완료하는 등 원하는 행동을 이끌어낼 수 있습니다"
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr "AMP는 다양한 플랫폼에서 멋진 사용자 경험을 제공합니다"
 
@@ -142,7 +132,7 @@ msgstr ""
 msgid "About"
 msgstr "AMP에 대하여"
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr "광고 기술 플랫폼"
 
@@ -154,11 +144,11 @@ msgstr "캘린더에 추가하기"
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr "광고 & 애널리틱스"
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr "광고 & 애널리틱스 - AMP 컴포넌트"
 
@@ -166,8 +156,8 @@ msgstr "광고 & 애널리틱스 - AMP 컴포넌트"
 msgid "Adtech success stories"
 msgstr "광고기술 성공 사례"
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr "광고게시자"
 
@@ -187,7 +177,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr "더 빠른 웹에서의 더 좋은 광고"
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr "블로그"
 
@@ -243,7 +233,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr "사례 연구"
 
@@ -255,8 +246,8 @@ msgstr "커뮤니티 리소스"
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr "기여"
 
@@ -269,11 +260,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr "첫번째 AMP 페이지 만들기"
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr "로그인이 필요한 AMP 페이지 만들기"
 
@@ -288,22 +279,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr "첫번째 AMP 페이지 만들기"
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr "설계 원칙"
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr "개발자 지원"
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "문서"
 
@@ -330,11 +322,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr "사례 연구 PDF 다운로드"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr "동적 콘텐츠"
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr "동적 콘텐츠 - AMP 컴포넌트"
 
@@ -366,7 +358,7 @@ msgstr ""
 "가장 기억에 남을 광고 소재조차 사용자의 광고가 느리고 파괴적인 경우 그 목적을 달성할 수 없습니다. AMP Ads는 새로운 방식으로 "
 "광고를 제작성하여 광고가 AMP 페이지처럼 빨리 작동하게 하여 광고가 의도한 바를 수행하고 찾고있는 가치를 전달할 수 있게합니다."
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr "이벤트"
@@ -375,7 +367,8 @@ msgstr "이벤트"
 msgid "Examples"
 msgstr "예제"
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -399,11 +392,16 @@ msgstr "트위터에서 팔로우하기"
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr "구현 시작하기"
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr "구현 시작하기"
 
@@ -427,8 +425,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr "더 고성능에 대한 경험을 통해 참여와 전환율을 확대하세요."
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "가이드"
 
@@ -444,14 +443,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr "더 빠른 성능과 인게이지먼트"
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr "AMP는 어떻게 동작하는가"
 
@@ -475,7 +474,7 @@ msgstr "범위를 확장하세요"
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -489,19 +488,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr "잠재 고객이 AMP 페이지에 관심을 갖도록 합니다."
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr "레이아웃"
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr "레이아웃 - AMP 컴포넌트"
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr "알아보기"
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -529,21 +528,21 @@ msgid ""
 "website."
 msgstr "AMP Ads에 대해 자세히 알아보고 캠페인 및 웹사이트를 위한 AMP 페이지를 구현해보세요"
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr "누가 AMP를 사용하는 지 살펴봅시다"
 
@@ -559,11 +558,11 @@ msgstr "어디서나 ROI를 극대화하세요"
 msgid "Maximize your revenue"
 msgstr "수익을 극대화하세요"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr "미디어"
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr "미디어 - AMP 컴포넌트"
 
@@ -572,8 +571,8 @@ msgid "More Past Events"
 msgstr "이전 이벤트 더보기"
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
-msgstr "기술 지원이 필요합니까?"
+msgid "Need more help?"
+msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
 msgid "New Video"
@@ -585,12 +584,10 @@ msgid "News"
 msgstr "뉴스"
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
 msgstr "다음 FAQ"
-
-#: /content/docs/reference/components
-msgid "Next Reference"
-msgstr "다음 레퍼런스"
 
 #: /content/learn/amp-design-principles.yaml
 msgid "No whitelists."
@@ -600,18 +597,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr "이전 이벤트"
@@ -620,22 +617,22 @@ msgstr "이전 이벤트"
 msgid "Platform Support"
 msgstr "지원 플랫폼"
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr "비디오 재생"
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr "프리젠테이션"
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr "프리젠테이션 - AMP 컴포넌트"
 
@@ -653,8 +650,8 @@ msgstr ""
 msgid "Privacy"
 msgstr "개인정보"
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "게시자"
 
@@ -675,7 +672,7 @@ msgstr ""
 "AMP로 구현하는 게시자는 페이지 소비 시간, 재방문수, 가시성, 클릭수 등 핵심 성과 지표를 유지 및 관리,개선하면서 어떤 기술 업체를 "
 "사용할 지, 어떤 비즈니스 모델을 사용할 지, 어떤 콘텐츠를 제시할 지 등을결정할 수 있습니다."
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr "사례 연구 읽기"
 
@@ -687,8 +684,8 @@ msgstr "사례 연구 읽기"
 msgid "Reduce complexity in your operations."
 msgstr "운영 복잡성을 줄입니다."
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "참조"
 
@@ -700,7 +697,7 @@ msgstr "GitHub에서 문서 버그 제보"
 msgid "Report a platform bug on GitHub"
 msgstr "GitHub에서 플랫폼 버그 제보"
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr "로드맵"
 
@@ -722,21 +719,21 @@ msgstr "모든 게시글 보기"
 msgid "See how other publishers have found success with AMP"
 msgstr "AMP를 이용한 다른 게시자가 성공한 사례를 확인하세요"
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr "AMP로 무엇을 할 수 있을까요"
 
@@ -760,11 +757,11 @@ msgstr "Slack 채널"
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr "소셜"
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr "소셜 - AMP 컴포넌트"
 
@@ -809,8 +806,9 @@ msgid "Start Building"
 msgstr "구현 시작하기"
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr "바로 구현 시작하기"
 
@@ -822,21 +820,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr "스스로의 통제 하에 비즈니스 강화하기"
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr "성공 사례"
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr "AMP 페이지를 게시한 도메인의 성공 사례"
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "지원"
 
@@ -844,9 +844,9 @@ msgstr "지원"
 msgid "Support Forum"
 msgstr "지원 포럼"
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr "지원하는 플랫폼, 벤더 및 파트너"
 
@@ -878,17 +878,17 @@ msgstr ""
 "AMP 프로젝트는 모든 사람들이 웹을 더 잘 이용할 수 있도록 하는 오픈소스 프로젝트입니다. 이 프로젝트를 통해 디바이스 및 배포 플랫폼 "
 "전반에 걸쳐 일관되게 빠르고 아름답고 우수한 웹 사이트 및 광고를 만들 수 있습니다"
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr "최신 정보"
 
@@ -946,8 +946,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -957,9 +957,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr "튜토리얼"
 
@@ -975,7 +977,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -1006,10 +1008,6 @@ msgstr ""
 #: /content/docs/build.md
 msgid "View templates"
 msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
-msgstr "FAQ를 방문하세요"
 
 #: /content/docs/build.md
 msgid "Walk through how to use AMP features with our tutorials."
@@ -1066,14 +1064,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr "AMP가 제공하는 것"
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "AMP란"
 
@@ -1102,12 +1100,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr "AMP는 어떤 이들을 위해 존재할까요?"
 
@@ -1115,28 +1113,12 @@ msgstr "AMP는 어떤 이들을 위해 존재할까요?"
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr ""
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr ""
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr ""
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr ""
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr ""
 
@@ -815,9 +815,9 @@ msgstr ""
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr ""
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "Dokumenty"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "Przewodniki"
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Wydawcy"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "Źródła wiedzy"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "Pomoc"
 
@@ -815,9 +815,9 @@ msgstr "Pomoc"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "Co to jest AMP"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "Documentos"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "Guias"
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Editores"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "Referência"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "Suporte"
 
@@ -815,9 +815,9 @@ msgstr "Suporte"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "O que é o AMP"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "Справка"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "Руководства"
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Издатели"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "Дополнительные материалы"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "Поддержка"
 
@@ -815,9 +815,9 @@ msgstr "Поддержка"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "Что такое AMP"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "เอกสาร"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "คำแนะนำ"
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "ผู้เผยแพร่"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "ข้อมูลอ้างอิง"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "การสนับสนุน"
 
@@ -815,9 +815,9 @@ msgstr "การสนับสนุน"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "AMP คืออะไร"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "Dokümanlar"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "Rehberler"
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Yayıncılar"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "Referans"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "Destek"
 
@@ -815,9 +815,9 @@ msgstr "Destek"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "AMP Nedir"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml

--- a/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/translations/zh_CN/LC_MESSAGES/messages.po
@@ -1,16 +1,4 @@
 #: /content/includes/home.yaml
-msgid "/content/learn/case-studies/teads.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/washingtonpost.md"
-msgstr ""
-
-#: /content/includes/home.yaml
-msgid "/content/learn/case-studies/wompmobile.md"
-msgstr ""
-
-#: /content/includes/home.yaml
 msgid "A collaborative effort"
 msgstr ""
 
@@ -60,11 +48,13 @@ msgstr ""
 msgid "AMP Conf. March 7/8."
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/spec/_blueprint.yaml
 msgid "AMP HTML Specification"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "AMP Overview"
 msgstr ""
 
@@ -72,7 +62,7 @@ msgstr ""
 msgid "AMP Roadmap"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "AMP components"
 msgstr ""
 
@@ -105,14 +95,14 @@ msgid ""
 "the actions you’re guiding them towards like completing a purchase."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "AMP provides a great user experience across many platforms"
 msgstr ""
 
@@ -129,7 +119,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Ad Tech Platforms"
 msgstr ""
 
@@ -141,11 +131,11 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Ads & Analytics"
 msgstr ""
 
-#: /content/docs/reference/components/ads-analytics
+#: /content/docs/reference/components/ads-analytics/_blueprint.yaml
 msgid "Ads & Analytics - AMP components"
 msgstr ""
 
@@ -153,8 +143,8 @@ msgstr ""
 msgid "Adtech success stories"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -174,7 +164,7 @@ msgstr ""
 msgid "Better advertising on a faster web."
 msgstr ""
 
-#: /content/includes/latest.yaml /content/latest/blog
+#: /content/includes/latest.yaml /content/latest/blog/_blueprint.yaml
 msgid "Blog"
 msgstr ""
 
@@ -223,7 +213,8 @@ msgid "CMS"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/learn/case-studies.html
-#: /content/learn/case-studies/category /views/about-casestudies.html:12
+#: /content/learn/case-studies/category/_blueprint.yaml
+#: /views/about-casestudies.html:12
 msgid "Case Studies"
 msgstr ""
 
@@ -235,8 +226,8 @@ msgstr ""
 msgid "Content Platforms"
 msgstr ""
 
-#: /content/docs/contribute.md /content/includes/menu.yaml /content/docs/contribute
-#: /content/docs/reference
+#: /content/docs/contribute.md /content/docs/contribute/_blueprint.yaml
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Contribute"
 msgstr ""
 
@@ -249,11 +240,11 @@ msgid ""
 " website."
 msgstr ""
 
-#: /content/docs/tutorials/create
+#: /content/docs/tutorials/create/_blueprint.yaml
 msgid "Create Your First AMP Page"
 msgstr ""
 
-#: /content/docs/tutorials/login_requiring
+#: /content/docs/tutorials/login_requiring/_blueprint.yaml
 msgid "Create a login-requiring AMP page"
 msgstr ""
 
@@ -268,22 +259,23 @@ msgid "Create your First AMP"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Create your first AMP page"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/amp-design-principles@ko.yaml
-#: /content/learn/amp-design-principles.yaml
+#: /content/includes/menu.yaml /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Design Principles"
 msgstr ""
 
 #: /content/includes/menu.yaml /content/support/developer.md
-#: /content/support/developer
+#: /content/support/developer/_blueprint.yaml
 msgid "Developer Support"
 msgstr ""
 
-#: /content/docs /content/docs/build.md /content/includes/menu.yaml
+#: /content/docs/_blueprint.yaml /content/docs/build.md /content/includes/menu.yaml
 msgid "Docs"
 msgstr "文档"
 
@@ -310,11 +302,11 @@ msgstr ""
 msgid "Download PDF Case study"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Dynamic Content"
 msgstr ""
 
-#: /content/docs/reference/components/dynamic-content
+#: /content/docs/reference/components/dynamic-content/_blueprint.yaml
 msgid "Dynamic Content - AMP components"
 msgstr ""
 
@@ -344,7 +336,7 @@ msgid ""
 "deliver the value you’re looking for."
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 #: /content/latest/list-event.html
 msgid "Events"
 msgstr ""
@@ -353,7 +345,8 @@ msgstr ""
 msgid "Examples"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support/faqs.md /content/support/faqs
+#: /content/includes/menu.yaml /content/support/faqs.md
+#: /content/support/faqs/_blueprint.yaml
 msgid "FAQs"
 msgstr ""
 
@@ -377,11 +370,16 @@ msgstr ""
 msgid "Get Started"
 msgstr ""
 
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Get Started Building"
 msgstr ""
 
+#: /content/includes/doc.yaml
+msgid "Get in touch"
+msgstr ""
+
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid "Get started building"
 msgstr ""
 
@@ -405,8 +403,9 @@ msgstr ""
 msgid "Grow engagement and increase conversions with faster experiences"
 msgstr ""
 
-#: /content/docs/build.md /content/docs/guides.md /content/includes/menu.yaml
-#: /content/docs/guides /content/docs/reference /content/docs/reference/components
+#: /content/docs/build.md /content/docs/guides.md
+#: /content/docs/guides/_blueprint.yaml /content/docs/reference/_blueprint.yaml
+#: /content/includes/menu.yaml
 msgid "Guides"
 msgstr "指南"
 
@@ -422,14 +421,14 @@ msgstr ""
 msgid "Higher Performance and Engagement"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/includes/menu.yaml /content/learn/about-how.yaml
+#: /content/learn/about-how@ar.yaml /content/learn/about-how@es.yaml
+#: /content/learn/about-how@fr.yaml /content/learn/about-how@id.yaml
+#: /content/learn/about-how@it.yaml /content/learn/about-how@ja.yaml
+#: /content/learn/about-how@ko.yaml /content/learn/about-how@pl.yaml
+#: /content/learn/about-how@pt_BR.yaml /content/learn/about-how@ru.yaml
+#: /content/learn/about-how@th.yaml /content/learn/about-how@tr.yaml
+#: /content/learn/about-how@zh_CN.yaml
 msgid "How AMP Works"
 msgstr ""
 
@@ -453,7 +452,7 @@ msgstr ""
 msgid "Join Now"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid ""
 "Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
 " providers using  AMP."
@@ -467,19 +466,19 @@ msgstr ""
 msgid "Keep your audience engaged with AMP pages"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Layout"
 msgstr ""
 
-#: /content/docs/reference/components/layout
+#: /content/docs/reference/components/layout/_blueprint.yaml
 msgid "Layout - AMP components"
 msgstr ""
 
-#: /content/learn
+#: /content/learn/_blueprint.yaml
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -507,21 +506,21 @@ msgid ""
 "website."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Learn who uses AMP"
 msgstr ""
 
@@ -537,11 +536,11 @@ msgstr ""
 msgid "Maximize your revenue"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Media"
 msgstr ""
 
-#: /content/docs/reference/components/media
+#: /content/docs/reference/components/media/_blueprint.yaml
 msgid "Media - AMP components"
 msgstr ""
 
@@ -550,7 +549,7 @@ msgid "More Past Events"
 msgstr ""
 
 #: /content/includes/doc.yaml
-msgid "Need Dev Support?"
+msgid "Need more help?"
 msgstr ""
 
 #: /content/pages/home.html:37 /content/pages/home.html:77
@@ -563,11 +562,9 @@ msgid "News"
 msgstr ""
 
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Next FAQ"
-msgstr ""
-
-#: /content/docs/reference/components
-msgid "Next Reference"
 msgstr ""
 
 #: /content/learn/amp-design-principles.yaml
@@ -578,18 +575,18 @@ msgstr ""
 msgid "Only do things if they can be made fast."
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Overview"
 msgstr ""
 
-#: /content/includes/lists.yaml /content/includes/events.yaml
+#: /content/includes/events.yaml /content/includes/lists.yaml
 #: /content/latest/list-past-event.html
 msgid "Past Events"
 msgstr ""
@@ -598,22 +595,22 @@ msgstr ""
 msgid "Platform Support"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "Play Video"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Presentation"
 msgstr ""
 
-#: /content/docs/reference/components/presentation
+#: /content/docs/reference/components/presentation/_blueprint.yaml
 msgid "Presentation - AMP components"
 msgstr ""
 
@@ -631,8 +628,8 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: /content/learn/who-uses-amp@ko.yaml /content/learn/who-uses-amp.yaml
 #: /content/learn/case-studies/category/publishers.md
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "发布商"
 
@@ -651,7 +648,7 @@ msgid ""
 "return visits, viewability, CTRs and more."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Read case studies"
 msgstr ""
 
@@ -663,8 +660,8 @@ msgstr ""
 msgid "Reduce complexity in your operations."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/reference.md /content/includes/menu.yaml
-#: /content/docs/reference
+#: /content/docs/build.md /content/docs/reference.md
+#: /content/docs/reference/_blueprint.yaml /content/includes/menu.yaml
 msgid "Reference"
 msgstr "参考"
 
@@ -676,7 +673,7 @@ msgstr ""
 msgid "Report a platform bug on GitHub"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/latest.yaml
+#: /content/includes/latest.yaml /content/includes/menu.yaml
 msgid "Roadmap"
 msgstr ""
 
@@ -698,21 +695,21 @@ msgstr ""
 msgid "See how other publishers have found success with AMP"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml /content/learn/about-how@zh_CN.yaml
-#: /content/learn/about-how@tr.yaml /content/learn/about-how@th.yaml
-#: /content/learn/about-how@ru.yaml /content/learn/about-how@pt_BR.yaml
-#: /content/learn/about-how@pl.yaml /content/learn/about-how@ko.yaml
-#: /content/learn/about-how@ja.yaml /content/learn/about-how@it.yaml
-#: /content/learn/about-how@id.yaml /content/learn/about-how@fr.yaml
-#: /content/learn/about-how@es.yaml /content/learn/about-how@ar.yaml
-#: /content/learn/about-how.yaml
+#: /content/learn/about-how.yaml /content/learn/about-how@ar.yaml
+#: /content/learn/about-how@es.yaml /content/learn/about-how@fr.yaml
+#: /content/learn/about-how@id.yaml /content/learn/about-how@it.yaml
+#: /content/learn/about-how@ja.yaml /content/learn/about-how@ko.yaml
+#: /content/learn/about-how@pl.yaml /content/learn/about-how@pt_BR.yaml
+#: /content/learn/about-how@ru.yaml /content/learn/about-how@th.yaml
+#: /content/learn/about-how@tr.yaml /content/learn/about-how@zh_CN.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "See what AMP can do for you"
 msgstr ""
 
@@ -736,11 +733,11 @@ msgstr ""
 msgid "Smart and coordinated ads boost campaign ROI"
 msgstr ""
 
-#: /content/docs/reference/components
+#: /content/docs/reference/components/_blueprint.yaml
 msgid "Social"
 msgstr ""
 
-#: /content/docs/reference/components/social
+#: /content/docs/reference/components/social/_blueprint.yaml
 msgid "Social - AMP components"
 msgstr ""
 
@@ -780,8 +777,9 @@ msgid "Start Building"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Start building now"
 msgstr ""
 
@@ -793,21 +791,23 @@ msgstr ""
 msgid "Strengthen your business while maintaining control"
 msgstr ""
 
-#: /content/docs/guides/responsive_amp
+#: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
-#: /content/learn/case-studies/category/publishers.md
 #: /content/learn/case-studies/category/advertisers.md
+#: /content/learn/case-studies/category/e-commerce.md
+#: /content/learn/case-studies/category/publishers.md
 msgid "Success stories of the domains publishing AMP pages"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/support /content/support/support.md
+#: /content/includes/menu.yaml /content/support/_blueprint.yaml
+#: /content/support/support.md
 msgid "Support"
 msgstr "支持"
 
@@ -815,9 +815,9 @@ msgstr "支持"
 msgid "Support Forum"
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid "Supported Platforms, Vendors and Partners"
 msgstr ""
 
@@ -845,17 +845,17 @@ msgid ""
 "distribution platforms."
 msgstr ""
 
-#: /content/support/faqs/supported-platforms@ko.md
-#: /content/support/faqs/supported-platforms@es.md
 #: /content/support/faqs/supported-platforms.md
+#: /content/support/faqs/supported-platforms@es.md
+#: /content/support/faqs/supported-platforms@ko.md
 msgid ""
 "The Accelerated Mobile Pages (AMP) Project is an open source initiative that "
 "makes it easy for publishers to create mobile-friendly content once and have "
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/includes/home.yaml /content/latest
-#: /content/latest/latest.html
+#: /content/includes/home.yaml /content/includes/menu.yaml
+#: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"
 msgstr ""
 
@@ -908,8 +908,8 @@ msgid ""
 "target=\"_blank\">Twitter</a> for the latest news and event listings."
 msgstr ""
 
-#: /content/learn/amp-design-principles@ko.yaml
 #: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
 msgid ""
 "These design principles are meant to guide the ongoing design and development"
 " of AMP. They should help us make internally consistent decisions."
@@ -919,9 +919,11 @@ msgstr ""
 msgid "Try out the hands-on examples on AMP by Example."
 msgstr ""
 
-#: /content/docs/build.md /content/docs/tutorials.md /content/includes/menu.yaml
-#: /content/learn/amp-design-principles.yaml /content/docs/tutorials
-#: /content/learn/who/publishers.yaml /content/learn/who/ad-tech-platforms.yaml
+#: /content/docs/build.md /content/docs/tutorials.md
+#: /content/docs/tutorials/_blueprint.yaml /content/includes/menu.yaml
+#: /content/learn/amp-design-principles.yaml
+#: /content/learn/amp-design-principles@ko.yaml
+#: /content/learn/who/ad-tech-platforms.yaml /content/learn/who/publishers.yaml
 msgid "Tutorials"
 msgstr ""
 
@@ -937,7 +939,7 @@ msgstr ""
 msgid "User Experience > Developer Experience > Ease of Implementation."
 msgstr ""
 
-#: /content/support/vendor.md /content/support/vendor
+#: /content/support/vendor.md /content/support/vendor/_blueprint.yaml
 msgid "Vendor Support"
 msgstr ""
 
@@ -967,10 +969,6 @@ msgstr ""
 
 #: /content/docs/build.md
 msgid "View templates"
-msgstr ""
-
-#: /content/includes/doc.yaml
-msgid "Visit our FAQ"
 msgstr ""
 
 #: /content/docs/build.md
@@ -1024,14 +1022,14 @@ msgstr ""
 msgid "What AMP Provides"
 msgstr ""
 
-#: /content/learn/overview@zh_CN.yaml /content/learn/overview@tr.yaml
-#: /content/learn/overview@th.yaml /content/learn/overview@ru.yaml
-#: /content/learn/overview@pt_BR.yaml /content/learn/overview@pl.yaml
-#: /content/learn/overview@ko.yaml /content/learn/overview@ja.yaml
-#: /content/learn/overview@it.yaml /content/learn/overview@id.yaml
-#: /content/learn/overview@fr.yaml /content/learn/overview@es.yaml
-#: /content/learn/overview@de.yaml /content/learn/overview@ar.yaml
-#: /content/learn/overview.yaml
+#: /content/learn/overview.yaml /content/learn/overview@ar.yaml
+#: /content/learn/overview@de.yaml /content/learn/overview@es.yaml
+#: /content/learn/overview@fr.yaml /content/learn/overview@id.yaml
+#: /content/learn/overview@it.yaml /content/learn/overview@ja.yaml
+#: /content/learn/overview@ko.yaml /content/learn/overview@pl.yaml
+#: /content/learn/overview@pt_BR.yaml /content/learn/overview@ru.yaml
+#: /content/learn/overview@th.yaml /content/learn/overview@tr.yaml
+#: /content/learn/overview@zh_CN.yaml
 msgid "What is AMP"
 msgstr "什么是 AMP"
 
@@ -1060,12 +1058,12 @@ msgid ""
 "of advertising by joining the AMP Ads Initiative today."
 msgstr ""
 
-#: /content/learn/who
+#: /content/learn/who/_blueprint.yaml
 msgid "Who Uses AMP"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp@ko.yaml
-#: /content/learn/who-uses-amp.yaml
+#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
+#: /content/learn/who-uses-amp@ko.yaml
 msgid "Who is AMP for?"
 msgstr ""
 
@@ -1073,28 +1071,12 @@ msgstr ""
 msgid "Why AMP Ads"
 msgstr ""
 
-#: /content/docs/build.md
-msgid "guides/responsive_amp.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampbyexample.com/"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "https://ampstart.com/"
+#: /content/learn/case-studies/category/e-commerce.md
+msgid "e-commerce"
 msgstr ""
 
 #: /content/pages/home.html:61
 msgid "or"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "reference/components.html"
-msgstr ""
-
-#: /content/docs/build.md
-msgid "tutorials/create.html"
 msgstr ""
 
 #: /content/includes/home.yaml


### PR DESCRIPTION
Just removing variables for URLs so they are not included in .po files for translations.  Also, ran `grow extract` to extract translations.