### PR TITLE
New batch of T1 locale translations (three articles, 15 translations)

### DIFF
--- a/content/docs/tutorials/login_requiring/add_comment@es.md
+++ b/content/docs/tutorials/login_requiring/add_comment@es.md
@@ -1,19 +1,20 @@
 ---
-$title: Agregar un comentario
+$title: Añadir un comentario
 $order: 1
 ---
 
-<amp-img src="/static/img/comment.png" alt="Agregar un comentario" height="325" width="300"></amp-img>
+<amp-img src="/static/img/comment.png" alt="Añadir un comentario" height="325" width="300"></amp-img>
 
-En este punto, el usuario puede agregar un comentario utilizando la librería `amp-form`. Observe cómo la presencia del formulario es condicional, dependiendo del estado del componente de `amp-access`:
+En este momento, un usuario puede añadir un comentario utilizando la biblioteca `amp-form`. La presencia del formulario depende del estado del componente `amp-access`:
 
 [sourcecode:html]
 <form amp-access="loggedIn" amp-access-hide method="post" action-xhr="<%host%>/samples_templates/comment_section/submit-comment-xhr" target="_top">
 [/sourcecode]
 
-Especificamos un método POST y una acción XHR, ya que las acciones no XHR no están permitidas con los métodos POST en AMP. Debido a que se trata de una demostración, no estamos persistiendo comentarios, por lo que sólo es posible añadir un comentario en el momento; cada vez que se agrega un comentario, el servidor AMPByExample responde con una respuesta JSON que contiene el texto introducido con algunas adiciones, como una marca de tiempo, un avatar y un nombre para el usuario.
+Determinamos un método POST y una acción XHR, porque las acciones que no son XHR no están permitidas en los métodos POST de AMP.
+Al ser una demostración, no se guardan los comentarios, así que solo es posible añadir un comentario en cada ocasión. Cuando se añade un comentario, el servidor AMPByExample envía una respuesta JSON que contiene el texto introducido con información adicional, como una marca de tiempo, un avatar y un nombre de usuario.
 
-He aquí un ejemplo de respuesta JSON:
+Este es un ejemplo de respuesta JSON:
 
 [sourcecode:json]
 {"Datetime":"09:34:21",
@@ -22,7 +23,7 @@ He aquí un ejemplo de respuesta JSON:
 "UserImg":"/img/ic_account_box_black_48dp_1x.png"}
 [/sourcecode]
 
