### PR TITLE
Unify void elements style

### DIFF
--- a/content/docs/guides/responsive_amp@ar.md
+++ b/content/docs/guides/responsive_amp@ar.md
@@ -51,7 +51,7 @@ toc: true
 <!doctype html>
   <head>
     <meta charset="utf-8">
-    <link rel="canonical" href="hello-world.html" >
+    <link rel="canonical" href="hello-world.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/content/docs/guides/responsive_amp@de.md
+++ b/content/docs/guides/responsive_amp@de.md
@@ -41,7 +41,7 @@ Beispiel:
 <!doctype html>
   <head>
     <meta charset="utf-8">
-    <link rel="canonical" href="hello-world.html" >
+    <link rel="canonical" href="hello-world.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/content/docs/guides/responsive_amp@fr.md
+++ b/content/docs/guides/responsive_amp@fr.md
@@ -40,7 +40,7 @@ Par exemple :
 <!doctype html>
   <head>
     <meta charset="utf-8">
-    <link rel="canonical" href="hello-world.html" >
+    <link rel="canonical" href="hello-world.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/content/docs/guides/responsive_amp@it.md
+++ b/content/docs/guides/responsive_amp@it.md
@@ -40,7 +40,7 @@ Ad esempio:
 <!doctype html>
   <head>
     <meta charset="utf-8">
-    <link rel="canonical" href="hello-world.html" >
+    <link rel="canonical" href="hello-world.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/content/docs/guides/responsive_amp@pl.md
+++ b/content/docs/guides/responsive_amp@pl.md
@@ -46,7 +46,7 @@ Na przykład:
 <!doctype html>
   <head>
     <meta charset="utf-8">
-    <link rel="canonical" href="hello-world.html" >
+    <link rel="canonical" href="hello-world.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/content/docs/guides/responsive_amp@ru.md
+++ b/content/docs/guides/responsive_amp@ru.md
@@ -40,7 +40,7 @@ toc: true
 <!doctype html>
   <head>
     <meta charset="utf-8">
-    <link rel="canonical" href="hello-world.html" >
+    <link rel="canonical" href="hello-world.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/content/docs/guides/responsive_amp@th.md
+++ b/content/docs/guides/responsive_amp@th.md
@@ -51,7 +51,7 @@ toc: true
 <!doctype html>
   <head>
     <meta charset="utf-8">
-    <link rel="canonical" href="hello-world.html" >
+    <link rel="canonical" href="hello-world.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/content/docs/guides/responsive_amp@tr.md
+++ b/content/docs/guides/responsive_amp@tr.md
@@ -40,7 +40,7 @@ Tüm stilleri, dokümanın head bölümündeki `<style amp-custom>` etiketinin i
 <!doctype html>
   <head>
     <meta charset="utf-8">
-    <link rel="canonical" href="hello-world.html" >
+    <link rel="canonical" href="hello-world.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/content/docs/reference/validation_errors.md
+++ b/content/docs/reference/validation_errors.md
@@ -53,7 +53,7 @@ The following tags must be present in all AMP docs:
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@ar.md
+++ b/content/docs/reference/validation_errors@ar.md
@@ -51,7 +51,7 @@ limitations under the License.
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@de.md
+++ b/content/docs/reference/validation_errors@de.md
@@ -48,7 +48,7 @@ Die folgenden Tags müssen in allen AMP-Dokumenten vorhanden sein:
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@es.md
+++ b/content/docs/reference/validation_errors@es.md
@@ -32,7 +32,7 @@ Todos los documentos de AMP deben contener las siguientes etiquetas:
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@fr.md
+++ b/content/docs/reference/validation_errors@fr.md
@@ -48,7 +48,7 @@ Les balises suivantes doivent être présentes dans tous les documents AMP :
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@id.md
+++ b/content/docs/reference/validation_errors@id.md
@@ -51,7 +51,7 @@ Tag berikut harus ada di semua dokumen AMP:
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@it.md
+++ b/content/docs/reference/validation_errors@it.md
@@ -48,7 +48,7 @@ I tag che seguono devono essere presenti in tutti i documenti AMP:
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@ja.md
+++ b/content/docs/reference/validation_errors@ja.md
@@ -49,7 +49,7 @@ limitations under the License.
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@pl.md
+++ b/content/docs/reference/validation_errors@pl.md
@@ -48,7 +48,7 @@ Wszystkie dokumenty AMP muszą zawierać poniższe tagi:
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@pt_BR.md
+++ b/content/docs/reference/validation_errors@pt_BR.md
@@ -32,7 +32,7 @@ As seguintes tags precisam estar presentes em todos os documentos de AMP:
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@ru.md
+++ b/content/docs/reference/validation_errors@ru.md
@@ -32,7 +32,7 @@ $title: Ошибки на AMP-страницах
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@th.md
+++ b/content/docs/reference/validation_errors@th.md
@@ -34,7 +34,7 @@ $title: ข้อผิดพลาดในการตรวจสอบคว
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@tr.md
+++ b/content/docs/reference/validation_errors@tr.md
@@ -32,7 +32,7 @@ Tüm AMP dokümanlarında aşağıdaki etiketler bulunmalıdır:
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/reference/validation_errors@zh_CN.md
+++ b/content/docs/reference/validation_errors@zh_CN.md
@@ -31,7 +31,7 @@ $title: AMP 验证错误
 * <a name="doctype"></a>`<!doctype html>`
 * <a name="html"></a>`<html amp> or <html ⚡>`
 * <a name="head"></a>`<head>`
-* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL" />`
+* <a name="canonical"></a>`<link rel="canonical" href="$SOME_URL">`
 * <a name="utf"></a>`<meta charset="utf-8">`
 * <a name="viewport"></a>`<meta name="viewport" content="...">`
 * <a name="boilerplate"></a>`<style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>`

--- a/content/docs/tutorials/create/basic_markup.md
+++ b/content/docs/tutorials/create/basic_markup.md
@@ -14,7 +14,7 @@ Copy this and save it to a file with a .html extension.
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -46,9 +46,9 @@ AMP HTML documents MUST:
 | Start with the `<!doctype html>` doctype. | Standard for HTML. |
 | Contain a top-level `<html ⚡>` tag <br>(`<html amp>` is accepted as well). | Identifies the page as AMP content. |
 | Contain `<head>` and `<body>` tags. | Optional in HTML but not in AMP.
-| Contain a `<meta charset="utf-8">` tag as the first child of their `<head>` tag. | Identifies the encoding for the page. | 
+| Contain a `<meta charset="utf-8">` tag as the first child of their `<head>` tag. | Identifies the encoding for the page. |
 | Contain a `<script async src="https://cdn.ampproject.org/v0.js"></script>` tag as the second child of their `<head>` tag. | Includes and loads the AMP JS library. |
-| Contain a `<link rel="canonical" href="$SOME_URL" />` tag inside their `<head>`. | Points to the regular HTML version of the AMP HTML document or to itself if no such HTML version exists. Learn more in [Make Your Page Discoverable](/docs/guides/discovery.html).
+| Contain a `<link rel="canonical" href="$SOME_URL">` tag inside their `<head>`. | Points to the regular HTML version of the AMP HTML document or to itself if no such HTML version exists. Learn more in [Make Your Page Discoverable](/docs/guides/discovery.html).
 | Contain a `<meta name="viewport" content="width=device-width,minimum-scale=1">` tag inside their `<head>` tag. It's also recommended to include `initial-scale=1`. | Specifies a responsive viewport. Learn more in [Create Responsive AMP Pages](/docs/guides/responsive/responsive_design.html). |
 | Contain the [AMP boilerplate code](/docs/reference/spec/amp-boilerplate.html) in their `<head>` tag.  | CSS boilerplate to initially hide the content until AMP JS is loaded. |
 

--- a/content/docs/tutorials/create/basic_markup@ar.md
+++ b/content/docs/tutorials/create/basic_markup@ar.md
@@ -11,7 +11,7 @@ $title: إنشاء صفحة AMP HTML
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ $title: إنشاء صفحة AMP HTML
   - أن تبدأ بـ doctype <span dir="ltr" class="nowrap">`<!doctype html>`</span>.
   - أن تحتوي على علامة المستوى الأعلى <span dir="ltr" class="nowrap">`<html ⚡>`</span> (تكون <span dir="ltr" class="nowrap">`<html amp>`</span> مقبولة كذلك).
   - أن تحتوي على العلامتين `<head>` و`<body>` (هما علامتان اختياريتان في HTML).
