### PR TITLE
Add Typekit origin for serving custom fonts.

### DIFF
--- a/content/docs/guides/responsive_amp/custom_fonts.md
+++ b/content/docs/guides/responsive_amp/custom_fonts.md
@@ -25,6 +25,7 @@ The following origins are whitelisted and allowed for font serving via link tags
 * Typography.com: **https://cloud.typography.com**
 * Fonts.com: **https://fast.fonts.net**
 * Google Fonts: **https://fonts.googleapis.com**
+* Typekit: **https://use.typekit.net**
 * Font Awesome: **https://maxcdn.bootstrapcdn.com**
 
 ### 2. Using `@font-face`


### PR DESCRIPTION
This adds Typekit to the whitelist for custom font serving. This feature was released by Typekit on 2017/08/30 (https://blog.typekit.com/2017/08/30/css-font-loading/). Help documentation can be found here: https://pages.typekit.com/early-access-user-guides/en/css-kits/#html-amp