### PR TITLE
Add example snippets for amp-fit-text

### DIFF
--- a/examples/src/ampfittext.html
+++ b/examples/src/ampfittext.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<!-- examples for https://www.ampproject.org/docs/guides/third_party_components-->
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="ampfittext.html" />
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body {
+      font-family: 'Questrial', Arial;
+      margin: 0 auto 0 auto;
+    }
+    div.fixedblock {
+      margin: 8px auto;
+      height: 300px;
+      width: 300px;
+      background-color: #c5e6ff;
+    }
+  </style>
+</head>
+<body>
+  <!-- base -->
+  <div class="fixedblock">
+    <amp-fit-text width="200" height="200" layout="flex_item">
+      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque
+      inermis reprehendunt. 
+    </amp-fit-text>
+  </div>
+  <!-- max-font -->
+  <div class="fixedblock">
+    <amp-fit-text width="200" height="200" layout="responsive"
+        max-font-size="22">
+      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque
+      inermis reprehendunt.
+    </amp-fit-text>
+  </div>
+  <!-- min-font -->
+  <div class="fixedblock">
+    <amp-fit-text width="200" height="200" layout="responsive"
+        min-font-size="40">
+      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque
+      inermis reprehendunt.
+    </amp-fit-text>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Adding embedded demo code for amp-fit-text.  Docs for amp-fit-text will be updated once these examples are up in production.