### PR TITLE
Add icon and CSS for external links in ref docs

### DIFF
--- a/assets/img/ic_open_in_new_blue.svg
+++ b/assets/img/ic_open_in_new_blue.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="#1c79c0">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/>
+</svg>

--- a/assets/sass/_content-post.scss
+++ b/assets/sass/_content-post.scss
@@ -17,7 +17,7 @@
     text-transform: none;
   }
 
-  a.external::after {
+  a[href*="//"]:not([href*="www.ampproject.org"]):not([href*="github.com/ampproject"])::after {
     content: "";
     display: inline-block;
     background-image: url('/static/img/ic_open_in_new_blue.svg');

--- a/assets/sass/_content-post.scss
+++ b/assets/sass/_content-post.scss
@@ -17,6 +17,17 @@
     text-transform: none;
   }
 
+  a.external::after {
+    content: "";
+    display: inline-block;
+    background-image: url('/static/img/ic_open_in_new_blue.svg');
+    background-size: 18px;
+    width: 18px;
+    height: 18px;
+    margin-left: 4px;
+    vertical-align: text-bottom;
+  }
+
   .button {
     &:before {
       display: none;


### PR DESCRIPTION
To make it apparent that links are "external" to the site, adding CSS and icon that will be used in ref docs, like in the following example:

![external-links-ref-docs](https://user-images.githubusercontent.com/1012254/28939283-ca654d4a-785e-11e7-9e10-a36bcd14a5d3.png)


Now, I'll just need to change all the ref docs that have examples, and add class="external" + consistent wording.

cc: @mattludwig 