### PR TITLE
Add mediarithmics entry in analytics-vendors

### DIFF
--- a/content/docs/guides/analytics_amp/analytics-vendors.md
+++ b/content/docs/guides/analytics_amp/analytics-vendors.md
@@ -159,6 +159,12 @@ Type attribute value: `mediametrie`
 
 Adds support for Médiamétrie tracking pages. Requires defining *var* `serial`. Vars `level1` to `level4` are optional.  More information can be found at [mediametrie.com](http://www.mediametrie.com/).
 
+### mediarithmics
+
+Type attribute value: `mediarithmics`
+
+Adds support for mediarithmics. More information and configuration details can be found at [developer.mediarithmics.com](https://developer.mediarithmics.com/).
+
 ### mParticle
 
 Type attribute value: `mparticle`


### PR DESCRIPTION
As mediarithmics was added as a Vendor yesterday (cf: https://github.com/ampproject/amphtml/pull/11472), I updated the analytics-vendors doc as requested.