### PR TITLE
Importing support.md file and adding to dev support section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ content/docs/reference/spec/*.md
 content/docs/reference/components/**/*.md
 content/docs/guides/amp-cors-requests.md
 content/docs/guides/amp-cache-debugging.md
+content/support/developer/get_support.md

--- a/assets/sass/_content-section.scss
+++ b/assets/sass/_content-section.scss
@@ -13,6 +13,13 @@
   }
 }
 
+.md {
+  ul,
+  ol {
+      margin-left: 40px;
+  }
+}
+
 @include max-screen($mobile-breakpoint) {
   .post-title {
     text-align: left;

--- a/content/support/developer/mailing-list.md
+++ b/content/support/developer/mailing-list.md
@@ -1,6 +1,0 @@
----
-$title@: Support Forum
-$order: 1
-goto: https://groups.google.com/forum/#!forum/amphtml-discuss
-group: 0
----

--- a/scripts/import_docs.js
+++ b/scripts/import_docs.js
@@ -82,12 +82,13 @@ function savePage(config, callback) {
 
   var optionalTOC = config.content.indexOf('[TOC]') > -1 ? 'toc: true\n' : '';
   var optionalCategory = (config.category ? "\n$category: " +  config.category : '');
+  var optionalGroup = (config.group ? "\ngroup: " + config.group : '');
   var optionalDependencies = getDependencies(config.content);
   optionalDependencies = optionalDependencies ? '\ncomponents:\n' + '  - ' + optionalDependencies.join('\n  - ') + '\n' : '';
 
   var frontMatter = `---
 $title: "${config.title}"
-$order: ${config.order || 0}${optionalCategory}
+$order: ${config.order || 0}${optionalCategory}${optionalGroup}
 ${optionalTOC}${optionalDependencies}---
 `;
 
@@ -142,7 +143,8 @@ importData.forEach((item) => {
       content: (item.toc ? '[TOC]\n' : '') + pageContent,
       title: item.title,
       order: item.order,
-      category: (item.category ? item.category : '')
+      category: (item.category ? item.category : ''),
+      group: (item.group ? item.group : '')
     }, function (err) {
       if (err) throw err;
       console.log('Successfully imported: ' + item.title);

--- a/scripts/import_docs.json
+++ b/scripts/import_docs.json
@@ -36,5 +36,12 @@
         "from": "spec/amp-cors-requests.md",
         "to": "docs/guides/amp-cors-requests.md",
         "category": "Deploy"
+    },
+    {
+        "title": "Getting Support",
+        "order": 1,
+        "from": "SUPPORT.md",
+        "to": "support/developer/get_support.md",
+        "group": 1
     }
 ]


### PR DESCRIPTION
Importing [AMPHTML's support.md](https://github.com/ampproject/amphtml/blob/master/SUPPORT.md) file into ampproject.org docs.  Adding the doc to the "Developer Support" section.

cc: @rudygalfi, @cramforce 

![getting-support](https://user-images.githubusercontent.com/1012254/30974064-ae04ff92-a43c-11e7-8637-e40c0883ec50.png)


Note: Needed to amend format in support.md - see https://github.com/ampproject/amphtml/pull/11474