-  - أن تحتوي على العلامة <span dir="ltr" class="nowrap">`<link rel="canonical" href="$SOME_URL" />`</span> داخل عنوانها، والتي تشير إلى إصدار HTML العادي لمستند <span dir="ltr" class="nowrap">AMP HTML</span> أو إلى نفسها إذا لم يكن إصدار HTML من هذا القبيل موجودًا.
+  - أن تحتوي على العلامة <span dir="ltr" class="nowrap">`<link rel="canonical" href="$SOME_URL">`</span> داخل عنوانها، والتي تشير إلى إصدار HTML العادي لمستند <span dir="ltr" class="nowrap">AMP HTML</span> أو إلى نفسها إذا لم يكن إصدار HTML من هذا القبيل موجودًا.
   - أن تحتوي على العلامة <span dir="ltr" class="nowrap">`<meta charset="utf-8">`</span> بوصفها التابع الأول للعلامة head.
   - أن تحتوي على العلامة <span dir="ltr" class="nowrap">`<meta name="viewport" content="width=device-width,minimum-scale=1">`</span> داخل العلامة head. من الموصى به أيضًا تضمين <span dir="ltr" class="nowrap">initial-scale=1</span>.
   - أن تحتوي على العلامة <span dir="ltr" class="nowrap">`<script async src="https://cdn.ampproject.org/v0.js"></script>`</span> بوصفها العنصر الأخير في head (يشمل هذا مكتبة <span dir="ltr" class="nowrap">AMP JS</span> ويقوم بتحميلها).

--- a/content/docs/tutorials/create/basic_markup@de.md
+++ b/content/docs/tutorials/create/basic_markup@de.md
@@ -11,7 +11,7 @@ Kopieren Sie es und speichern Sie es in einer Datei mit der Erweiterung ".html".
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ AMP-HTML-Dokumente MÜSSEN:
   - mit dem Doctype `<!doctype html>` beginnen.
   - ein Top-Level-`<html ⚡>`-Tag enthalten (`<html amp>` wird auch akzeptiert).
   - die Tags `<head>` und `body` enthalten (in HTML sind sie optional).
-  - im head-Element das Tag `<link rel="canonical" href="$SOME_URL" />` enthalten, das auf die reguläre HTML-Version des AMP-HTML-Dokuments oder auf sich selbst verweist, falls keine reguläre HTML-Version existiert.
+  - im head-Element das Tag `<link rel="canonical" href="$SOME_URL">` enthalten, das auf die reguläre HTML-Version des AMP-HTML-Dokuments oder auf sich selbst verweist, falls keine reguläre HTML-Version existiert.
   - ein `<meta charset="utf-8">`-Tag als erstes untergeordnetes Element des head-Tags enthalten.
   - das Tag `<meta name="viewport" content="width=device-width,minimum-scale=1">` innerhalb des head-Tags enthalten. Außerdem wird empfohlen, "initial-scale=1" einzufügen.
   - das Tag `<script async src="https://cdn.ampproject.org/v0.js"></script>` als letztes Element im head-Tag enthalten. Damit wird die AMP-JS-Bibliothek eingeschlossen und geladen.

--- a/content/docs/tutorials/create/basic_markup@es.md
+++ b/content/docs/tutorials/create/basic_markup@es.md
@@ -14,7 +14,7 @@ Cópialo y guárdalo en un archivo con extensión .html.
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <title>Hola, AMP</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -48,7 +48,7 @@ Los documentos AMP HTML DEBEN:
 | Contener las etiquetas `<head>` y `<body>`. | Opcional en HTML pero requerido en AMP.
 | Contener la etiqueta `<meta charset="utf-8">` como el primer hijo de su etiqueta `<head>`. | Identifica la codificación de la página. | 
 | Contener la etiqueta `<script async src="https://cdn.ampproject.org/v0.js"></script>` como el segundo hijo de su etiqueta `<head>`. | Incluye y carga la librería AMP JS. |
