### PR TITLE
Pick up localization for who-uses-amp page

### DIFF
--- a/content/learn/who-uses-amp@es.yaml
+++ b/content/learn/who-uses-amp@es.yaml
@@ -13,24 +13,24 @@ hero:
   triangle_img: hero_triangle.png
 
 cards:
-  - name@: Publishers
+  - name: Publishers
     cta: Aprender Más
     icon: who_icon_publishers.svg
 
-  # - name@: SMB
-  #   cta@: Learn More
+  # - name: SMB
+  #   cta: Learn More
   #   icon: card_smb.svg
 
-  - name@: Ad Tech Platforms
+  - name: Ad Tech Platforms
     cta: Aprender Más
     icon: who_icon_adtech.svg
 
-  - name@: Advertisers
+  - name: Advertisers
     cta: Aprender Más
     icon: who_icon_advertisers.svg
 
-  # - name@: Developers
-  #   cta@: Learn More
+  # - name: Developers
+  #   cta: Learn More
   #   icon: card_developers.svg
 
 cta:

--- a/content/learn/who-uses-amp@it.yaml
+++ b/content/learn/who-uses-amp@it.yaml
@@ -1,4 +1,4 @@
-$title: Who is AMP for?
+$title: Chi è AMP?
 $order: 1
 class: about-who
 $view: /views/about-who.html
@@ -6,15 +6,15 @@ $parent: /content/learn/overview.yaml
 $path: /learn/who-uses-amp/
 
 hero:
-  title: Who is AMP for?
-  subtitle: Join an ecosystem of 850,000 domains, leading platforms, and 100+ technology providers using  AMP.
+  title: Chi è AMP?
+  subtitle: Unisciti ad un ecosistema di 850.000 domini, piattaforme leader e 100+ fornitori di tecnologie che utilizzano AMP.
   hero_img_base: /static/img/about/who-use-amp/who_phones_hero
   line_img: who_lines1.svg
   triangle_img: hero_triangle.png
 
 cards:
   - name: Publishers
-    cta: Learn More
+    cta: Ulteriori informazioni
     icon: who_icon_publishers.svg
 
   # - name: SMB
@@ -22,11 +22,11 @@ cards:
   #   icon: card_smb.svg
 
   - name: Ad Tech Platforms
-    cta: Learn More
+    cta: Ulteriori informazioni
     icon: who_icon_adtech.svg
 
   - name: Advertisers
-    cta: Learn More
+    cta: Ulteriori informazioni
     icon: who_icon_advertisers.svg
 
   # - name: Developers
@@ -34,6 +34,6 @@ cards:
   #   icon: card_developers.svg
 
 cta:
-  title: Success stories
-  link_text: Read case studies
+  title: Storie di successo
+  link_text: Leggi i casi di studio
   link_url: /content/learn/case-studies.html

--- a/content/learn/who-uses-amp@ko.yaml
+++ b/content/learn/who-uses-amp@ko.yaml
@@ -12,24 +12,24 @@ hero:
   triangle_img: hero_triangle.png
 
 cards:
-  - name@: Publishers
-    cta@: Learn More
+  - name: Publishers
+    cta: 더 알아보기
     icon: who_icon_publishers.svg
 
-  # - name@: SMB
-  #   cta@: Learn More
+  # - name: SMB
+  #   cta: Learn More
   #   icon: card_smb.svg
 
-  - name@: Ad Tech Platforms
-    cta@: Learn More
+  - name: Ad Tech Platforms
+    cta: 더 알아보기
     icon: who_icon_adtech.svg
 
-  - name@: Advertisers
-    cta@: Learn More
+  - name: Advertisers
+    cta: 더 알아보기
     icon: who_icon_advertisers.svg
 
-  # - name@: Developers
-  #   cta@: Learn More
+  # - name: Developers
+  #   cta: Learn More
   #   icon: card_developers.svg
 
 cta:

--- a/translations/ar/LC_MESSAGES/messages.po
+++ b/translations/ar/LC_MESSAGES/messages.po
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "دور النشر"
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -167,11 +167,6 @@ msgstr ""
 msgid "About"
 msgstr "Über"
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -193,8 +188,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr "Werbetreibende"
 
