### PR TITLE
Adding examples for amp-ad and amp-form

### DIFF
--- a/examples/src/ampad.html
+++ b/examples/src/ampad.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script> 
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="ampad.html" />
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body>
+  <!-- basic -->
+<div>
+  <amp-ad type="a9"
+      width="300" height="250"
+      data-aax_size="300x250"
+      data-aax_pubname="test123"
+      data-aax_src="302">
+  </amp-ad>
+  <amp-ad width="300" height="250"
+      type="industrybrains"
+      data-width="300"
+      data-height="250"
+      data-cid="19626-3798936394">
+  </amp-ad>
+  <amp-embed type="taboola"
+      width="400" height="300"
+      layout="responsive"
+      data-publisher="amp-demo"
+      data-mode="thumbnails-a"
+      data-placement="Ads Example"
+      data-article="auto">
+  </amp-embed>
+</div>
+  <!-- fallback -->
+  <amp-ad width="300"
+      height="200"
+      type="doubleclick"
+      data-slot="/4119129/doesnt-exist">
+    <div fallback>
+      <p>Thank you for trying AMP!</p>
+      <p>You got lucky! We have no ad to show to you!</p>
+    </div>
+  </amp-ad>
+</body>
+</html>

--- a/examples/src/ampform.html
+++ b/examples/src/ampform.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="ampform.html" />
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      font-family: sans-serif;
+    }
+    form.amp-form-submit-success [submit-success],
+    form.amp-form-submit-error [submit-error]{
+      margin-top: 16px;
+    }
+    form.amp-form-submit-success [submit-success] {
+      color: green;
+    }
+    form.amp-form-submit-error [submit-error] {
+      color: red;
+    }
+    input {
+      padding: .6em;
+      margin:  .2em;
+      border-radius: 4px;
+      border: 1px solid #ccc;
+      box-shadow: inset 0 1px 3px #ddd;
+    }
+    label {
+      margin-right: .5em;
+    }
+    span[visible-when-invalid] {
+      padding-left: .3em;
+      color: #666;
+      vertical-align: middle;
+      font-size: .875em;
+    }
+  </style>
+</head>
+<body>
+<!-- basic -->
+<div>
+  <form method="post" action-xhr="https://example.com/subscribe" target="_top">
+    <fieldset>
+      <label>
+        <span>Name:</span>
+        <input type="text" name="name" required>
+      </label><br>
+      <label>
+        <span>Email:</span>
+        <input type="email" name="email" required>
+      </label><br>
+      <input type="submit" value="Subscribe">
+    </fieldset>
+    <div submit-success>
+      <template type="amp-mustache">
+        Subscription successful!
+      </template>
+    </div>
+    <div submit-error>
+      <template type="amp-mustache">
+        Subscription failed!
+      </template>
+    </div>
+  </form>
+</div>
+<!-- customval -->
+<div>
+  <form method="post"
+        action-xhr="https://example.com/subscribe"
+        custom-validation-reporting="show-all-on-submit"
+        target="_blank">
+    <fieldset>
+      <label>
+        <span>Name:</span>
+        <input type="text" name="name" id="name5" required pattern="\w+\s\w+">
+        <span visible-when-invalid="valueMissing" validation-for="name5"></span>
+        <span visible-when-invalid="patternMismatch" validation-for="name5">
+          Please enter your first and last name separated by a space (e.g. Jane Miller)
+        </span>
+      </label><br>
+      <label>
+        <span>Email:</span>
+        <input type="email" name="email" id="email5" required>
+        <span visible-when-invalid="valueMissing" validation-for="email5"></span>
+        <span visible-when-invalid="typeMismatch" validation-for="email5"></span>
+      </label><br>
+      <input type="submit" value="Subscribe">
+    </fieldset>
+  </form>
+</div>
+<!-- inputevent -->
+<div>
+  <form id="myform"
+        method="post"
+        action-xhr="https://example.com/myform"
+        target="_blank">
+    <fieldset>
+      <label>
+        <input name="answer1" value="Value 1" type="radio" on="change:myform.submit">Value 1
+      </label>
+      <label>
+        <input name="answer1" value="Value 2" type="radio" on="change:myform.submit">Value 2
+      </label>
+    </fieldset>
+  </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adding examples that will be embedded in the reference docs for: amp-ad and amp-form.

Demos: [amp-form](https://barb-ampdocs.firebaseapp.com/amp-form.html), [amp-ad](https://barb-ampdocs.firebaseapp.com/amp-ad.html#example:-displaying-a-few-ads)