-| Contener una etiqueta `<link rel="canonical" href="$SOME_URL" />` en la etiqueta `<head>`. | Apunta a la versión regular en HTML de la página AMP, o bien apunta a sí mmisma si dicha versión no existe. Aprende más en [Hacer que tu página sea visible](/es/docs/guides/discovery.html).
+| Contener una etiqueta `<link rel="canonical" href="$SOME_URL">` en la etiqueta `<head>`. | Apunta a la versión regular en HTML de la página AMP, o bien apunta a sí mmisma si dicha versión no existe. Aprende más en [Hacer que tu página sea visible](/es/docs/guides/discovery.html).
 | Contener una etiqueta `<meta name="viewport" content="width=device-width,minimum-scale=1">` en la etiqueta `<head>`. También se recomienda incluir `initial-scale=1`. | Especifica un `viewport` responsivo. Aprende más en [Crear páginas AMP responsivas](/es/docs/guides/responsive/responsive_design.html). |
 | Contener el [código AMP boilerplate](/docs/reference/spec/amp-boilerplate.html) en la etiqueta `<head>`.  | CSS para ocultar inicialmente el contenido hasta que se carga AMP JS. |
 

--- a/content/docs/tutorials/create/basic_markup@fr.md
+++ b/content/docs/tutorials/create/basic_markup@fr.md
@@ -11,7 +11,7 @@ Copiez et enregistrez ce qui suit dans un fichier .html.
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ Les documents AMP HTML DOIVENT :
   - Commencer par le type du document `<!doctype html>`.
   - Contenir une balise `<html ⚡>` de niveau supérieur (`<html amp>` est également accepté).
   - Contenir les balises `<head>` et `<body>` (facultatives dans HTML).
-  - Contenir une balise `<link rel="canonical" href="$SOME_URL" />` dans l'en-tête qui pointe vers la version HTML standard du document AMP HTML ou vers le document lui-même si aucune version HTML n'existe.
+  - Contenir une balise `<link rel="canonical" href="$SOME_URL">` dans l'en-tête qui pointe vers la version HTML standard du document AMP HTML ou vers le document lui-même si aucune version HTML n'existe.
   - Contenir une balise `<meta charset="utf-8">` comme premier enfant de la balise head.
   - Contenir une balise `<meta name="viewport" content="width=device-width,minimum-scale=1">` dans la balise head. Il est également recommandé d'inclure initial-scale=1.
   - Contenir une balise `<script async src="https://cdn.ampproject.org/v0.js"></script>` comme dernier élément de l'en-tête (inclut et charge la bibliothèque AMP JS).

--- a/content/docs/tutorials/create/basic_markup@id.md
+++ b/content/docs/tutorials/create/basic_markup@id.md
@@ -11,7 +11,7 @@ Salin yang berikut ini dan simpanlah ke file dengan ekstensi .html.
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ Dokumen AMP HTML HARUS:
   - Mulai dengan tipe dokumen `<!doctype html>`.
   - Berisi tag `<html ⚡>` tingkat atas (`<html amp>` juga berterima).
   - Berisi tag `<head>` dan `<body>` (Keduanya opsional dalam HTML).
-  - Berisi tag `<link rel="canonical" href="$SOME_URL" />` dalam bagian kepala yang menunjuk pada versi HTML reguler dari dokumen AMP HTML atau menunjuk pada dirinya sendiri jika tidak ada versi HTML seperti itu.
+  - Berisi tag `<link rel="canonical" href="$SOME_URL">` dalam bagian kepala yang menunjuk pada versi HTML reguler dari dokumen AMP HTML atau menunjuk pada dirinya sendiri jika tidak ada versi HTML seperti itu.
   - Berisi tag `<meta charset="utf-8">` sebagai anak pertama dari tag kepalanya.
   - Berisi tag `<meta name="viewport" content="width=device-width,minimum-scale=1">` di dalam tag kepalanya. Juga disarankan untuk menyertakan initial-scale=1.
   - Berisi tag `<script async src="https://cdn.ampproject.org/v0.js"></script>` sebagai elemen terakhir dalam kepalanya (ini mencakup dan memuat pustaka AMP JS).

--- a/content/docs/tutorials/create/basic_markup@it.md
+++ b/content/docs/tutorials/create/basic_markup@it.md
@@ -11,7 +11,7 @@ Copialo e salvalo in un file con estensione .html.
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ I documenti HTML AMP DEVONO:
   - Iniziare con il doctype `<!doctype html>`.
   - Contenere un tag di primo livello `<html ⚡>` (`<html amp>` è ugualmente accettato).
   - Contenere i tag `<head>` e `<body>` (questi sono opzionali in HTML).
