### PR TITLE
Add new components to docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   - $HOME/.cache/pip
   - /home/travis/.local/bin
 install:
-- pip install grow==0.2.4 --user $USER
+- pip install grow --user
 - npm install -g gulp
 - npm install -g firebase-tools
 - npm install

--- a/content/docs/reference/components.md
+++ b/content/docs/reference/components.md
@@ -45,6 +45,7 @@ Here are the components grouped by category:
 | [`amp-mustache`](components/amp-mustache.html) | Allows rendering of [`Mustache.js`](https://github.com/janl/mustache.js/) templates. |
 | [`amp-selector`](components/amp-selector.html) |  Represents a control that presents a menu of options and lets the user choose from it. |
 | [`amp-user-notification`](components/amp-user-notification.html) | Displays a dismissable notification to the user. |
+| [`amp-web-push`](components/amp-web-push.html) | Allows users to subscribe to [web push notifications](https://developers.google.com/web/fundamentals/engage-and-retain/push-notifications/). |
 
 ### Layout
 
@@ -57,6 +58,7 @@ Here are the components grouped by category:
 | [`amp-fx-parallax`](components/amp-fx-parallax.html) |  An attribute that enables a 3D-perspective effect on an element. |
 | [`amp-iframe`](components/amp-iframe.html) | Displays an iframe. |
 | [`amp-lightbox`](components/amp-lightbox.html) | Allows for a “lightbox” or similar experience. |
+| [`amp-position-observer`](components/amp-position-observer.html) | Monitors position of an element within the viewport as a user scrolls and dispatches  events that can be used with other components. |
 | [`amp-sidebar`](components/amp-sidebar.html) | Provides a way to display meta content intended for temporary access such as navigation, links, buttons, menus. |
 
 
@@ -76,6 +78,7 @@ Here are the components grouped by category:
 | [`amp-ima-video`](components/amp-ima-video.html) | Embeds a video player for instream video ads that are integrated with the [IMA SDK](https://developers.google.com/interactive-media-ads/docs/sdks/html5/). |
 | [`amp-image-lightbox`](components/amp-image-lightbox.html) | Allows for an “image lightbox” or similar experience. |
 | [`amp-img`](components/amp-img.html)  | Replaces the HTML5 `img` tag. |
+| [`amp-imgur`](components/amp-imgur.html)  | Displays an [Imgur](http://imgur.com/) post. |
 | [`amp-izlesene`](components/amp-izlesene.html)  | Displays an [Izlesene](https://www.izlesene.com/) video. |
 | [`amp-jwplayer`](components/amp-jwplayer.html) | Displays a cloud-hosted [JW Player](https://www.jwplayer.com/). |
 | [`amp-kaltura-player`](components/amp-kaltura-player.html) | Displays the Kaltura Player as used in [Kaltura's Video Platform](https://corp.kaltura.com/). |

--- a/scripts/component_categories.json
+++ b/scripts/component_categories.json
@@ -20,6 +20,7 @@
     "amp-selector": "dynamic-content",
     "amp-user-notification": "dynamic-content",
     "amp-sortable-table": "dynamic-content",
+    "amp-web-push": "dynamic-content",
 
     "amp-accordion": "layout",
     "amp-app-banner": "layout",
@@ -28,6 +29,7 @@
     "amp-fx-parallax": "layout",
     "amp-iframe": "layout",
     "amp-lightbox": "layout",
+    "amp-position-observer": "layout",
     "amp-sidebar": "layout",
 
     "amp-3q-player": "media",
@@ -41,6 +43,7 @@
     "amp-hulu": "media",
     "amp-ima-video": "media",
     "amp-image-lightbox": "media",
+    "amp-imgur": "media",
     "amp-img": "media",
     "amp-izlesene": "media",
     "amp-jwplayer": "media",


### PR DESCRIPTION
Include new components to docs: amp-imgur, amp-web-push, and amp-position-observer.



Fixes: https://github.com/ampproject/docs/issues/674

nit: cleanup grow version now that 0.2.4 works
cc: @honeybadgerdontcare 