### PR TITLE
Fix grids so pulls in translated titles

### DIFF
--- a/views/doc_grid.html
+++ b/views/doc_grid.html
@@ -14,7 +14,7 @@
     <div class="content">
       <article class="post{% if doc.toc %} has-toc{% endif %}">
 
-        <h1 class="post-title">{{ doc.title }}</h1>
+        <h1 class="post-title">{{ _(doc.title) }}</h1>
 
         <div class="post-content">
           {{doc.html|render|safe}}

--- a/views/partials/grid-card.html
+++ b/views/partials/grid-card.html
@@ -19,7 +19,7 @@
 
     <div class="card-title">
       {% if isCase %}<h4>{% else %}<h2>{% endif %}
-        {{doc.headline or doc.title}}
+        {{doc.headline or _(doc.title)}}
       {% if isCase %}</h4>{% else %}</h2>{% endif %}
     </div>
 


### PR DESCRIPTION
@SidVal noticed that the titles on the grid landing pages weren't all translated; it should be using the translated variables.  Fixed now.


Related to:https://github.com/ampproject/docs/pull/473#issuecomment-300559601