@@ -557,13 +550,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -584,7 +570,6 @@ msgstr ""
 msgid "Learn"
 msgstr "Infos"
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -750,8 +735,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Verlagen"
 
@@ -775,11 +758,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -928,11 +906,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1224,8 +1197,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/es/LC_MESSAGES/messages.po
+++ b/translations/es/LC_MESSAGES/messages.po
@@ -179,11 +179,6 @@ msgstr ""
 msgid "About"
 msgstr "Acerca de"
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr "Plataformas de Anuncios"
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr "Agregar al Calendario"
@@ -205,8 +200,6 @@ msgid "Adtech success stories"
 msgstr "Historias de éxito de Adtech"
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr "Anunciantes"
 
@@ -576,13 +569,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -603,7 +589,6 @@ msgstr "Diseño - AMP componentes"
 msgid "Learn"
 msgstr "Aprender"
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -773,8 +758,6 @@ msgid "Privacy"
 msgstr "Privacidad"
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Editores"
 
@@ -799,11 +782,6 @@ msgstr ""
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
 msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
-msgstr "Leer casos de estudio"
 
 #: /views/partials/grid-card.html:27
 msgid "Read the Case Study"
@@ -952,11 +930,6 @@ msgstr "Fortalezca su negocio manteniendo el control"
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
-msgstr "Historias de Éxito"
 
 #: /content/learn/case-studies.html
 #: /content/learn/case-studies/category/advertisers.md
@@ -1253,8 +1226,7 @@ msgstr "Quién usa AMP"
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr "¿Para quién es AMP?"
 

--- a/translations/fr/LC_MESSAGES/messages.po
+++ b/translations/fr/LC_MESSAGES/messages.po
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Éditeurs"
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/id/LC_MESSAGES/messages.po
+++ b/translations/id/LC_MESSAGES/messages.po
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Penerbit"
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/it/LC_MESSAGES/messages.po
+++ b/translations/it/LC_MESSAGES/messages.po
@@ -184,11 +184,6 @@ msgstr ""
 msgid "About"
 msgstr "Informazioni"
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr "Piattaforme di pubblicità"
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr "Aggiungi al calendario"
@@ -210,8 +205,6 @@ msgid "Adtech success stories"
 msgstr "Storie di successo di Adtech"
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr "Inserzionisti"
 
@@ -606,15 +599,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-"Unisciti ad un ecosistema di 850.000 domini, piattaforme leader e 100+ "
-"fornitori di tecnologie che utilizzano AMP."
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -635,7 +619,6 @@ msgstr "Layout - Componenti AMP"
 msgid "Learn"
 msgstr "Impara"
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -809,8 +792,6 @@ msgid "Privacy"
 msgstr "Privacy"
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Editori"
 
@@ -840,11 +821,6 @@ msgstr ""
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
 msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
-msgstr "Leggi i casi di studio"
 
 #: /views/partials/grid-card.html:27
 msgid "Read the Case Study"
@@ -1009,11 +985,6 @@ msgstr "Rafforzare la tua attività mantenendo il controllo"
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr "Stile & Layout"
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
-msgstr "Storie di successo"
 
 #: /content/learn/case-studies.html
 #: /content/learn/case-studies/category/advertisers.md
@@ -1357,8 +1328,7 @@ msgstr "Chi usa AMP"
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr "Chi è AMP?"
 

--- a/translations/ja/LC_MESSAGES/messages.po
+++ b/translations/ja/LC_MESSAGES/messages.po
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "サイト運営者"
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -172,11 +172,6 @@ msgstr ""
 msgid "About"
 msgstr "AMP에 대하여"
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr "광고 기술 플랫폼"
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr "캘린더에 추가하기"
@@ -198,8 +193,6 @@ msgid "Adtech success stories"
 msgstr "광고기술 성공 사례"
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr "광고게시자"
 
