### PR TITLE
Broke out "Supported Browsers" as separate topic in FAQs

### DIFF
--- a/content/support/faqs/supported-browsers.md
+++ b/content/support/faqs/supported-browsers.md
@@ -1,0 +1,31 @@
+---
+$title@: Supported Browsers
+$order: 4
+$parent: /content/support/faqs.md
+class: who
+
+cta:
+  title@: Next FAQ
+  link_text@: AMP Overview
+  link_url: /content/support/faqs/overview.md
+
+---
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+In general we support the latest two versions of major browsers like Chrome, Firefox, Edge, Safari and Opera. We support desktop, phone, tablet and the web view version of these respective browsers.
+
+Beyond that, the core AMP library and built-in elements should aim for very wide browser support and we accept fixes for all browsers with market share greater than 1 percent.
+
+In particular, we try to maintain "it might not be perfect but isn't broken"-support for the Android 4.0 system browser and Chrome 28+ on phones.

--- a/content/support/faqs/supported-browsers@es.md
+++ b/content/support/faqs/supported-browsers@es.md
@@ -1,0 +1,32 @@
+---
+$title: Navegadores Soportados
+$order: 4
+$parent: /content/support/faqs.md
+class: who
+
+cta:
+  title: Próximo FAQ
+  link_text@: AMP Overview
+  link_url: /content/support/faqs/overview.md
+
+---
+
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+En general, apoyamos las 2 últimas versiones de los principales navegadores como Chrome, Firefox, Edge, Safari y Opera. Soportamos las versiones de escritorio, el teléfono, y la versión en tableta de estos browsers.
+
+Más allá de eso, la biblioteca principal de AMP y los elementos integrados deben apuntar a un soporte de navegador muy amplio y aceptamos correcciones para todos los navegadores con cuota de mercado superior al 1 por ciento.
+
+En particular, tratamos de mantener un soporte "puede que no sea perfecto, pero no está roto" para el navegador del sistema Android 4.0 y Chrome 28+ en los teléfonos.

--- a/content/support/faqs/supported-browsers@ko.md
+++ b/content/support/faqs/supported-browsers@ko.md
@@ -1,0 +1,33 @@
+---
+$title: 지원하는 브라우저
+$order: 4
+$parent: /content/support/faqs.md
+class: who
+
+cta:
+  title: 다음 FAQ
+  link_text: AMP 살펴보기
+  link_url: /content/support/faqs/overview.md
+---
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+보통 Chrome, Firefox, Edge, Safari, Opera같은 주요 브라우저의 2가지 최신 버전을 지원합니다.
+우리는 이러한 브라우저의 데스크탑, 휴대전화, 태블릿 및 웹 뷰 버전을 지원합니다.
+
+이외에도 핵심 AMP 라이브러리 및 내장 요소는 매우 광범위한 브라웢 지원을 목표로 하며,
+시장 점유율이 1% 이상인 모든 브라우저에 대한 수정 사항을 허용합니다.
+
+특히 Android 4.0 시스템 브라우저 및 휴대전화의 Chrome 28+를 지원하며,
+"완벽하게 동작하지는 않지만 깨지지는 않음" 상태를 유지하고자 합니다.

--- a/content/support/faqs/supported-platforms.md
+++ b/content/support/faqs/supported-platforms.md
@@ -49,25 +49,3 @@ A growing number of platforms, vendors, and partners support the AMP Project by 
   {% endfor %}
   </amp-accordion>
 </div>
-
-<hr>
-
-# Supported Browsers
-
-<div class="browser-container">
-{% for item in who.browsers %}
-  <div class="browser">
-    <amp-img width="75"
-        height="75"
-        layout="responsive"
-        src="{{item.img}}"></amp-img>
-    <p class="browser-title">{{item.title}}</p>
-  </div>
-{% endfor %}
-</div>
-
-In general we support the 2 latest versions of major browsers like Chrome, Firefox, Edge, Safari and Opera. We support desktop, phone, tablet and the web view version of these respective browsers.
-
-Beyond that, the core AMP library and built-in elements should aim for very wide browser support and we accept fixes for all browsers with market share greater than 1 percent.
-
-In particular, we try to maintain "it might not be perfect but isn't broken"-support for the Android 4.0 system browser and Chrome 28+ on phones.

--- a/content/support/faqs/supported-platforms@es.md
+++ b/content/support/faqs/supported-platforms@es.md
@@ -49,25 +49,3 @@ Un número creciente de plataformas, proveedores y socios soportan el proyecto A
   {% endfor %}
   </amp-accordion>
 </div>
