### PR TITLE
Fix issue 519 - card name localization

### DIFF
--- a/content/learn/who-uses-amp.yaml
+++ b/content/learn/who-uses-amp.yaml
@@ -14,22 +14,27 @@ hero:
 
 cards:
   - name: Publishers
+    filename: publishers
     cta: Learn More
     icon: who_icon_publishers.svg
 
   # - name: SMB
+  #   filename: smb
   #   cta: Learn More
   #   icon: card_smb.svg
 
   - name: Ad Tech Platforms
+    filename: ad-tech-platforms
     cta: Learn More
     icon: who_icon_adtech.svg
 
   - name: Advertisers
+    filename: advertisers
     cta: Learn More
     icon: who_icon_advertisers.svg
 
   # - name: Developers
+  #   filename: developers
   #   cta: Learn More
   #   icon: card_developers.svg
 

--- a/content/learn/who-uses-amp@es.yaml
+++ b/content/learn/who-uses-amp@es.yaml
@@ -13,23 +13,28 @@ hero:
   triangle_img: hero_triangle.png
 
 cards:
-  - name: Publishers
+  - name: Editores
+    filename: publishers
     cta: Aprender Más
     icon: who_icon_publishers.svg
 
   # - name: SMB
+  #   filename: smb
   #   cta: Learn More
   #   icon: card_smb.svg
 
-  - name: Ad Tech Platforms
+  - name: Plataformas Tecnológicas de Anuncios
+    filename: ad-tech-platforms
     cta: Aprender Más
     icon: who_icon_adtech.svg
 
-  - name: Advertisers
+  - name: Anunciantes
+    filename: advertisers
     cta: Aprender Más
     icon: who_icon_advertisers.svg
 
   # - name: Developers
+  #   filename: developers
   #   cta: Learn More
   #   icon: card_developers.svg
 

--- a/content/learn/who-uses-amp@it.yaml
+++ b/content/learn/who-uses-amp@it.yaml
@@ -13,23 +13,28 @@ hero:
   triangle_img: hero_triangle.png
 
 cards:
-  - name: Publishers
+  - name: Editori
+    filename: publishers
     cta: Ulteriori informazioni
     icon: who_icon_publishers.svg
 
   # - name: SMB
+  #   filename: smb
   #   cta: Learn More
   #   icon: card_smb.svg
 
-  - name: Ad Tech Platforms
+  - name: Piattaforme di pubblicità
+    filename: ad-tech-platforms
     cta: Ulteriori informazioni
     icon: who_icon_adtech.svg
 
-  - name: Advertisers
+  - name: Inserzionisti
+    filename: advertisers
     cta: Ulteriori informazioni
     icon: who_icon_advertisers.svg
 
   # - name: Developers
+  #   filename: developers
   #   cta: Learn More
   #   icon: card_developers.svg
 

--- a/content/learn/who-uses-amp@ko.yaml
+++ b/content/learn/who-uses-amp@ko.yaml
@@ -12,23 +12,28 @@ hero:
   triangle_img: hero_triangle.png
 
 cards:
-  - name: Publishers
+  - name: 게시자
+    filename: publishers
     cta: 더 알아보기
     icon: who_icon_publishers.svg
 
   # - name: SMB
+  #   filename: smb
   #   cta: Learn More
   #   icon: card_smb.svg
 
-  - name: Ad Tech Platforms
+  - name: 광고 기술 플랫폼
+    filename: ad-tech-platforms
     cta: 더 알아보기
     icon: who_icon_adtech.svg
 
-  - name: Advertisers
+  - name: 광고게시자
+    filename: advertisers
     cta: 더 알아보기
     icon: who_icon_advertisers.svg
 
   # - name: Developers
+  #   filename: developers
   #   cta: Learn More
   #   icon: card_developers.svg
 

--- a/views/about-who.html
+++ b/views/about-who.html
@@ -39,7 +39,7 @@
     </section>
     <section class="user-categories card-container">
       {% for card in doc.cards %}
-        <a class="card" id="{{card.name|slug}}" href="{{g.doc('/content/learn/who/' ~ card.name|slug ~ '.yaml', locale=doc.locale).url.path}}">
+        <a class="card" id="{{card.filename|slug}}" href="{{g.doc('/content/learn/who/' ~ card.filename|slug ~ '.yaml', locale=doc.locale).url.path}}">
           <amp-img
               noloading
               height=150


### PR DESCRIPTION
Fixes #519 

Card name was being used as filename and title, but when localized it broke.  Broke out filename as separate - always will be english filename.