### PR TITLE
Add 404.html to content root by overriding blueprint configuration (Issue #258)

### DIFF
--- a/content/pages/404.html
+++ b/content/pages/404.html
@@ -1,4 +1,5 @@
 ---
+$path: /404.html
 $title: Page not Found (404)
 class: 404
 stylesheet: pages/404.css


### PR DESCRIPTION
This adds a 404.html to the root of the content directory by overriding the rule in content/pages/_blueprint.yaml : Firebase requires /404.html in the content root; previous rule results in a /404/ directory being created.