### PR TITLE
Remove meta tag for X-UA-Compatible

### DIFF
--- a/content/docs/guides/responsive_amp/style_pages.md
+++ b/content/docs/guides/responsive_amp/style_pages.md
@@ -117,7 +117,6 @@ so that many pages across the site can include embedded youtube videos.
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@ar.md
+++ b/content/docs/guides/responsive_amp/style_pages@ar.md
@@ -43,7 +43,6 @@ $title: لغة CSS المعتمدة
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@de.md
+++ b/content/docs/guides/responsive_amp/style_pages@de.md
@@ -28,7 +28,6 @@ Unter anderem enthält es auch das Skript für benutzerdefinierte Elemente für 
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@es.md
+++ b/content/docs/guides/responsive_amp/style_pages@es.md
@@ -40,7 +40,6 @@ También incluye la secuencia de comandos de elemento personalizado para
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@fr.md
+++ b/content/docs/guides/responsive_amp/style_pages@fr.md
@@ -27,7 +27,6 @@ Il comprend également, entre autres, le script d'élément personnalisé pour [
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@id.md
+++ b/content/docs/guides/responsive_amp/style_pages@id.md
@@ -42,7 +42,6 @@ sehingga berbagai laman di situs dapat menyertakan video youtube yang disematkan
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@it.md
+++ b/content/docs/guides/responsive_amp/style_pages@it.md
@@ -26,7 +26,6 @@ Ad esempio, nella sezione [head.html](https://github.com/ampproject/docs/blob/ma
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@ja.md
+++ b/content/docs/guides/responsive_amp/style_pages@ja.md
@@ -20,7 +20,6 @@ $title: サポートされる CSS
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@ko.md
+++ b/content/docs/guides/responsive_amp/style_pages@ko.md
@@ -130,7 +130,6 @@ AMP 페이지는 커스텀 폰트를 제외한 외부 스타일 시트를 포함
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@pl.md
+++ b/content/docs/guides/responsive_amp/style_pages@pl.md
@@ -36,7 +36,6 @@ Zawiera również, między innymi, element niestandardowy skryptu dla
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@pt_BR.md
+++ b/content/docs/guides/responsive_amp/style_pages@pt_BR.md
@@ -40,7 +40,6 @@ de modo que muitas páginas em todo o site podem incluir vídeos incorporados do
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@ru.md
+++ b/content/docs/guides/responsive_amp/style_pages@ru.md
@@ -28,7 +28,6 @@ $title: Поддерживаемые элементы CSS
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@th.md
+++ b/content/docs/guides/responsive_amp/style_pages@th.md
@@ -43,7 +43,6 @@ $title: CSS ที่รองรับ
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@tr.md
+++ b/content/docs/guides/responsive_amp/style_pages@tr.md
@@ -28,7 +28,6 @@ Diğerlerinin yanı sıra [`amp-youtube`](/docs/reference/extended/amp-youtube.h
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/content/docs/guides/responsive_amp/style_pages@zh_CN.md
+++ b/content/docs/guides/responsive_amp/style_pages@zh_CN.md
@@ -21,7 +21,6 @@ $title: 支持的 CSS
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta name="description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
 

--- a/views/partials/head.html
+++ b/views/partials/head.html
@@ -1,7 +1,6 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta property="og:description" content="{% if doc.description %}{{doc.description}} – {% endif %}Accelerated Mobile Pages Project">
   <meta property="og:image" content="https://www.ampproject.org/static/img/logo-og-image.jpg">
   {% if doc.description %}<meta name="description" content="{{doc.description}} – AMP">{% endif %}


### PR DESCRIPTION
Per Greg's comment in https://github.com/ampproject/docs/issues/369#issuecomment-305253425, the meta is a no-op so removing from template.