### PR TITLE
Add partial localization support for breadcrumbs and other minor improvements

### DIFF
--- a/scripts/update_blog_links.js
+++ b/scripts/update_blog_links.js
@@ -90,7 +90,9 @@ avatar: ${ item.avatar }
 date_data: ${ moment(item.date).format() }
 $date: ${ moment(item.date).format("MMMM D, YYYY") }
 $parent: ${parent}
-
+$path: /latest/blog/{base}/
+$localization:
+  path: /{locale}/latest/blog/{base}/
 components:
   - social-share
 ---
@@ -215,6 +217,7 @@ const fetchLatestAdsContent = fetchFeedAsync({
   // write the posts into their own files
   for (var post of posts) {
     writeBlogPage(post, '../content/latest/blog-ads/', '/content/latest-ads/list-blog-ads.html');
+    writeBlogPage(post, '../content/latest/blog-ads/', '/content/latest/list-blog.html');
   }
 
   // combine posts  and save into list-blog-ads.yml

--- a/views/partials/breadcrumb-nav.html
+++ b/views/partials/breadcrumb-nav.html
@@ -1,26 +1,37 @@
-{% set currentDocs = [] %}
-{% do currentDocs.append(g.doc(doc.pod_path)) %}
-{% set listItems = [] %}
-{% set currentDoc = currentDocs|last %}
-{% set firstListItem %}
-<li>{{currentDoc.titles('breadcrumb')}}</li>
-{% endset %}
-{% if listItems.append(firstListItem) %}{% endif %}
-{% if currentDocs.append(g.doc(currentDoc.pod_path).parent) %}{% endif %}
-{% if not currentDocs|last == None %}
-  {% for _ in range(10) %}
-    {% set currentDoc = currentDocs|last %}
-{% set nextListItem %}
-<li><a href="{{currentDoc.url.path}}">{{currentDoc.titles('breadcrumb')}}</a></li>
-{% endset %}
-    {% if listItems.append(nextListItem|safe) %}{% endif %}
-    {% set currentDoc = currentDocs|last %}
-    {% if currentDocs.append(g.doc(currentDoc.pod_path).parent) %}{% endif %}
-    {% if currentDocs|last == None %}{% break %}{% endif %}
+{#
+ # Breadcrumb Nav
+ #}
+{% set current_docs = [] %}
+{% do current_docs.append(g.doc(doc.pod_path, locale=doc.locale)) %}
+{% set markup_payloads = [] %}
+{#
+ ## Current page
+ #}
+{% set current_doc = current_docs|last %}
+{% set markup_payload -%}
+  <li>{{_(current_doc.titles('breadcrumb'))}}</li>
+{%- endset %}
+{% do markup_payloads.append(markup_payload|safe) %}
+{#
+ ## Ancestors
+ #}
+{% do current_docs.append(current_doc.parent) %}
+{% if not current_docs|last == None %}
+  {% for _ in range(10) %} {# Capped at 10 levels #}
+    {% set current_doc = current_docs|last %}
+    {% set markup_payload -%}
+      <li><a href="{{g.doc(current_doc.pod_path, locale=doc.locale).url.path}}">{{current_doc.titles('breadcrumb')}}</a></li>
+    {%- endset %}
+    {% do markup_payloads.append(markup_payload|safe) %}
+    {% do current_docs.append(current_doc.parent) %}
+    {% if current_docs|last == None %}{% break %}{% endif %}
   {% endfor %}
 {% endif %}
+{#
+ ## Cash out
+ #}
 <nav class="breadcrumb">
   <ul>
-    {{listItems|reverse|join('    ')|safe}}
+    {{markup_payloads|reverse|join('\n    ')|safe}}
   </ul>
 </nav>


### PR DESCRIPTION
In addition to the changes mentioned in #486, this PR accounts for path errors as seen in #481, which were also causing the build to break with the previous rendition of this PR. This seems like a Grow bug to me, but I will have to investigate further to see why paths that are only defined in the blueprint are based on collection names. This PR builds without errors and I've tested it to ensure that it is working properly. The reason why several of the breadcrumbs are not translated is because their respective titles are not translated, which may be something worth working on.