### PR TITLE
Import the AMP Events & Actions doc into site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ assets/css/*
 content/includes/who.yaml
 content/docs/contribute/governance.md
 content/learn/design-principles.md
+content/docs/reference/amp-actions-and-events.md
 content/docs/reference/spec.md
 content/docs/reference/spec/*.md
 content/docs/reference/components/**/*.md

--- a/scripts/import_docs.json
+++ b/scripts/import_docs.json
@@ -24,6 +24,12 @@
         "to": "docs/reference/spec/amp-html-layout.md"
     },
     {
+        "title": "Actions and events in AMP",
+        "order": 8,
+        "from": "spec/amp-actions-and-events.md",
+        "to": "docs/reference/amp-actions-and-events.md"
+    },
+    {
         "title": "Debug AMP Cache issues",
         "order": 1,
         "from": "spec/amp-cache-debugging.md",


### PR DESCRIPTION
Import the [Actions and Events in AMP](https://github.com/ampproject/amphtml/blob/master/spec/amp-actions-and-events.md) doc into site.

Cleaning up doc in: https://github.com/ampproject/amphtml/pull/11919