### PR TITLE
Update analytics_amp.md

### DIFF
--- a/content/docs/guides/analytics_amp.md
+++ b/content/docs/guides/analytics_amp.md
@@ -43,7 +43,7 @@ You must identify this data before you can configure it.
 Key data points to consider:
 
 * Will you track only page views, or additional user engagement patterns
-(see also [amp-pixel or amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics))?
+(see also [amp-pixel or amp-analytics](/docs/guides/analytics/analytics_basics.html#use-amp-pixel-or-amp-analytics?))?
 * What kinds of data will you capture about your users, your content,
 the device or browser (see also [Variable substitution](/docs/guides/analytics/analytics_basics.html#variable-substitution))?
 * How will you identify your users (see also [User identification](/docs/guides/analytics/analytics_basics.html#user-identification))?


### PR DESCRIPTION
minor issue linking anchor.

Link:
`https://www.ampproject.org/docs/guides/analytics/analytics_basics#use-amp-pixel-or-amp-analytics`

Must be:
`https://www.ampproject.org/docs/guides/analytics/analytics_basics#use-amp-pixel-or-amp-analytics?`