-
-<hr>
-
-# Navegadores Soportados
-
-<div class="browser-container">
-{% for item in who.browsers %}
-  <div class="browser">
-    <amp-img width="75"
-        height="75"
-        layout="responsive"
-        src="{{item.img}}"></amp-img>
-    <p class="browser-title">{{item.title}}</p>
-  </div>
-{% endfor %}
-</div>
-
-En general, apoyamos las 2 últimas versiones de los principales navegadores como Chrome, Firefox, Edge, Safari y Opera. Soportamos las versiones de escritorio, el teléfono, y la versión en tableta de estos browsers.
-
-Más allá de eso, la biblioteca principal de AMP y los elementos integrados deben apuntar a un soporte de navegador muy amplio y aceptamos correcciones para todos los navegadores con cuota de mercado superior al 1 por ciento.
-
-En particular, tratamos de mantener un soporte "puede que no sea perfecto, pero no está roto" para el navegador del sistema Android 4.0 y Chrome 28+ en los teléfonos.

--- a/content/support/faqs/supported-platforms@ko.md
+++ b/content/support/faqs/supported-platforms@ko.md
@@ -49,28 +49,3 @@ AMP 프로젝트를 지원하는 플랫폼, 공급 업체 및 파트너가 증�
   {% endfor %}
   </amp-accordion>
 </div>
-
-<hr>
-
-# 지원하는 브라우저
-
-<div class="browser-container">
-{% for item in who.browsers %}
-  <div class="browser">
-    <amp-img width="75"
-        height="75"
-        layout="responsive"
-        src="{{item.img}}"></amp-img>
-    <p class="browser-title">{{item.title}}</p>
-  </div>
-{% endfor %}
-</div>
-
-보통 Chrome, Firefox, Edge, Safari, Opera같은 주요 브라우저의 2가지 최신 버전을 지원합니다.
-우리는 이러한 브라우저의 데스크탑, 휴대전화, 태블릿 및 웹 뷰 버전을 지원합니다.
-
-이외에도 핵심 AMP 라이브러리 및 내장 요소는 매우 광범위한 브라웢 지원을 목표로 하며,
-시장 점유율이 1% 이상인 모든 브라우저에 대한 수정 사항을 허용합니다.
-
-특히 Android 4.0 시스템 브라우저 및 휴대전화의 Chrome 28+를 지원하며,
-"완벽하게 동작하지는 않지만 깨지지는 않음" 상태를 유지하고자 합니다.

--- a/scripts/update_platforms_page.js
+++ b/scripts/update_platforms_page.js
@@ -127,6 +127,22 @@ function addVideo() {
           link: https://www.youtube.com/ `;
 }
 
+function addBrowsers() {
+  newYaml += `
+
+browsers:
+  - title: Chrome
+    img: /static/img/platforms/chrome.png
+  - title: Firefox
+    img: /static/img/platforms/firefox.png
+  - title: Edge
+    img: /static/img/platforms/edge.png
+  - title: Safari
+    img: /static/img/platforms/safari.png
+  - title: Opera
+    img: /static/img/platforms/opera.png `;
+}
+
 // Put them into the right location in the YAML
 newYaml = `page_title: "Participants"
 
@@ -139,6 +155,8 @@ addAnalytics();
 addContentPlatforms();
 addCMS();
 addVideo();
+addBrowsers();
+
 
 // Save back to disk
 fs.writeFileSync('../content/includes/who.yaml', newYaml);

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -868,6 +868,10 @@ msgstr "Compañías Tecnológicas usando AMP"
 msgid "Templates"
 msgstr "Plantillas"
 
+#: /content/support/faqs/supported-browsers.md
+msgid "Supported Browsers"
+msgstr "Navegadores Soportados"
+
 #: /content/learn/who/ad-tech-platforms.yaml
 msgid ""
 "The AMP Project is an open source initiative to protect the future of the web"

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -858,6 +858,10 @@ msgstr ""
 msgid "Templates"
 msgstr ""
 
+#: /content/support/faqs/supported-browsers.md
+msgid "Supported Browsers"
+msgstr "지원하는 브라우저"
+
 #: /content/learn/who/ad-tech-platforms.yaml
 msgid ""
 "The AMP Project is an open source initiative to protect the future of the web"

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -854,6 +854,11 @@ msgid ""
 "it load instantly everywhere. – Accelerated Mobile Pages Project"
 msgstr ""
 
+#: /content/support/faqs/supported-browsers.md
+msgid "Supported Browsers"
+msgstr ""
+
+
 #: /content/includes/home.yaml /content/includes/menu.yaml
 #: /content/latest/_blueprint.yaml /content/latest/latest.html
 msgid "The Latest"


### PR DESCRIPTION
Took out "Supported Browsers" section from "Supported Vendors..." and made it it's own topic so it's easier to find and consume.

Also within Supported Browsers linked up images (they were already there, just not generated in yaml), so it'll look like this:
![browser-support](https://cloud.githubusercontent.com/assets/1012254/26598783/5809f450-4544-11e7-8fe3-1f52c7ab00fc.png)

Note, had to add title to messages.po file because the localized title in the actual .md wasn't being picked up.  I suspect it's related to the fixes that Derek will implement (in https://github.com/ampproject/docs/pull/501).

FYI: This was related to some SO questions about this topic.