### PR TITLE
Remove hamburger menu random gray box

### DIFF
--- a/assets/sass/_header.scss
+++ b/assets/sass/_header.scss
@@ -128,11 +128,12 @@
     }
   }
 
-  .tab {
+  div.tab {
     padding: 6px 20px;
 
     &::before {
       bottom: 0;
+      box-shadow: $header-shadow;
       content: '';
       left: -10px;
       opacity: 0;

--- a/assets/sass/_header.scss
+++ b/assets/sass/_header.scss
@@ -133,7 +133,6 @@
 
     &::before {
       bottom: 0;
-      box-shadow: $header-shadow;
       content: '';
       left: -10px;
       opacity: 0;


### PR DESCRIPTION
Remove box-shadow so that mysterious gray box won't appear on hamburger menu hover.

I don't believe this rule applies anywhere else on the site.  I did look around!


Fixes: https://github.com/ampproject/docs/issues/472