-  - Contenere un tag `<link rel="canonical" href="$SOME_URL" />` all’interno dell’intestazione che faccia riferimento alla normale versione HTML del documento HTML AMP o a sé stesso se non esiste tale versione HTML.
+  - Contenere un tag `<link rel="canonical" href="$SOME_URL">` all’interno dell’intestazione che faccia riferimento alla normale versione HTML del documento HTML AMP o a sé stesso se non esiste tale versione HTML.
   - Contenere un tag `<meta charset="utf-8">` in quanto primo tag secondario del tag dell’intestazione.
   - Contenere un tag `<meta name="viewport" content="width=device-width,minimum-scale=1">` all’interno del tag dell’intestazione. Si consiglia anche di includere initial-scale=1.
   - Contenere un tag `<script async src="https://cdn.ampproject.org/v0.js"></script>` in quanto ultimo elemento dell’intestazione (ciò comprende e carica la libreria AMP JS).

--- a/content/docs/tutorials/create/basic_markup@ja.md
+++ b/content/docs/tutorials/create/basic_markup@ja.md
@@ -11,7 +11,7 @@ $title: AMP HTML ページを作成する
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ AMP HTML ドキュメントが満たすべき条件は以下のとおりです�
   - `<!doctype html>` という文書型宣言で開始する。
   - 最上位階層のタグを `<html ⚡>`（`<html amp>` でも可）にする。
   - `<head>` タグと `<body>` タグ（HTML ではどちらも任意）を含める。
-  - ヘッド部に `<link rel="canonical" href="$SOME_URL" />` タグを入れて、AMP HTML 版の通常の HTML バージョンを指定する。該当する HTML が存在しない場合は自身を指定する。
+  - ヘッド部に `<link rel="canonical" href="$SOME_URL">` タグを入れて、AMP HTML 版の通常の HTML バージョンを指定する。該当する HTML が存在しない場合は自身を指定する。
   - head タグの最初の子要素を `<meta charset="utf-8">` タグにする。
   - head タグ内に `<meta name="viewport" content="width=device-width,minimum-scale=1">` タグを含める。initial-scale=1 も入れることをお勧めします。
   - head タグの最後の要素を `<script async src="https://cdn.ampproject.org/v0.js"></script>` タグにする（これによって AMP JS ライブラリがインクルードされ、読み込まれます）。

--- a/content/docs/tutorials/create/basic_markup@ko.md
+++ b/content/docs/tutorials/create/basic_markup@ko.md
@@ -11,7 +11,7 @@ $title: AMP HTML 페이지 만들기
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ AMP HTML 문서는:
   - Doctype `<!doctype html>`로 시작해야 합니다.
   - 최상위 `<html ⚡>` 태그를 포함해야 합니다(`<html amp>`도 허용됨).
   - `<head>` 및 `<body>` 태그를 포함해야 합니다(HTML에서는 선택 항목).
-  - AMP HTML 문서의 일반 HTML 버전을 가리키는 `<link rel="canonical" href="$SOME_URL" />` 태그를 헤드 내에 포함해야 합니다. 이러한 HTML 버전이 없는 경우 스스로를 가리키는 태그를 포함해야 합니다.
+  - AMP HTML 문서의 일반 HTML 버전을 가리키는 `<link rel="canonical" href="$SOME_URL">` 태그를 헤드 내에 포함해야 합니다. 이러한 HTML 버전이 없는 경우 스스로를 가리키는 태그를 포함해야 합니다.
   - 헤드 태그의 첫 번째 하위 요소로서 `<meta charset="utf-8">` 태그를 포함해야 합니다.
   - 헤드 태그 내에 `<meta name="viewport" content="width=device-width,minimum-scale=1">` 태그를 포함해야 합니다. 또한 initial-scale=1을 포함시키는 것이 좋습니다.
   - 헤드의 마지막 요소로서 `<script async src="https://cdn.ampproject.org/v0.js"></script>` 태그를 포함해야 합니다(이 요소는 AMP JS 라이브러리를 포함하고 로드합니다).

