### PR TITLE
Include amp-facebook-like component into docs

### DIFF
--- a/content/docs/reference/components.md
+++ b/content/docs/reference/components.md
@@ -102,8 +102,9 @@ Here are the components grouped by category:
 
 | Component | Description |
 | --------- | ----------- |
-| [`amp-facebook`](components/amp-facebook.html) | Displays a Facebook post or video. |
 | [`amp-facebook-comments`](components/amp-facebook-comments.html) | Embeds the Facebook comments plugin. |
+| [`amp-facebook-like`](components/amp-facebook-like.html) | Embeds the Facebook like button plugin. |
+| [`amp-facebook`](components/amp-facebook.html) | Displays a Facebook post or video. |
 | [`amp-gfycat`](components/amp-gfycat.html) | Displays a [Gfycat](https://gfycat.com) video GIF. |
 | [`amp-instagram`](components/amp-instagram.html) | Displays an Instagram embed. |
 | [`amp-pinterest`](components/amp-pinterest.html) | Displays a Pinterest widget or Pin It button. |

--- a/content/docs/reference/components/_blueprint.yaml
+++ b/content/docs/reference/components/_blueprint.yaml
@@ -21,5 +21,5 @@ custom_children:
     href: /content/docs/reference/components/presentation/amp-animation.md
     collection: /content/docs/reference/components/presentation
   - title@: Social
-    href: /content/docs/reference/components/social/amp-facebook.md
+    href: /content/docs/reference/components/social/amp-facebook-comments.md
     collection: /content/docs/reference/components/social

--- a/scripts/component_categories.json
+++ b/scripts/component_categories.json
@@ -61,12 +61,12 @@
 
     "amp-facebook": "social",
     "amp-facebook-comments": "social",
+    "amp-facebook-like": "social",
     "amp-gfycat": "social",
     "amp-instagram": "social",
     "amp-pinterest": "social",
     "amp-reddit": "social",
     "amp-social-share": "social",
     "amp-twitter": "social",
-    "amp-vine": "social",
-    "amp-share-tracking": "social"
+    "amp-vine": "social"
 }


### PR DESCRIPTION
Now that amp-facebook-live component is in production, include it in the docs. Related to: #483 
Also, adjusted side-nav so "1st" component listed is selected when user selects "Social"
Also, removed "amp-share-tracking" from docs because a) there are no docs for the component.


