### PR TITLE
Import AMP Cache Debugging guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ content/docs/reference/spec.md
 content/docs/reference/spec/*.md
 content/docs/reference/components/**/*.md
 content/docs/guides/amp-cors-requests.md
+content/docs/guides/amp-cache-debugging.md

--- a/scripts/import_docs.json
+++ b/scripts/import_docs.json
@@ -25,6 +25,13 @@
         "to": "docs/reference/spec/amp-boilerplate.md"
     },
     {
+        "title": "Debug AMP Cache issues",
+        "order": 1,
+        "from": "spec/amp-cache-debugging.md",
+        "to": "docs/guides/amp-cache-debugging.md",
+        "category": "Debug"
+    },
+    {
         "title": "CORS in AMP",
         "order": 10,
         "from": "spec/amp-cors-requests.md",


### PR DESCRIPTION
Per Malte's request in https://github.com/ampproject/amphtml/pull/7430#issuecomment-307210873, importing the AMP Cache Debugging guide into docset.