--- a/content/docs/tutorials/create/basic_markup@pl.md
+++ b/content/docs/tutorials/create/basic_markup@pl.md
@@ -11,7 +11,7 @@ Skopiuj go i zapisz w pliku z rozszerzeniem .html.
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ Dokumenty AMP HTML MUSZĄ:
   - Zaczynać się od deklaracji doctype `<!doctype html>`.
   - Zawierać znacznik `<html ⚡>` najwyższego poziomu (akceptowany jest również znacznik `<html amp>`).
   - Zawierać znaczniki `<head>` i `<body>` (w języku HTML są one opcjonalne).
-  - Zawierać w sekcji head znacznik `<link rel="canonical" href="$SOME_URL" />` wskazujący wersję dokumentu AMP HTML w zwykłym HTML lub ten sam dokument, jeśli taka wersja HTML nie istnieje.
+  - Zawierać w sekcji head znacznik `<link rel="canonical" href="$SOME_URL">` wskazujący wersję dokumentu AMP HTML w zwykłym HTML lub ten sam dokument, jeśli taka wersja HTML nie istnieje.
   - Zawierać znacznik `<meta charset="utf-8">` jako pierwszy element podrzędny znacznika head.
   - Zawierać znacznik `<meta name="viewport" content="width=device-width,minimum-scale=1">` wewnątrz znacznika head. Zalecane jest także dodanie atrybutu initial-scale=1.
   - Zawierać znacznik `<script async src="https://cdn.ampproject.org/v0.js"></script>` jako ostatni element w sekcji head (służy do dołączenia i ładowania biblioteki AMP JS).

--- a/content/docs/tutorials/create/basic_markup@pt_BR.md
+++ b/content/docs/tutorials/create/basic_markup@pt_BR.md
@@ -11,7 +11,7 @@ Copie e salve-a em um arquivo de extensão .html.
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ Documentos em AMP HTML DEVEM:
   - Ser iniciados pelo doctype `<!doctype html>`.
   - Conter uma tag `<html ⚡>` de nível superior (`<html amp>` também é aceita).
   - Conter as tags `<head>` e `<body>` (elas são opcionais em HTML).
-  - Conter uma tag `<link rel="canonical" href="$SOME_URL" />` dentro do cabeçalho que aponte para a versão em HTML comum do documento em AMP HTML, ou para o próprio documento se a versão em HTML não existir.
+  - Conter uma tag `<link rel="canonical" href="$SOME_URL">` dentro do cabeçalho que aponte para a versão em HTML comum do documento em AMP HTML, ou para o próprio documento se a versão em HTML não existir.
   - Conter uma tag `<meta charset="utf-8">` como primeira filha da tag do cabeçalho.
   - Conter uma tag `<meta name="viewport" content="width=device-width,minimum-scale=1">`dentro da tag do cabeçalho. Também é recomendável incluir initial-scale=1.
   - Conter uma tag `<script async src="https://cdn.ampproject.org/v0.js"></script>` como o último elemento do cabeçalho (isso inclui e carrega a biblioteca de AMP JS).

--- a/content/docs/tutorials/create/basic_markup@ru.md
+++ b/content/docs/tutorials/create/basic_markup@ru.md
@@ -11,7 +11,7 @@ $title: Создание страницы AMP HTML
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ $title: Создание страницы AMP HTML
   - Начинаться с типа документа `<!doctype html>`.
   - Содержать тег верхнего уровня `<html ⚡>` (также допускается использование `<html amp>`).
   - Содержать теги `<head>` и `<body>` (необязательные в разметке HTML).
-  - Содержать внутри заголовка тег `<link rel="canonical" href="$SOME_URL" />`, который указывает на обычную HTML-версию документа AMP HTML или на сам исходный документ, если такой версии не существует.
+  - Содержать внутри заголовка тег `<link rel="canonical" href="$SOME_URL">`, который указывает на обычную HTML-версию документа AMP HTML или на сам исходный документ, если такой версии не существует.
   - Содержать тег `<meta charset="utf-8">` в качестве первого дочернего элемента тега заголовка.
   - Содержать в теге заголовка тег `<meta name="viewport" content="width=device-width,minimum-scale=1">`. Также рекомендуется включить в него значение initial-scale=1.
   - Содержать в качестве последнего элемента заголовка тег `<script async src="https://cdn.ampproject.org/v0.js"></script>`, который указывает и загружает библиотеку AMP JS.

