### PR TITLE
(ES) Modified link name "Include images & videos"

### DIFF
--- a/content/docs/tutorials/create/include_image@es.md
+++ b/content/docs/tutorials/create/include_image@es.md
@@ -12,7 +12,7 @@ Para demostrar el aspecto que tendría el marcado adicional, a continuación te 
 [/sourcecode]
 
 {% call callout('Leer más', type='read') %}
-Para saber por qué reemplazamos etiquetas como `<img>` por `<amp-img>` y cuántas hay disponibles, consulta [Incluir Iframes y medios](/es/docs/guides/amp_replacements.html).
+Para saber por qué reemplazamos etiquetas como `<img>` por `<amp-img>` y cuántas hay disponibles, consulta [Incluir imágenes y videos](/es/docs/guides/amp_replacements.html).
 {% endcall %}
 
 <div class="prev-next-buttons">


### PR DESCRIPTION
Modified link name from 'Include Iframes and Media' to 'Include Images & Video' for Spanish.