-El componente de formulario simplemente mostrará esos valores dentro de la página usando la plantilla [amp-mustache](https://www.ampproject.org/docs/reference/components/amp-mustache):
+Esos valores sencillamente se mostrarán en la página utilizando la plantilla [amp-mustache](https://www.ampproject.org/es/docs/reference/components/amp-mustache):
 
 [sourcecode:html]
 <div submit-success>
@@ -38,7 +39,7 @@ El componente de formulario simplemente mostrará esos valores dentro de la pág
 </div>
 [/sourcecode]
 
-En este ejemplo, sólo estamos comprobando si el valor del comentario no está vacío; si el valor está vacío, devolvemos un error que hace que el código siguiente se ejecute
+En este ejemplo, solo comprobamos que el valor del comentario no esté vacío; en caso contrario, devolvemos un error que ejecuta el código siguiente:
 
 [sourcecode:html]
 <div submit-error>
@@ -48,19 +49,21 @@ En este ejemplo, sólo estamos comprobando si el valor del comentario no está v
 </div>
 [/sourcecode]
 
-Como un toque extra, añadimos el atributo `required` para reforzar la presencia del texto del comentario antes de enviar el comentario:
+Adicionalmente, añadimos el atributo `required` para exigir que el comentario tenga texto antes de que se pueda enviar:
 
-<amp-img src="/static/img/enforce-comment.png" alt="Enforce comment" height="325" width="300"></amp-img>
+<amp-img src="/static/img/enforce-comment.png" alt="Exigir comentario" height="325" width="300"></amp-img>
 
 [sourcecode:html]
 <input type="text" class="data-input" name="text" placeholder="Your comment..." required>
 [/sourcecode]
 
-Cuando añada un comentario y haga clic en el botón Enviar, debería ver algo similar a la siguiente captura de pantalla:
+Cuando añades un comentario y haces clic en el botón para enviarlo, aparece algo similar a lo que se ve en esta captura de pantalla:
 
-<amp-img src="/static/img/logout-button.png" alt="Comment added" height="352" width="300"></amp-img>
+<amp-img src="/static/img/logout-button.png" alt="Comentario añadido" height="352" width="300"></amp-img>
 
 <div class="prev-next-buttons">
   <a class="button prev-button" href="/es/docs/tutorials/login_requiring/login.html"><span class="arrow-prev">Anterior</span></a>
-  <a class="button next-button" href="/es/docs/tutorials/login_requiring/logout.html"><span class="arrow-next">Próximo</span></a>
+  <a class="button next-button" href="/es/docs/tutorials/login_requiring/logout.html"><span class="arrow-next">Siguiente</span></a>
 </div>
+ 
+ 

--- a/content/docs/tutorials/login_requiring/add_comment@id.md
+++ b/content/docs/tutorials/login_requiring/add_comment@id.md
@@ -1,0 +1,69 @@
+---
+$title: Menambahkan komentar
+$order: 1
+---
+
+<amp-img src="/static/img/comment.png" alt="Add comment" height="325" width="300"></amp-img>
+
+Di titik ini, pengguna dapat menambahkan komentar menggunakan koleksi `amp-form`. Perhatikan bagaimana kemunculan formulir bersifat kondisional, bergantung pada status komponen `amp-access`:
+
+[sourcecode:html]
+<form amp-access="loggedIn" amp-access-hide method="post" action-xhr="<%host%>/samples_templates/comment_section/submit-comment-xhr" target="_top">
+[/sourcecode]
+
+Kami menentukan metode POST dan tindakan XHR, karena tindakan non XHR tidak diizinkan dengan metode POST di AMP.
+Karena ini adalah demo, kami tidak memberikan banyak komentar, jadi 1 komentar hanya dapat ditambahkan dalam satu kesempatan. Setiap kali komentar ditambahkan, server AMPByExample membalas dengan respons JSON yang berisi teks yang dimasukkan dengan beberapa tambahan, seperti stempel waktu, avatar, dan nama untuk pengguna.
+
+Berikut adalah contoh respons JSON:
+
+[sourcecode:json]
+{"Datetime":"09:34:21",
+"User":"Charlie",
+"Text":"Hello!",
+"UserImg":"/img/ic_account_box_black_48dp_1x.png"}
+[/sourcecode]
+
+Komponen formulir hanya akan menampilkan nilai di dalam halaman menggunakan [amp-mustache](https://www.ampproject.org/id/docs/reference/components/amp-mustache) template:
+
+[sourcecode:html]
+<div submit-success>
+  <template type="amp-mustache">
+    <div class="comment-user">
+      <amp-img width="44" class="user-avatar" height="44" alt="user" src="{{UserImg}}"></amp-img>
+      <div class="card comment">
+        <p><span class="user">{% raw %}{{User}}{% endraw %}</span><span class="date">{% raw %}{{Datetime}}{% endraw %}</span></p>
+        <p>{% raw %}{{Text}}{% endraw %}</p>
+      </div>
+    </div>
+  </template>
+</div>
+[/sourcecode]
+
+Dalam contoh ini, kami hanya memeriksa apakah nilai komentar tidak kosong. Jika nilainya kosong, kami menampilkan error yang menyebabkan kode berikut dijalankan:
+
+[sourcecode:html]
+<div submit-error>
+  <template type="amp-mustache">
+    Error! Looks like something went wrong with your comment, please try to submit it again.
+  </template>
+</div>
+[/sourcecode]
+
+Sebagai sentuhan tambahan, kami menambahkan atribut `required` untuk menerapkan kehadiran teks komentar sebelum mengirim komentar:
+
+<amp-img src="/static/img/enforce-comment.png" alt="Enforce comment" height="325" width="300"></amp-img>
+
+[sourcecode:html]
+<input type="text" class="data-input" name="text" placeholder="Your comment..." required>
+[/sourcecode]
+
+Saat menambahkan komentar dan mengklik tombol kirim, Anda kini harusnya melihat sesuatu yang serupa dengan screenshot berikut:
+
+<amp-img src="/static/img/logout-button.png" alt="Comment added" height="352" width="300"></amp-img>
+
+<div class="prev-next-buttons">
+  <a class="button prev-button" href="/id/docs/tutorials/login_requiring/login.html"><span class="arrow-prev">Sebelumnya</span></a>
+  <a class="button next-button" href="/id/docs/tutorials/login_requiring/logout.html"><span class="arrow-next">Berikutnya</span></a>
+</div>
+ 
+ 

--- a/content/docs/tutorials/login_requiring/add_comment@ja.md
+++ b/content/docs/tutorials/login_requiring/add_comment@ja.md
@@ -1,0 +1,67 @@
+---
+$title: コメントを追加する
+$order: 1
+---
+
+<amp-img src="/static/img/comment.png" alt="コメントの追加" height="325" width="300"></amp-img>
+
+ここで、ユーザーは `amp-form` ライブラリを使用してコメントを追加できます。フォームが存在するかどうかは、`amp-access` コンポーネントの状態によって決まることに注意してください。
+
+[sourcecode:html]
+<form amp-access="loggedIn" amp-access-hide method="post" action-xhr="<%host%>/samples_templates/comment_section/submit-comment-xhr" target="_top">
+[/sourcecode]
+
+AMP では XHR 以外のアクションを POST メソッドとともに使用できないため、POST メソッドと XHR アクションを指定します。
+これはデモであり、コメントを残すことを想定していないため、ここで追加できるコメントは 1 つのみです。コメントを追加するたびに、AMPByExample サーバーは、入力したテキストと、タイムスタンプとユーザーのアバターや名前などの追加情報を含む JSON レスポンスを返します。
+
+JSON レスポンスの例を次に示します。
+
+[sourcecode:json]
+{"Datetime":"09:34:21",
+"User":"Charlie",
+"Text":"Hello!",
+"UserImg":"/img/ic_account_box_black_48dp_1x.png"}
+[/sourcecode]
+
+フォーム コンポーネントは、[amp-mustache](https://www.ampproject.org/ja/docs/reference/components/amp-mustache) テンプレートを使用して、ページ内に値を表示します。
+
+[sourcecode:html]
+<div submit-success>
+  <template type="amp-mustache">
+    <div class="comment-user">
+      <amp-img width="44" class="user-avatar" height="44" alt="user" src="{{UserImg}}"></amp-img>
+      <div class="card comment">
+         <p><span class="user">{% raw %}{{User}}{% endraw %}</span><span class="date">{% raw %}{{Datetime}}{% endraw %}</span></p>
+        <p>{% raw %}{{Text}}{% endraw %}</p>
+      </div>
+    </div>
+  </template>
+</div>
+[/sourcecode]
+
+この例では、コメントの値が空でないことのみをチェックしています。値が空の場合は、エラーが返されて次のコードが実行されます。
+
+[sourcecode:html]
+<div submit-error>
+  <template type="amp-mustache">
+    Error! Looks like something went wrong with your comment, please try to submit it again.
+  </template>
+</div>
+[/sourcecode]
+
+さらに念のため、テキストを入力しないとコメントを送信できないように `required` 属性を追加します。
+
+<amp-img src="/static/img/enforce-comment.png" alt="コメント入力の強制" height="325" width="300"></amp-img>
+
+[sourcecode:html]
+<input type="text" class="data-input" name="text" placeholder="Your comment..." required>
+[/sourcecode]
+
+コメントを追加して送信ボタンをクリックすると、次のスクリーンショットのような画面が表示されます。
+
+<amp-img src="/static/img/logout-button.png" alt="コメントが追加されました" height="352" width="300"></amp-img>
+
+<div class="prev-next-buttons">
+  <a class="button prev-button" href="/ja/docs/tutorials/login_requiring/login.html"><span class="arrow-prev">前へ</span></a>
+  <a class="button next-button" href="/ja/docs/tutorials/login_requiring/logout.html"><span class="arrow-next">次へ</span></a>
+</div>

--- a/content/docs/tutorials/login_requiring/add_comment@pt_BR.md
+++ b/content/docs/tutorials/login_requiring/add_comment@pt_BR.md
@@ -1,0 +1,67 @@
+---
+$title: Adicionar um comentário
+$order: 1
+---
+
+<amp-img src="/static/img/comment.png" alt="Adicionar comentário" height="325" width="300"></amp-img>
+
+Nesse momento, o usuário pode adicionar um comentário usando a biblioteca `amp-form`. A presença do formulário é condicional. Ela depende do estado do componente `amp-access`:
+
+[sourcecode:html]
+<form amp-access="loggedIn" amp-access-hide method="post" action-xhr="<%host%>/samples_templates/comment_section/submit-comment-xhr" target="_top">
+[/sourcecode]
+
+Especificamos um método POST e uma ação XHR, porque as AMP não permitem ações que não sejam XHR com métodos POST.
+Como esta é apenas uma demonstração, só é possível adicionar um comentário no momento. Sempre que um comentário for adicionado, o servidor AMPByExample enviará uma resposta JSON com o texto inserido e algumas adições, como o carimbo de data/hora, o avatar e o nome do usuário.
+
+Veja um exemplo de resposta JSON:
+
+[sourcecode:json]
+{"Datetime":"09:34:21",
+"User":"Charlie",
+"Text":"Hello!",
+"UserImg":"/img/ic_account_box_black_48dp_1x.png"}
+[/sourcecode]
+
+O componente do formulário exibirá esses valores dentro da página usando o modelo [amp-mustache](https://www.ampproject.org/pt_br/docs/reference/components/amp-mustache):
+
+[sourcecode:html]
+<div submit-success>
+  <template type="amp-mustache">
+    <div class="comment-user">
+      <amp-img width="44" class="user-avatar" height="44" alt="user" src="{{UserImg}}"></amp-img>
+      <div class="card comment">
+        <p><span class="user">{% raw %}{{User}}{% endraw %}</span><span class="date">{% raw %}{{Datetime}}{% endraw %}</span></p>
+        <p>{% raw %}{{Text}}{% endraw %}</p>
+      </div>
+    </div>
+  </template>
+</div>
+[/sourcecode]
+
+Neste exemplo, apenas verificamos se o valor do comentário não está vazio. Caso esteja, retornaremos um erro que fará com que o seguinte código seja executado:
+
+[sourcecode:html]
+<div submit-error>
+  <template type="amp-mustache">
+    Error! Looks like something went wrong with your comment, please try to submit it again.
+  </template>
+</div>
+[/sourcecode]
+
+Além disso, adicionamos o atributo `required` para exigir que o comentário tenha algum texto antes do envio:
+
+<amp-img src="/static/img/enforce-comment.png" alt="Enforce comment" height="325" width="300"></amp-img>
+
+[sourcecode:html]
+<input type="text" class="data-input" name="text" placeholder="Seu comentário…" required>
+[/sourcecode]
+
+Após inserir um comentário e clicar no botão para enviá-lo, você verá algo semelhante à seguinte captura de tela:
+
+<amp-img src="/static/img/logout-button.png" alt="Comment added" height="352" width="300"></amp-img>
+
+<div class="prev-next-buttons">
+  <a class="button prev-button" href="/pt_br/docs/tutorials/login_requiring/login.html"><span class="arrow-prev">Anterior</span></a>
+  <a class="button next-button" href="/pt_br/docs/tutorials/login_requiring/logout.html"><span class="arrow-next">Próxima</span></a>
+</div>

--- a/content/docs/tutorials/login_requiring/add_comment@zh_CN.md
+++ b/content/docs/tutorials/login_requiring/add_comment@zh_CN.md
@@ -1,0 +1,67 @@
+---
+$title: 添加评论
+$order: 1
+---
+
+<amp-img src="/static/img/comment.png" alt="Add comment" height="325" width="300"></amp-img>
+
+此时，用户可以使用 `amp-form` 库添加评论。请注意，相应表单能否被显示出来是有条件的（取决于 `amp-access` 组件的状态）：
+
+[sourcecode:html]
+<form amp-access="loggedIn" amp-access-hide method="post" action-xhr="<%host%>/samples_templates/comment_section/submit-comment-xhr" target="_top">
+[/sourcecode]
+
+由于 AMP 网页中不允许使用 POST 方法执行任何非 XHR 操作，因此我们指定了一种 POST 方法和一项 XHR 操作。
+鉴于这是一次演示，我们不会只介绍评论，所以目前只能添加一条评论；一旦有人添加了评论，AMPByExample 服务器就会用包含所输入文字及一些添加项（如时间戳、用户头像和姓名）的 JSON 响应进行回复。
+
+下面是一个 JSON 响应示例：
+
+[sourcecode:json]
+{"Datetime":"09:34:21",
+"User":"Charlie",
+"Text":"Hello!",
+"UserImg":"/img/ic_account_box_black_48dp_1x.png"}
+[/sourcecode]
+
+表单组件会通过使用 [amp-mustache](https://www.ampproject.org/zh_cn/docs/reference/components/amp-mustache) 模板来仅将上述值显示在该网页内：
+
+[sourcecode:html]
+<div submit-success>
+  <template type="amp-mustache">
+    <div class="comment-user">
+      <amp-img width="44" class="user-avatar" height="44" alt="user" src="{{UserImg}}"></amp-img>
+      <div class="card comment">
+        <p><span class="user">{% raw %}{{User}}{% endraw %}</span><span class="date">{% raw %}{{Datetime}}{% endraw %}</span></p>
+        <p>{% raw %}{{Text}}{% endraw %}</p>
+      </div>
+    </div>
+  </template>
+</div>
+[/sourcecode]
+
+在此示例中，我们只检查评论的值是否不为空；如果评论的值为空，我们就会返回一个错误，而该错误会导致系统执行以下代码
+
+[sourcecode:html]
+<div submit-error>
+  <template type="amp-mustache">
+    Error! Looks like something went wrong with your comment, please try to submit it again.
+  </template>
+</div>
+[/sourcecode]
+
+我们添加了 `required` 属性作为补充，以便在提交评论之前强制显示评论文字：
+
+<amp-img src="/static/img/enforce-comment.png" alt="Enforce comment" height="325" width="300"></amp-img>
+
+[sourcecode:html]
+<input type="text" class="data-input" name="text" placeholder="Your comment..." required>
+[/sourcecode]
+
+如果您添加评论并点击“提交”按钮，那么您现在应该能看到与以下屏幕截图相似的内容：
+
+<amp-img src="/static/img/logout-button.png" alt="Comment added" height="352" width="300"></amp-img>
+
+<div class="prev-next-buttons">
+  <a class="button prev-button" href="/zh_cn/docs/tutorials/login_requiring/login.html"><span class="arrow-prev">上一页</span></a>
+  <a class="button next-button" href="/zh_cn/docs/tutorials/login_requiring/logout.html"><span class="arrow-next">下一页</span></a>
+</div>

--- a/content/support/faqs/supported-browser@id.md
+++ b/content/support/faqs/supported-browser@id.md
@@ -1,0 +1,31 @@
+---
+$title@: Browser yang Didukung
+$order: 4
+$parent: /content/support/faqs.md
+class: who
+
+cta:
+  title@: FAQ Selanjutnya
+  link_text@: Ringkasan AMP
+  link_url: /content/support/faqs/overview@id.md
+
+---
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+Pada umumnya, kami mendukung 2 versi terbaru browser besar seperti Chrome, Firefox, Edge, Safari, dan Opera. Kami mendukung versi tampilan desktop, ponsel, tablet, dan web dari masing-masing browser ini.
+
+Lebih dari itu, koleksi AMP inti serta elemen bawaan harus bertujuan untuk mencapai dukungan browser yang sangat luas, dan kami menerima perbaikan bagi semua browser dengan pangsa pasar yang lebih besar dari 1 persen.
+
+Secara khusus, kami mencoba mempertahankan dukungan "sepertinya tidak sempurna, tapi masih dapat digunakan" untuk browser sistem Android 4.0 dan Chrome 28+ di ponsel.

--- a/content/support/faqs/supported-browser@ja.md
+++ b/content/support/faqs/supported-browser@ja.md
@@ -1,0 +1,31 @@
+---
+$title@: 対応ブラウザ
+$order: 4
+$parent: /content/support/faqs.md
+class: who
+
+cta:
+  title@: 次のよくある質問
+  link_text@: AMP の概要
+  link_url: /content/support/faqs/overview@ja.md
+
+---
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+AMP は通常、Chrome、Firefox、Edge、Safari、Opera といった主要ブラウザの最新バージョンとその 1 つ前のバージョンをサポートしており、パソコン、スマートフォン、タブレット、各種ブラウザのウェブビュー版に対応しています。
+
+また、さまざまなブラウザで主要な AMP ライブラリと組み込み要素を利用できるよう、市場シェアが 1% を超えるブラウザについては、それぞれに応じた修正を行います。
+
+スマートフォンに搭載されている Android 4.0 システム ブラウザと Chrome 28 以降については、「完璧ではないが破損もしていない」という状態でのサポートを維持するよう努めています。

--- a/content/support/faqs/supported-browser@pt_BR.md
+++ b/content/support/faqs/supported-browser@pt_BR.md
@@ -1,0 +1,31 @@
+---
+$title@: Navegadores compatíveis
+$order: 4
+$parent: /content/support/faqs@pt_br.md
+classe: quem
+
+cta:
+  title@: Próximas Perguntas frequentes
+  link_text@: Visão geral de AMP
+  link_url: /content/support/faqs/overview@pt_br.md
+
+---
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+Em geral, oferecemos compatibilidade com as duas versões mais recentes dos principais navegadores como Chrome, Firefox, Edge, Safari e Opera. As versões para tablet, smartphone, computadores desktop e visualização da Web desses navegadores também são compatíveis com AMP.
+
+Além disso, o ideal é que os elementos integrados e a biblioteca AMP principal tenham compatibilidade com uma grande variedade de navegadores. Aceitamos correções de todos os navegadores com participação no mercado maior do que 1%.
+
+Para o navegador do sistema Android 4.0 e o Chrome versão 28 e posteriores em smartphones, nosso suporte tenta seguir a abordagem "pode não ser perfeito, mas está funcionando".

--- a/content/support/faqs/supported-browser@zh_CN.md
+++ b/content/support/faqs/supported-browser@zh_CN.md
@@ -1,0 +1,31 @@
+---
+$title@: 支持的浏览器
+$order: 4
+$parent: /content/support/faqs.md
+class: who
+
+cta:
+  title@: 下一个常见问题解答
+  link_text@: AMP 概览
+  link_url: /content/support/faqs/overview@zh_cn.md
+
+---
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+一般来说，我们支持 Chrome、Firefox、Edge、Safari 和 Opera 等主流浏览器的最新的两个版本。我们分别支持这些浏览器的桌面设备版本、手机版本、平板电脑版本和网页视图版本。
+
+除此之外，由于 AMP 核心库和内置元素的目标应该是实现非常广泛的浏览器支持，因此我们接受市场份额大于 1% 的所有浏览器的修复程序。
+
+需要特别说明的是，我们会继续努力为手机上的 Android 4.0 系统浏览器和 Chrome 28+ 提供“虽尚不完美，但还算稳定”的支持。

--- a/content/support/faqs/supported-platforms@id.md
+++ b/content/support/faqs/supported-platforms@id.md
@@ -1,15 +1,15 @@
 ---
-$title: Plataformas, proveedores y socios
+$title@: Platform, Vendor, dan Partner yang Didukung
 $order: 3
 $parent: /content/support/faqs.md
 class: who
 
-description: El proyecto Accelerated Mobile Pages (AMP) es una iniciativa de código abierto que facilita a los editores crear contenido para móviles una vez y que se cargue instantáneamente en todas partes. – Accelerated Mobile Pages Project
+description@: Proyek Accelerated Mobile Pages (AMP) adalah inisiatif open source yang mempermudah penayang untuk membuat konten mobile-friendly dan dapat dimuat dengan cepat di mana saja. – Proyek Accelerated Mobile Pages
 
 cta:
-  title: Próximo FAQ
-  link_text: AMP Overview
-  link_url: /content/support/faqs/overview@es.md
+  title@: FAQ Berikutnya
+  link_text@: Ringkasan AMP
+  link_url: /content/support/faqs/overview@id.md
 
 ---
 {% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
@@ -22,7 +22,7 @@ cta:
   </ul>
 </div>
 
-Un número creciente de plataformas, proveedores y socios soportan el proyecto AMP al proporcionar componentes personalizados o ofrecer integración con páginas AMP dentro de sus plataformas.
+Semakin banyak platform, vendor, dan partner mendukung Proyek AMP dengan menyediakan komponen kustom atau menawarkan integrasi dengan halaman AMP dalam platform mereka.
 
 <div class="who-container">
   <amp-accordion disable-session-states>

--- a/content/support/faqs/supported-platforms@ja.md
+++ b/content/support/faqs/supported-platforms@ja.md
@@ -1,15 +1,15 @@
 ---
-$title: Plataformas, proveedores y socios
+$title@: AMP を支持するプラットフォーム、ベンダー、パートナー
 $order: 3
 $parent: /content/support/faqs.md
 class: who
 
-description: El proyecto Accelerated Mobile Pages (AMP) es una iniciativa de código abierto que facilita a los editores crear contenido para móviles una vez y que se cargue instantáneamente en todas partes. – Accelerated Mobile Pages Project
+description@: AMP（Accelerated Mobile Pages）は、どこにいても瞬時に読み込まれるモバイル フレンドリーなコンテンツを簡単に作成できるようにするためのオープンソース プロジェクトです。- Accelerated Mobile Pages プロジェクト
 
 cta:
-  title: Próximo FAQ
-  link_text: AMP Overview
-  link_url: /content/support/faqs/overview@es.md
+  title@: 次のよくある質問
+  link_text@: AMP の概要
+  link_url: /content/support/faqs/overview@ja.md
 
 ---
 {% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
@@ -22,7 +22,7 @@ cta:
   </ul>
 </div>
 
-Un número creciente de plataformas, proveedores y socios soportan el proyecto AMP al proporcionar componentes personalizados o ofrecer integración con páginas AMP dentro de sus plataformas.
+カスタム コンポーネントの提供や AMP ページのプラットフォームへの統合などを通じて AMP プロジェクトをサポートするプラットフォーム、ベンダー、パートナーの数は増え続けています。
 
 <div class="who-container">
   <amp-accordion disable-session-states>

--- a/content/support/faqs/supported-platforms@ko.md
+++ b/content/support/faqs/supported-platforms@ko.md
@@ -9,7 +9,7 @@ description: AMP (Accelerated Mobile Pages) 프로젝트는 게시자가 모바�
 cta:
   title: 다음 FAQ
   link_text: AMP 살펴보기
-  link_url: /content/support/faqs/overview.md
+  link_url: /content/support/faqs/overview@ko.md
 
 ---
 {% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}

--- a/content/support/faqs/supported-platforms@pt_BR.md
+++ b/content/support/faqs/supported-platforms@pt_BR.md
@@ -1,15 +1,15 @@
 ---
-$title: Plataformas, proveedores y socios
+$title@: Plataformas, fornecedores e parceiros compatíveis
 $order: 3
-$parent: /content/support/faqs.md
+$parent: /content/support/faqs@pt_br.md
 class: who
 
-description: El proyecto Accelerated Mobile Pages (AMP) es una iniciativa de código abierto que facilita a los editores crear contenido para móviles una vez y que se cargue instantáneamente en todas partes. – Accelerated Mobile Pages Project
+description@: O projeto Accelerated Mobile Pages (AMP) é uma iniciativa de código aberto que facilita a criação de conteúdo otimizado para dispositivos móveis. Com ele, os editores podem criar conteúdo uma vez só e carregar esse material de maneira instantânea em qualquer lugar. – Projeto Accelerated Mobile Pages
 
 cta:
-  title: Próximo FAQ
-  link_text: AMP Overview
-  link_url: /content/support/faqs/overview@es.md
+  title@: Próximas Perguntas frequentes
+  link_text@: Visão geral de AMP
+  link_url: /content/support/faqs/overview@pt_br.md
 
 ---
 {% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
@@ -22,7 +22,7 @@ cta:
   </ul>
 </div>
 
-Un número creciente de plataformas, proveedores y socios soportan el proyecto AMP al proporcionar componentes personalizados o ofrecer integración con páginas AMP dentro de sus plataformas.
+Um número cada vez maior de plataformas, fornecedores e parceiros oferece compatibilidade com o projeto AMP por meio de componentes personalizados ou integração de páginas AMP em plataformas.
 
 <div class="who-container">
   <amp-accordion disable-session-states>

--- a/content/support/faqs/supported-platforms@zh_CN.md
+++ b/content/support/faqs/supported-platforms@zh_CN.md
@@ -1,15 +1,15 @@
 ---
-$title: Plataformas, proveedores y socios
+$title@: 支持的平台、供应商和合作伙伴
 $order: 3
 $parent: /content/support/faqs.md
 class: who
 
-description: El proyecto Accelerated Mobile Pages (AMP) es una iniciativa de código abierto que facilita a los editores crear contenido para móviles una vez y que se cargue instantáneamente en todas partes. – Accelerated Mobile Pages Project
+description@: Accelerated Mobile Pages (AMP) 项目是一项开放源代码计划，旨在让发布商轻松做到：只需创建一次适合在移动设备上浏览的内容，即可使这些内容在各种设备上都能瞬间完成加载 - Accelerated Mobile Pages 项目
 
 cta:
-  title: Próximo FAQ
-  link_text: AMP Overview
-  link_url: /content/support/faqs/overview@es.md
+  title@: 下一个常见问题解答
+  link_text@: AMP 概览
+  link_url: /content/support/faqs/overview@zh_cn.md
 
 ---
 {% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
@@ -22,7 +22,7 @@ cta:
   </ul>
 </div>
 
-Un número creciente de plataformas, proveedores y socios soportan el proyecto AMP al proporcionar componentes personalizados o ofrecer integración con páginas AMP dentro de sus plataformas.
+越来越多的平台、供应商和合作伙伴通过在各自的平台内提供自定义组件或集成 AMP 网页功能来支持 AMP 项目。
 
 <div class="who-container">
   <amp-accordion disable-session-states>


### PR DESCRIPTION
Updated the following articles:
1) add_comments.md (i.e., creating a login-requiring AMP page, step 2) (es, id, ja, pt_BR, zh_CN)
- Replacing the (es) version with the updated one.

2) supported-browser.md (id, ja, pt_BR, zh_CN)

3) supported-platforms.md (es, id, ja, ko, pt_BR, zh_CN)
- Replacing the (es) and (ko) version with the updated one. 