--- a/content/docs/tutorials/create/basic_markup@th.md
+++ b/content/docs/tutorials/create/basic_markup@th.md
@@ -11,7 +11,7 @@ $title: สร้างหน้า AMP HTML
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ $title: สร้างหน้า AMP HTML
   - เริ่มต้นด้วย doctype `<!doctype html>`
   - มีแท็ก `<html ⚡>` ระดับบนสุด (สามารถใช้ `<html amp>` ได้เช่นกัน)
   - มีแท็ก `<head>` และ `<body>` (มีหรือไม่ก็ได้ใน HTML)
-  - มีแท็ก `<link rel="canonical" href="$SOME_URL" />` อยู่ภายในส่วนหัวที่นำไปยังเอกสาร AMP HTML เวอร์ชัน HTML ปกติหรือไปยังหน้านั้นเองในกรณีที่ไม่มีเวอร์ชัน HTML
+  - มีแท็ก `<link rel="canonical" href="$SOME_URL">` อยู่ภายในส่วนหัวที่นำไปยังเอกสาร AMP HTML เวอร์ชัน HTML ปกติหรือไปยังหน้านั้นเองในกรณีที่ไม่มีเวอร์ชัน HTML
   - มีแท็ก `<meta charset="utf-8">` เป็นรายการย่อยแรกของแท็กส่วนหัว
   - มีแท็ก `<meta name="viewport" content="width=device-width,minimum-scale=1">` อยู่ในแท็กส่วนหัว โดยแนะนำให้ใส่ initial-scale=1 ไว้ด้วย
   - มีแท็ก `<script async src="https://cdn.ampproject.org/v0.js"></script>` เป็นอิลิเมนต์สุดท้ายในส่วนหัว (ซึ่งรวมถึงและการโหลดไลบรารี AMP JS)

--- a/content/docs/tutorials/create/basic_markup@tr.md
+++ b/content/docs/tutorials/create/basic_markup@tr.md
@@ -11,7 +11,7 @@ Bunu kopyalayın veya .html uzantılı bir dosyaya kaydedin.
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ AMP HTML belgeleri şu özelliklere sahip olmalıdır:
   - Belge tipiyle `<!doctype html>` başlamalıdır.
   - Üst seviye bir `<html ⚡>` etiketi içermelidir (`<html amp>` de kabul edilir).
   - `<head>` ve `<body>` etiketleri içermelidir (HTML›de isteğe bağlıdır).
-  - Başında AMP HTML belgesinin düzenli HTML sürümünü ya da böyle bir HTML versiyonu mevcut değilse kendisini gösteren bir `<link rel="canonical" href="$SOME_URL" />` etiketi içerir.
+  - Başında AMP HTML belgesinin düzenli HTML sürümünü ya da böyle bir HTML versiyonu mevcut değilse kendisini gösteren bir `<link rel="canonical" href="$SOME_URL">` etiketi içerir.
   - Baş etiketin ilk ürünü olarak `<meta charset="utf-8">` etiketini içerir.
   - Baş etiketin içerisinde bir `<meta name="viewport" content="width=device-width,minimum-scale=1">` etiketi içerir. initial-scale=1›in de eklenmesi önerilir.
   - Başında en son öge olarak`<script async src="https://cdn.ampproject.org/v0.js"></script>` etiketini içerir (Buna AMP JS kitaplığı da eklenip yüklenir).

--- a/content/docs/tutorials/create/basic_markup@zh_CN.md
+++ b/content/docs/tutorials/create/basic_markup@zh_CN.md
@@ -11,7 +11,7 @@ $title: 创建 AMP HTML 页面
   <head>
     <meta charset="utf-8">
     <title>Hello, AMPs</title>