@@ -569,13 +562,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -596,7 +582,6 @@ msgstr "레이아웃 - AMP 컴포넌트"
 msgid "Learn"
 msgstr "알아보기"
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -762,8 +747,6 @@ msgid "Privacy"
 msgstr "개인정보"
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "게시자"
 
@@ -787,11 +770,6 @@ msgstr ""
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
 msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
-msgstr "사례 연구 읽기"
 
 #: /views/partials/grid-card.html:27
 msgid "Read the Case Study"
@@ -945,11 +923,6 @@ msgstr "스스로의 통제 하에 비즈니스 강화하기"
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
 msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
-msgstr "성공 사례"
 
 #: /content/learn/case-studies.html
 #: /content/learn/case-studies/category/advertisers.md
@@ -1246,8 +1219,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr "AMP는 어떤 이들을 위해 존재할까요?"
 

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr ""
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/pl/LC_MESSAGES/messages.po
+++ b/translations/pl/LC_MESSAGES/messages.po
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Wydawcy"
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/translations/pt_BR/LC_MESSAGES/messages.po
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Editores"
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/ru/LC_MESSAGES/messages.po
+++ b/translations/ru/LC_MESSAGES/messages.po
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Издатели"
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/th/LC_MESSAGES/messages.po
+++ b/translations/th/LC_MESSAGES/messages.po
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "ผู้เผยแพร่"
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/tr/LC_MESSAGES/messages.po
+++ b/translations/tr/LC_MESSAGES/messages.po
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "Yayıncılar"
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 

--- a/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/translations/zh_CN/LC_MESSAGES/messages.po
@@ -163,11 +163,6 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Ad Tech Platforms"
-msgstr ""
-
 #: /content/includes/latest.yaml
 msgid "Add to Calendar"
 msgstr ""
@@ -189,8 +184,6 @@ msgid "Adtech success stories"
 msgstr ""
 
 #: /content/learn/case-studies/category/advertisers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Advertisers"
 msgstr ""
 
@@ -553,13 +546,6 @@ msgid ""
 "serving faster, lighter and more effective ads."
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid ""
-"Join an ecosystem of  850,000 domains, leading platforms, and 100+ technology"
-" providers using  AMP."
-msgstr ""
-
 #: /content/learn/who/amp-ads.yaml
 msgid "Kavata Mbondo"
 msgstr ""
@@ -580,7 +566,6 @@ msgstr ""
 msgid "Learn"
 msgstr ""
 
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@ko.yaml
 #: /content/learn/who/advertisers.yaml /views/partials/grid-card.html:28
 #: /views/partials/promo_banner.html:17
 msgid "Learn More"
@@ -746,8 +731,6 @@ msgid "Privacy"
 msgstr ""
 
 #: /content/learn/case-studies/category/publishers.md
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
 msgid "Publishers"
 msgstr "发布商"
 
@@ -768,11 +751,6 @@ msgstr ""
 
 #: /content/learn/who/amp-ads.yaml
 msgid "Publishers:<br>Keep audiences engaged"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Read case studies"
 msgstr ""
 
 #: /views/partials/grid-card.html:27
@@ -921,11 +899,6 @@ msgstr ""
 
 #: /content/docs/guides/responsive_amp/_blueprint.yaml
 msgid "Style & Layout"
-msgstr ""
-
-#: /content/learn/who-uses-amp.yaml /content/learn/who-uses-amp@es.yaml
-#: /content/learn/who-uses-amp@ko.yaml
-msgid "Success stories"
 msgstr ""
 
 #: /content/learn/case-studies.html
@@ -1210,8 +1183,7 @@ msgstr ""
 msgid "Who are AMP Ads for?"
 msgstr ""
 
-#: /content/includes/menu.yaml /content/learn/who-uses-amp.yaml
-#: /content/learn/who-uses-amp@es.yaml /content/learn/who-uses-amp@ko.yaml
+#: /content/includes/menu.yaml
 msgid "Who is AMP for?"
 msgstr ""
 


### PR DESCRIPTION
Fixes #520 

Localized text now in localized files, not in translation variables.  
Still need to fix #519 