### PR TITLE
Fix lang switcher click target and shifting

### DIFF
--- a/assets/sass/_lang_switcher.scss
+++ b/assets/sass/_lang_switcher.scss
@@ -25,6 +25,21 @@
     }
   }
 
+  h6 {
+    color: $color-black-95;
+    display: inline-block;
+    overflow: hidden;
+    padding: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: normal;
+    text-transform: uppercase;
+
+    span {
+      padding-right: 6px;
+    }
+  }
+
   .current {
     font-size: 1em;
     margin-right: 100px;

--- a/content/pages/404.html
+++ b/content/pages/404.html
@@ -4,9 +4,6 @@ $title: Page not Found (404)
 class: 404
 stylesheet: pages/404.css
 
-$localization:
-    locales:
-    - en
 ---
 
 <section class="fourofour">

--- a/content/pages/amp-conf.html
+++ b/content/pages/amp-conf.html
@@ -5,9 +5,6 @@ class: amp-conf
 
 stylesheet: pages/amp-conf-2018.css
 
-$localization:
-    locales:
-    - en
 ---
 
 <section class="teaser amp-conf-section">

--- a/views/partials/lang_switcher.html
+++ b/views/partials/lang_switcher.html
@@ -1,9 +1,7 @@
 <div class="language desktop">
   <amp-accordion disable-session-states>
     <section>
-      <h6 class="current">
-        <a class="flag-{{ doc.locale }}"><span>{{ doc.locale.get_language_name() }}</span></a>
-      </h6>
+      <h6 class="current flag-{{ doc.locale }}"><span>{{ doc.locale.get_language_name() }}</span></h6>
       <div class="others">
         <div class="others-inner">
           {% for locale in doc.locales if not locale == doc.locale  %}


### PR DESCRIPTION
Fixes #764 including:
- When click on text or any area in h6, lang switcher expands
- For AMP Conf page and 404 page where there was no localized langs the lang switcher shifted;


Intended behavior: cannot collapse lang-switcher if click off it. As we are using an accordion, and it's not an actual drop-down.