### PR TITLE
Added translations for ID, JA, PT_BR, ZH_CN for supported-browsers.md

### DIFF
--- a/content/support/faqs/supported-browsers@id.md
+++ b/content/support/faqs/supported-browsers@id.md
@@ -1,0 +1,31 @@
+---
+$title@: Browser yang Didukung
+$order: 4
+$parent: /content/support/faqs.md
+class: who
+
+cta:
+  title@: FAQ Selanjutnya
+  link_text@: Ringkasan AMP
+  link_url: /content/support/faqs/overview@id.md
+
+---
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+Pada umumnya, kami mendukung 2 versi terbaru browser besar seperti Chrome, Firefox, Edge, Safari, dan Opera. Kami mendukung versi tampilan desktop, ponsel, tablet, dan web dari masing-masing browser ini.
+
+Lebih dari itu, koleksi AMP inti serta elemen bawaan harus bertujuan untuk mencapai dukungan browser yang sangat luas, dan kami menerima perbaikan bagi semua browser dengan pangsa pasar yang lebih besar dari 1 persen.
+
+Secara khusus, kami mencoba mempertahankan dukungan "sepertinya tidak sempurna, tapi masih dapat digunakan" untuk browser sistem Android 4.0 dan Chrome 28+ di ponsel.

--- a/content/support/faqs/supported-browsers@ja.md
+++ b/content/support/faqs/supported-browsers@ja.md
@@ -1,0 +1,31 @@
+---
+$title@: 対応ブラウザ
+$order: 4
+$parent: /content/support/faqs.md
+class: who
+
+cta:
+  title@: 次のよくある質問
+  link_text@: AMP の概要
+  link_url: /content/support/faqs/overview@ja.md
+
+---
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+AMP は通常、Chrome、Firefox、Edge、Safari、Opera といった主要ブラウザの最新バージョンとその 1 つ前のバージョンをサポートしており、パソコン、スマートフォン、タブレット、各種ブラウザのウェブビュー版に対応しています。
+
+また、さまざまなブラウザで主要な AMP ライブラリと組み込み要素を利用できるよう、市場シェアが 1% を超えるブラウザについては、それぞれに応じた修正を行います。
+
+スマートフォンに搭載されている Android 4.0 システム ブラウザと Chrome 28 以降については、「完璧ではないが破損もしていない」という状態でのサポートを維持するよう努めています。

--- a/content/support/faqs/supported-browsers@pt_BR.md
+++ b/content/support/faqs/supported-browsers@pt_BR.md
@@ -1,0 +1,31 @@
+---
+$title@: Navegadores compatíveis
+$order: 4
+$parent: /content/support/faqs@pt_br.md
+classe: quem
+
+cta:
+  title@: Próximas Perguntas frequentes
+  link_text@: Visão geral de AMP
+  link_url: /content/support/faqs/overview@pt_br.md
+
+---
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+Em geral, oferecemos compatibilidade com as duas versões mais recentes dos principais navegadores como Chrome, Firefox, Edge, Safari e Opera. As versões para tablet, smartphone, computadores desktop e visualização da Web desses navegadores também são compatíveis com AMP.
+
+Além disso, o ideal é que os elementos integrados e a biblioteca AMP principal tenham compatibilidade com uma grande variedade de navegadores. Aceitamos correções de todos os navegadores com participação no mercado maior do que 1%.
+
+Para o navegador do sistema Android 4.0 e o Chrome versão 28 e posteriores em smartphones, nosso suporte tenta seguir a abordagem "pode não ser perfeito, mas está funcionando".

--- a/content/support/faqs/supported-browsers@zh_CN.md
+++ b/content/support/faqs/supported-browsers@zh_CN.md
@@ -1,0 +1,31 @@
+---
+$title@: 支持的浏览器
+$order: 4
+$parent: /content/support/faqs.md
+class: who
+
+cta:
+  title@: 下一个常见问题解答
+  link_text@: AMP 概览
+  link_url: /content/support/faqs/overview@zh_cn.md
+
+---
+{% set who = g.doc('/content/includes/who.yaml', locale=doc.locale) %}
+
+<div class="browser-container">
+{% for browser in who.browsers %}
+  <div class="browser">
+    <amp-img width="75"
+        height="75"
+        layout="responsive"
+        src="{{browser.img}}"></amp-img>
+    <p class="browser-title">{{browser.title}}</p>
+  </div>
+{% endfor %}
+</div>
+
+一般来说，我们支持 Chrome、Firefox、Edge、Safari 和 Opera 等主流浏览器的最新的两个版本。我们分别支持这些浏览器的桌面设备版本、手机版本、平板电脑版本和网页视图版本。
+
+除此之外，由于 AMP 核心库和内置元素的目标应该是实现非常广泛的浏览器支持，因此我们接受市场份额大于 1% 的所有浏览器的修复程序。
+
+需要特别说明的是，我们会继续努力为手机上的 Android 4.0 系统浏览器和 Chrome 28+ 提供“虽尚不完美，但还算稳定”的支持。


### PR DESCRIPTION
Continuation of https://github.com/ampproject/docs/pull/719#pullrequestreview-69052258

Made changes to the id, ja, pt_BR, zh_CN translations to change the file names from "supported-browser" to "supported_browsers" (with an added "s" at the end).
