### PR TITLE
Fix order of topics in tutorial

### DIFF
--- a/content/docs/tutorials/add_advanced/adding_carousels.md
+++ b/content/docs/tutorials/add_advanced/adding_carousels.md
@@ -1,6 +1,6 @@
 ---
 $title: Adding carousels
-$order: 2
+$order: 3
 toc: true
 ---
 

--- a/content/docs/tutorials/add_advanced/adding_carousels@es.md
+++ b/content/docs/tutorials/add_advanced/adding_carousels@es.md
@@ -1,7 +1,5 @@
 ---
 $title: Agregar carruseles
-$order: 2
-toc: true
 ---
 
 [TOC]

--- a/content/docs/tutorials/add_advanced/adding_components@es.md
+++ b/content/docs/tutorials/add_advanced/adding_components@es.md
@@ -1,7 +1,5 @@
 ---
 $title: Agregando componentes AMP ampliados
-$order: 2
-toc: true
 ---
 
 [TOC]

--- a/content/docs/tutorials/add_advanced/congratulations.md
+++ b/content/docs/tutorials/add_advanced/congratulations.md
@@ -1,6 +1,6 @@
 ---
 $title: Congratulations!
-$order: 6
+$order: 7
 ---
 
 You’ve finished the "Add advanced AMP features" tutorial and successfully explored many key advanced components of AMP!

--- a/content/docs/tutorials/add_advanced/congratulations@es.md
+++ b/content/docs/tutorials/add_advanced/congratulations@es.md
@@ -1,6 +1,5 @@
 ---
 $title: ¡Felicitaciones!
-$order: 6
 ---
 
 Ha terminado el tutorial "Añadir características avanzadas de AMP" y ha explorado con éxito muchos componentes avanzados clave de AMP.

--- a/content/docs/tutorials/add_advanced/fonts.md
+++ b/content/docs/tutorials/add_advanced/fonts.md
@@ -1,6 +1,6 @@
 ---
 $title: Adding fonts
-$order: 5
+$order: 6
 ---
 
 In AMP, to keep the load times of documents as fast as possible, you cannot include external stylesheets. However, there is one exception to this rule&mdash;**fonts**.  

--- a/content/docs/tutorials/add_advanced/fonts@es.md
+++ b/content/docs/tutorials/add_advanced/fonts@es.md
@@ -1,6 +1,5 @@
 ---
 $title: Agregando fuentes
-$order: 5
 ---
 
 En AMP, para mantener los tiempos de carga de documentos lo más rápido posible, no puede incluir hojas de estilo externas. Sin embargo, hay una excepción a esta regla &mdash; **fuentes**.

--- a/content/docs/tutorials/add_advanced/navigating.md
+++ b/content/docs/tutorials/add_advanced/navigating.md
@@ -1,6 +1,6 @@
 ---
 $title: Navigating your site 
-$order: 4
+$order: 5
 toc: true
 ---
 

--- a/content/docs/tutorials/add_advanced/navigating@es.md
+++ b/content/docs/tutorials/add_advanced/navigating@es.md
@@ -1,7 +1,5 @@
 ---
 $title: Navegando por su sitio
-$order: 4
-toc: true
 ---
 
 [TOC]

--- a/content/docs/tutorials/add_advanced/review_code@es.md
+++ b/content/docs/tutorials/add_advanced/review_code@es.md
@@ -1,6 +1,5 @@
 ---
 $title: Revisar el código de inicio
-$order: 1
 ---
 
 Antes de comenzar a agregar código, revisemos la página [article.amp.html](https://github.com/googlecodelabs/accelerated-mobile-pages-advanced/blob/master/article.amp.html) de ejemplo, que debería ser la siguiente:

--- a/content/docs/tutorials/add_advanced/setting_up@es.md
+++ b/content/docs/tutorials/add_advanced/setting_up@es.md
@@ -1,7 +1,5 @@
 ---
 $title: Configuración
-$order: 0
-$parent: /content/docs/tutorials/add_advanced.md
 ---
 
 ## Requisitos Previos

--- a/content/docs/tutorials/add_advanced/tracking_data.md
+++ b/content/docs/tutorials/add_advanced/tracking_data.md
@@ -1,6 +1,6 @@
 ---
 $title: Tracking engagement with analytics
-$order: 3
+$order: 4
 ---
 
 Analytics platforms are commonly integrated into websites through inline JavaScript snippets and function calls, which trigger events that are sent back to the analytics system. AMP provides a flexible JSON configuration syntax to replicate this process for several analytics partners.

--- a/content/docs/tutorials/add_advanced/tracking_data@es.md
+++ b/content/docs/tutorials/add_advanced/tracking_data@es.md
@@ -1,6 +1,5 @@
 ---
 $title: Seguimiento del compromiso con analíticas
-$order: 3
 ---
 
 Las plataformas de Google Analytics se integran comúnmente en sitios web a través de fragmentos JavaScript en línea y llamadas de función, que activan eventos que se envían al sistema analítico. AMP proporciona una sintaxis de configuración flexible de JSON para replicar este proceso para varios partners de análisis.


### PR DESCRIPTION
Thanks to @calebcordry - amp-fit-text script should be added before component used; turns out the topics weren't in correct order, that is, "Adding carousels" should come *after* "Adding extended components".