-    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html" />
+    <link rel="canonical" href="http://example.ampproject.org/article-metadata.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <script type="application/ld+json">
       {
@@ -42,7 +42,7 @@ AMP HTML 文档必须：
   - 以文档类型 `<!doctype html>` 开头
   - 包含顶级 `<html ⚡>` 标记（也接受 `<html amp>`）
   - 包含 `<head>` 和 `<body>` 标记（这些标记在 HTML 中是可选的）
-  - 在<head>内包含一个 `<link rel="canonical" href="$SOME_URL" />` 标记，该标记指向 AMP HTML 文档的常规 HTML 版本，或在此类 HTML 版本不存在的情况下指向文档本身
+  - 在<head>内包含一个 `<link rel="canonical" href="$SOME_URL">` 标记，该标记指向 AMP HTML 文档的常规 HTML 版本，或在此类 HTML 版本不存在的情况下指向文档本身
   - 包含 `<meta charset="utf-8">` 标记作为<head>标记的第一个子项
   - 在<head>标记内包含 `<meta name="viewport" content="width=device-width,minimum-scale=1">` 标记。还建议包括 initial-scale=1
   - 包含 `<script async src="https://cdn.ampproject.org/v0.js"></script>` 标记作为<head>中的最后一个元素（这样做将会包括并加载 AMP JS 库）

--- a/examples/src/ampaccordion.html
+++ b/examples/src/ampaccordion.html
@@ -5,7 +5,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-accordion" src="https://cdn.ampproject.org/v0/amp-accordion-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="ampaccordion.html" />
+  <link rel="canonical" href="ampaccordion.html">
   <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400" rel="stylesheet">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/examples/src/ampad.html
+++ b/examples/src/ampad.html
@@ -5,7 +5,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script> 
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="ampad.html" />
+  <link rel="canonical" href="ampad.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 </head>
 <body>

--- a/examples/src/ampanim.html
+++ b/examples/src/ampanim.html
@@ -5,7 +5,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-anim" src="https://cdn.ampproject.org/v0/amp-anim-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="ampanim.html" />
+  <link rel="canonical" href="ampanim.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 </head>
 <body>

--- a/examples/src/ampaudio.html
+++ b/examples/src/ampaudio.html
@@ -5,7 +5,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="ampaudio.html" />
+  <link rel="canonical" href="ampaudio.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 </head>
 <body>

--- a/examples/src/ampcarousel.html
+++ b/examples/src/ampcarousel.html
@@ -5,7 +5,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="ampcarousel.html" />
+  <link rel="canonical" href="ampcarousel.html">
   <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400" rel="stylesheet">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/examples/src/ampform.html
+++ b/examples/src/ampform.html
@@ -6,7 +6,7 @@
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="ampform.html" />
+  <link rel="canonical" href="ampform.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <style amp-custom>
     body {

--- a/examples/src/ampimg.html
+++ b/examples/src/ampimg.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="ampimg.html" />
+  <link rel="canonical" href="ampimg.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 </head>
 <body>

--- a/examples/src/amplist.html
+++ b/examples/src/amplist.html
@@ -7,7 +7,7 @@
   <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <link rel="canonical" href="amplist.html" />
+  <link rel="canonical" href="amplist.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <style amp-custom>
     body {

--- a/examples/src/amptwitter.html
+++ b/examples/src/amptwitter.html
@@ -6,7 +6,7 @@
   <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
-  <link rel="canonical" href="amptwitter.html" />
+  <link rel="canonical" href="amptwitter.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <style amp-custom>
     body {

--- a/examples/src/ampvideo.html
+++ b/examples/src/ampvideo.html
@@ -5,7 +5,7 @@
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="ampvideo.html" />
+  <link rel="canonical" href="ampvideo.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 </head>
 <body>

--- a/examples/src/thirdparty.html
+++ b/examples/src/thirdparty.html
@@ -9,7 +9,7 @@
   src="https://cdn.ampproject.org/v0/amp-instagram-0.1.js"></script>
   <script async custom-element="amp-ad" src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script> 
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-  <link rel="canonical" href="thirdparty.html" />
+  <link rel="canonical" href="thirdparty.html">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 </head>
 <body>


### PR DESCRIPTION
In the spec, examples, and docs the style of void elements in `<head>` is inconsistent. I noticed it first for `<link rel="canonical" …>` in the tutorial, which includes `/` compared to `<meta>`s around it. A quick look at other places showed me that the style without `/` is prevailing.

<img width="763" alt="screenshot_2017-07-26_15_52_34" src="https://user-images.githubusercontent.com/68341/28624832-aa125582-721a-11e7-9371-24339eb3bfe5.png">

---

This PR removes the closing slash for all `<link>` and `<meta>` elements.

* Replaced all occurrences of `<link (.+) ?/>` resp. `<meta (.+) ?/>`, with `<link $1>` resp. `<meta $1>`.

Sibling PR in ampproject/amphtml: https://github.com/ampproject/amphtml/pull/10644