### PR TITLE
Incorporate `gettext` function for extracted title translations

### DIFF
--- a/views/partials/head.html
+++ b/views/partials/head.html
@@ -7,7 +7,7 @@
   {% if doc.description %}<meta name="description" content="{{doc.description}} – AMP">{% endif %}
   <meta name="amp-experiments-opt-in" content="">
 
-  <title>{% if doc.title %}{{doc.title}} – {% endif %}AMP</title>
+  <title>{% if doc.title %}{{_(doc.title)}} – {% endif %}AMP</title>
   <link rel="shortcut icon" href="/static/img/amp_favicon.png?v=3">
   <link rel="canonical" href="https://www.ampproject.org{{doc.url.path}}">
 


### PR DESCRIPTION
This PR applies the `gettext` function to page titles. The translations have already been done, this just activates them on non-default locales. This also prepares #501 to utilize an alternative method for breadcrumb translations.