### PR TITLE
Translations for "Enable Progressive Web App features for your AMP pages"

### DIFF
--- a/content/docs/guides/pwa-amp/amp-as-pwa@es.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@es.md
@@ -1,0 +1,121 @@
+---
+$title: Habilitar las funciones de las aplicaciones web progresivas en páginas AMP
+$order: 0
+toc: true
+---
+
+[TOC]
+
+{{ image('/static/img/docs/pwamp_add_to_homescreen.png', 848, 1500, align='right third', caption='AMPbyExample activa el mensaje "Añadir a la pantalla de inicio".') }}
+
+Muchos sitios web no necesitan más de lo que ya les ofrece AMP. [AMPbyExample](http://ampbyexample.com/), por ejemplo, es al mismo tiempo una página AMP y una aplicación web progresiva (PWA):
+
+1. Dispone de un [archivo de manifiesto de aplicación web](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/), que genera el mensaje "Añadir a la pantalla de inicio".
+2. Cuenta con un [componente service worker](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers) y, por tanto, permite que se acceda a ella sin conexión, entre otras cosas.
+
+Cuando un usuario visita [AMPbyExample](http://ampbyexample.com/) desde una plataforma compatible con AMP y después sigue desplazándose por el sitio web, sale de la caché de AMP y pasa al origen. El sitio web sigue usando la biblioteca de AMP, pero al encontrarse en el origen, puede usar un componente service worker, pedir instalaciones, etc.
+
+{% call callout('Nota', type='caution') %}
+Service worker no puede interactuar con la versión de tu página almacenada en la caché de AMP. Úsalo en el resto del recorrido hasta el origen.
+{% endcall %}
+
+## Añadir un archivo de manifiesto de aplicación web
+
+Si añades un [archivo de manifiesto de aplicación web](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/) a tus páginas AMP, te aseguras de que los usuarios puedan instalar tu sitio web en la pantalla de inicio de sus dispositivos. Los archivos de manifiesto de aplicación web en AMP no tienen misterio.
+
+En primer lugar, crea el archivo de manifiesto:
+
+[sourcecode:json]
+{
+  "short_name": "ABE",
+  "name": "AMPByExample",
+  "icons": [
+    {
+      "src": "launcher-icon-1x.png",
+      "type": "image/png",
+      "sizes": "48x48"
+    },
+    {
+      "src": "launcher-icon-2x.png",
+      "type": "image/png",
+      "sizes": "96x96"
+    },
+    {
+      "src": "launcher-icon-4x.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    }
+  ],
+  "start_url": "index.html?launcher=true"
+}
+[/sourcecode]
+
+A continuación, enlázalo desde la sección `<head>` de tu página AMP:
+
+[sourcecode:html]
+<link rel="manifest" href="/manifest.json">
+[/sourcecode]
+
+{% call callout('Nota', type='success') %}
+Consulta más información sobre el [archivo de manifiesto de aplicación web en Web Fundamentals](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/).
+{% endcall %}
+
+## Instalar un componente service worker para habilitar el acceso sin conexión
+
+Un service worker es un proxy de cliente que se sitúa entre tu página y el servidor, y que puede usarse para crear fantásticas experiencias sin conexión, generar esqueletos de aplicación de carga rápida y enviar notificaciones push.
+
+{% call callout('Nota', type='note') %}
+Si es la primera vez que oyes hablar de los componentes service worker, consulta este [artículo de introducción en Web Fundamentals](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers).
+{% endcall %}
+
+Los componentes service worker tienen que estar registrados en una página concreta; de lo contrario, el navegador no los encontrará ni ejecutará. Para registrarlos, debes usar un [pequeño fragmento de JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration) o, en páginas AMP, un componente [`<amp-install-serviceworker>`](/es/docs/reference/components/amp-install-serviceworker).
+
+En este caso, introduce primero la secuencia de comandos del componente `<amp-install-serviceworker>` en la sección `<head>` de tu página:
+
+[sourcecode:html]
+<script async custom-element="amp-install-serviceworker"
+  src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>
+[/sourcecode]
+
+A continuación, añade el fragmento siguiente en algún lugar de la sección `<body>` (modifícalo para que apunte a tu service worker actual):
+
+[sourcecode:html]
+<amp-install-serviceworker
+      src="https://www.your-domain.com/serviceworker.js"
+      layout="nodisplay">
+</amp-install-serviceworker>
+[/sourcecode]
+
+Si el usuario navega hasta las páginas AMP alojadas en tu sitio web (y no hasta las almacenadas en la caché de AMP, que son las que generalmente se publican con el primer clic), el componente service worker toma el control y puede [empezar a hacer un montón de cosas interesantes](https://developers.google.com/web/fundamentals/instant-and-offline/offline-ux).
+
+## Ampliar páginas AMP con un service worker
+
+Con la técnica anterior, puedes habilitar el acceso sin conexión a tu sitio web AMP, así como ampliar tus páginas **en cuanto se publiquen desde el propio sitio web**. Puedes modificar la respuesta con el evento `fetch` del service worker y devolver la que quieras:
+
+[sourcecode:js]
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    caches.open('mysite').then(function(cache) {
+      return cache.match(event.request).then(function(response) {
+        var fetchPromise = fetch(event.request).then(function(networkResponse) {
+          cache.put(event.request, networkResponse.clone());
+          return networkResponse;
+        })
+
+        // Modifica aquí la respuesta antes de enviarla.
+        ...
+
+        return response || fetchPromise;
+      })
+    })
+  );
+});
+[/sourcecode]
+
+Esta técnica te permite modificar tu página AMP con todo tipo de funcionalidades adicionales
+que, de otra manera, no superarían la [validación de AMP](/es/docs/guides/validate.html) como, por ejemplo:
+
+* Las funciones dinámicas que necesitan código JavaScript personalizado.
+* Los componentes que están personalizados o que solo son relevantes para tu sitio web.
+ 
+ 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@es.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@es.md
@@ -1,7 +1,5 @@
 ---
 $title: Habilitar las funciones de las aplicaciones web progresivas en páginas AMP
-$order: 0
-toc: true
 ---
 
 [TOC]
@@ -68,7 +66,7 @@ Un service worker es un proxy de cliente que se sitúa entre tu página y el ser
 Si es la primera vez que oyes hablar de los componentes service worker, consulta este [artículo de introducción en Web Fundamentals](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers).
 {% endcall %}
 
-Los componentes service worker tienen que estar registrados en una página concreta; de lo contrario, el navegador no los encontrará ni ejecutará. Para registrarlos, debes usar un [pequeño fragmento de JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration) o, en páginas AMP, un componente [`<amp-install-serviceworker>`](/es/docs/reference/components/amp-install-serviceworker).
+Los componentes service worker tienen que estar registrados en una página concreta; de lo contrario, el navegador no los encontrará ni ejecutará. Para registrarlos, debes usar un [pequeño fragmento de JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration) o, en páginas AMP, un componente [`<amp-install-serviceworker>`](/es/docs/reference/components/amp-install-serviceworker.html).
 
 En este caso, introduce primero la secuencia de comandos del componente `<amp-install-serviceworker>` en la sección `<head>` de tu página:
 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@id.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@id.md
@@ -1,0 +1,121 @@
+---
+$title: Mengaktifkan fitur Progressive Web App untuk halaman AMP
+$order: 0
+toc: true
+---
+
+[TOC]
+
+{{ image('/static/img/docs/pwamp_add_to_homescreen.png', 848, 1500, align='right third', caption='AMPbyExample memicu permintaan "Tambahkan ke Layar Utama".') }}
+
+Banyak situs yang tidak akan memerlukan apa pun di luar batas AMP. [AMPbyExample](http://ampbyexample.com/), misalnya, yang merupakan AMP sekaligus Progressive Web App:
+
+1. AMPbyExample memiliki [Manifes Aplikasi Web](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/), yang meminta banner “Tambahkan ke Layar Utama”.
+1. AMPbyExample memiliki [Service Worker](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers), sehingga memungkinkan akses offline dan lain sebagainya.
+
+Ketika pengguna membuka [AMPbyExample](http://ampbyexample.com/) dari platform yang mendukung AMP lalu lanjut mengklik ke situs yang sama, mereka keluar dari Cache AMP ke halaman asli. Tentunya situs masih menggunakan koleksi AMP, namun karena saat ini ditayangkan di halaman asli, situs dapat menggunakan service worker, meminta penginstalan, dan lain-lain.
+
+{% call callout('Ingat', type='caution') %}
+Service Worker tidak akan dapat berinteraksi dengan versi halaman yang tersimpan dalam cache AMP. Gunakan untuk melanjutkan perjalanan berikutnya ke halaman asli.
+{% endcall %}
+
+## Menambahkan Manifes Aplikasi Web
+
+Menambahkan [Manifes Aplikasi Web](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/) ke halaman AMP memastikan bahwa pengguna dapat menambahkan situs Anda ke layar utama perangkat mereka. Tidak ada yang istimewa tentang manifes Aplikasi Web di AMP.
+
+Pertama, buat manifes:
+
+[sourcecode:json]
+{
+  "short_name": "ABE",
+  "name": "AMPByExample",
+  "icons": [
+    {
+      "src": "launcher-icon-1x.png",
+      "type": "image/png",
+      "sizes": "48x48"
+    },
+    {
+      "src": "launcher-icon-2x.png",
+      "type": "image/png",
+      "sizes": "96x96"
+    },
+    {
+      "src": "launcher-icon-4x.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    }
+  ],
+  "start_url": "index.html?launcher=true"
+}
+[/sourcecode]
+
+Kemudian, tautkan manifes dari `<head>` halaman AMP:
+
+[sourcecode:html]
+<link rel="manifest" href="/manifest.json">
+[/sourcecode]
+
+{% call callout('Tips', type='success') %}
+Pelajari lebih lanjut tentang [Manifes Aplikasi Web di WebFundamentals](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/).
+{% endcall %}
+
+## Menginstal Service Worker untuk mengaktifkan akses offline
+
+Service Worker adalah proxy sisi-klien yang berada di antara halaman dan server, serta dapat digunakan untuk menciptakan pengalaman akses offline yang memuaskan, skenario pemuatan app shell yang cepat, dan mengirimkan notifikasi push.
+
+{% call callout('Catatan', type='note') %}
+Jika konsep Service Worker merupakan hal baru bagi Anda, baca [pendahuluan di WebFundamentals](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers).
+{% endcall %}
+
+Service Worker perlu didaftarkan pada halaman tertentu, karena jika tidak, browser tidak akan menemukan atau menjalankannya. Secara default, tindakan ini dilakukan dengan bantuan [sedikit JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration). Pada Halaman AMP, Anda menggunakan komponen [`<amp-install-serviceworker>`](/id/docs/reference/components/amp-install-serviceworker) untuk melakukan hal yang sama.
+
+Untuk melakukannya, sertakan komponen `<amp-install-serviceworker>` terlebih dahulu melalui skripnya pada `<head>` halaman Anda:
+
+[sourcecode:html]
+<script async custom-element="amp-install-serviceworker"
+  src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>
+[/sourcecode]
+
+Kemudian, tambahkan parameter berikut di tempat lain dalam `<body>` (ubah agar mengarah ke Service Worker sebenarnya):
+
+[sourcecode:html]
+<amp-install-serviceworker
+      src="https://www.your-domain.com/serviceworker.js"
+      layout="nodisplay">
+</amp-install-serviceworker>
+[/sourcecode]
+
+Jika pengguna membuka halaman AMP di halaman asli (bukan klik pertama, yang biasanya ditayangkan dari Cache AMP), Service Worker akan mengambil alih dan dapat melakukan [banyak hal keren](https://developers.google.com/web/fundamentals/instant-and-offline/offline-ux).
+
+## Meluaskan Halaman AMP melalui Service Worker
+
+Anda dapat menggunakan teknik di atas untuk mengaktifkan akses offline ke situs AMP, serta meluaskan halaman **segera setelah situs ditayangkan dari halaman aslinya**. Hal ini terjadi karena Anda dapat mengubah respons melalui kejadian `fetch` Service Worker, dan mengembalikan respons apa pun yang diinginkan:
+
+[sourcecode:js]
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    caches.open('mysite').then(function(cache) {
+      return cache.match(event.request).then(function(response) {
+        var fetchPromise = fetch(event.request).then(function(networkResponse) {
+          cache.put(event.request, networkResponse.clone());
+          return networkResponse;
+        })
+
+        // Ubah respons di sini sebelum hilang..
+        ...
+
+        return response || fetchPromise;
+      })
+    })
+  );
+});
+[/sourcecode]
+
+Dengan menggunakan teknik ini, Anda dapat mengubah Halaman AMP dengan segala fungsi
+tambahan yang sebaliknya akan menggagalkan [validasi AMP](/id/docs/guides/validate.html), misalnya:
+
+* Fitur dinamis yang memerlukan JS kustom.
+* Komponen yang disesuaikan/hanya relevan untuk situs Anda.
+ 
+ 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@id.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@id.md
@@ -1,7 +1,5 @@
 ---
 $title: Mengaktifkan fitur Progressive Web App untuk halaman AMP
-$order: 0
-toc: true
 ---
 
 [TOC]
@@ -68,7 +66,7 @@ Service Worker adalah proxy sisi-klien yang berada di antara halaman dan server,
 Jika konsep Service Worker merupakan hal baru bagi Anda, baca [pendahuluan di WebFundamentals](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers).
 {% endcall %}
 
-Service Worker perlu didaftarkan pada halaman tertentu, karena jika tidak, browser tidak akan menemukan atau menjalankannya. Secara default, tindakan ini dilakukan dengan bantuan [sedikit JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration). Pada Halaman AMP, Anda menggunakan komponen [`<amp-install-serviceworker>`](/id/docs/reference/components/amp-install-serviceworker) untuk melakukan hal yang sama.
+Service Worker perlu didaftarkan pada halaman tertentu, karena jika tidak, browser tidak akan menemukan atau menjalankannya. Secara default, tindakan ini dilakukan dengan bantuan [sedikit JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration). Pada Halaman AMP, Anda menggunakan komponen [`<amp-install-serviceworker>`](/id/docs/reference/components/amp-install-serviceworker.html) untuk melakukan hal yang sama.
 
 Untuk melakukannya, sertakan komponen `<amp-install-serviceworker>` terlebih dahulu melalui skripnya pada `<head>` halaman Anda:
 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@ja.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@ja.md
@@ -1,7 +1,5 @@
 ---
 $title: AMP ページでプログレッシブ ウェブアプリ機能を有効にする
-$order: 0
-toc: true
 ---
 
 [TOC]
@@ -68,7 +66,7 @@ Service Worker は、ページとサーバーの間に存在するクライア�
 Service Worker をご存知ない場合は、[Web Fundamentals の概要説明](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers) をご覧ください。
 {% endcall %}
 
-Service Worker は、ブラウザで見つけて実行できるように、特定のページに登録する必要があります。デフォルトでは、こうした登録は [少しの JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration) を利用して行います。AMP ページの場合、[`<amp-install-serviceworker>`](/ja/docs/reference/components/amp-install-serviceworker) コンポーネントを使って同じことができます。
+Service Worker は、ブラウザで見つけて実行できるように、特定のページに登録する必要があります。デフォルトでは、こうした登録は [少しの JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration) を利用して行います。AMP ページの場合、[`<amp-install-serviceworker>`](/ja/docs/reference/components/amp-install-serviceworker.html) コンポーネントを使って同じことができます。
 
 登録するには、まず `<amp-install-serviceworker>` コンポーネントを、そのスクリプトを使ってページの `<head>` に含めます。
 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@ja.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@ja.md
@@ -1,0 +1,121 @@
+---
+$title: AMP ページでプログレッシブ ウェブアプリ機能を有効にする
+$order: 0
+toc: true
+---
+
+[TOC]
+
+{{ image('/static/img/docs/pwamp_add_to_homescreen.png', 848, 1500, align='right third', caption='AMPbyExample で表示される「ホーム画面に追加」のプロンプト') }}
+
+多くのウェブサイトでは、AMP を使えば必要なことがすべてできるようになります。たとえば [AMPbyExample](http://ampbyexample.com/) は、AMP でもありプログレッシブ ウェブアプリでもあります。
+
+1. [ウェブアプリ マニフェスト](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/) が設定されていて、これにより「ホーム画面に追加」のバナーが表示される
+1. [Service Worker](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers) を使用しているので、特にオフライン アクセスなどが可能になる
+
+ユーザーが AMP 対応プラットフォームから [AMPbyExample](http://ampbyexample.com/) にアクセスした後、クリックで引き続き同じサイトへ進む場合、AMP キャッシュから離れて配信元に移動することになります。このような場合も当然、ウェブサイトは AMP ライブラリを使用しますが、この時点で配信元に存在しているので、Service Worker を利用したり、インストールを求めるメッセージを表示したりすることなどが可能です。
+
+{% call callout('注意', type='caution') %}
+Service Worker は、ページの AMP キャッシュ バージョンには対応できません。配信元へ進む際に使用してください。
+{% endcall %}
+
+## ウェブアプリ マニフェストを追加する
+
+AMP ページに[ウェブアプリ マニフェスト](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/) を追加すると、ユーザーが端末のホーム画面にサイトをインストールできるようになります。AMP のウェブアプリ マニフェストについては、特別なことは何もありません。
+
+まず、マニフェストを作成します。
+
+[sourcecode:json]
+{
+  "short_name": "ABE",
+  "name": "AMPByExample",
+  "icons": [
+    {
+      "src": "launcher-icon-1x.png",
+      "type": "image/png",
+      "sizes": "48x48"
+    },
+    {
+      "src": "launcher-icon-2x.png",
+      "type": "image/png",
+      "sizes": "96x96"
+    },
+    {
+      "src": "launcher-icon-4x.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    }
+  ],
+  "start_url": "index.html?launcher=true"
+}
+[/sourcecode]
+
+次に、この作成したマニフェストに、AMP ページの `<head>` からリンクします。
+
+[sourcecode:html]
+<link rel="manifest" href="/manifest.json">
+[/sourcecode]
+
+{% call callout('ヒント', type='success') %}
+詳しくは、[Web Fundamentals のウェブアプリ マニフェストについての説明](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/) をご覧ください。
+{% endcall %}
+
+## Service Worker をインストールしてオフライン アクセスを有効にする
+
+Service Worker は、ページとサーバーの間に存在するクライアント サイドのプロキシです。Service Worker を利用すると、オフラインでの優れたユーザー エクスペリエンスを実現したり、アプリケーション シェルのシナリオの読み込みを高速化したり、プッシュ通知を送信したりできます。
+
+{% call callout('メモ', type='note') %}
+Service Worker をご存知ない場合は、[Web Fundamentals の概要説明](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers) をご覧ください。
+{% endcall %}
+
+Service Worker は、ブラウザで見つけて実行できるように、特定のページに登録する必要があります。デフォルトでは、こうした登録は [少しの JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration) を利用して行います。AMP ページの場合、[`<amp-install-serviceworker>`](/ja/docs/reference/components/amp-install-serviceworker) コンポーネントを使って同じことができます。
+
+登録するには、まず `<amp-install-serviceworker>` コンポーネントを、そのスクリプトを使ってページの `<head>` に含めます。
+
+[sourcecode:html]
+<script async custom-element="amp-install-serviceworker"
+  src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>
+[/sourcecode]
+
+次に、下記のコードを `<body>` 内に追加します（実際にお使いの Service Worker に変更してください）。
+
+[sourcecode:html]
+<amp-install-serviceworker
+      src="https://www.your-domain.com/serviceworker.js"
+      layout="nodisplay">
+</amp-install-serviceworker>
+[/sourcecode]
+
+ユーザーが（通常 AMP キャッシュから提供される最初のクリックではなく）配信元の AMP ページに移動した場合、Service Worker が引き継いで [多様な優れた方法](https://developers.google.com/web/fundamentals/instant-and-offline/offline-ux) で対処できます。
+
+## Service Worker を使って AMP ページを拡張する
+
+上記の方法を利用して AMP ウェブサイトへのオフライン アクセスを有効にするだけでなく、**ページが配信元から提供されたらすぐに** 拡張することも可能です。これは、Service Worker の `fetch` イベントにより応答を編集して、必要な応答を返すことができるためです。
+
+[sourcecode:js]
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    caches.open('mysite').then(function(cache) {
+      return cache.match(event.request).then(function(response) {
+        var fetchPromise = fetch(event.request).then(function(networkResponse) {
+          cache.put(event.request, networkResponse.clone());
+          return networkResponse;
+        })
+
+        // 応答が返される前にここで編集する
+        ...
+
+        return response || fetchPromise;
+      })
+    })
+  );
+});
+[/sourcecode]
+
+この方法を使うと、AMP ページを修正して、あらゆる追加機能について
+[AMP の検証](/ja/docs/guides/validate.html) に失敗するのを防ぐことができます。たとえば次のような機能です。
+
+* カスタム JS を必要とする動的な機能
+* サイト向けにカスタマイズされたコンポーネントやサイトにのみ関連するコンポーネント
+ 
+ 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@ko.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@ko.md
@@ -1,7 +1,5 @@
 ---
 $title: AMP 페이지에 프로그레시브 웹 앱 기능 사용 설정
-$order: 0
-toc: true
 ---
 
 [TOC]
@@ -68,7 +66,7 @@ AMP 페이지에 [웹 앱 매니페스트](https://developers.google.com/web/fun
 서비스 워커라는 개념을 처음 접하시는 분은 [WebFundamentals 소개](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers)를 읽어보세요.
 {% endcall %}
 
-서비스 워커는 특정 페이지에 등록되어야 합니다. 그렇지 않으면 브라우저에서 서비스 워커를 찾거나 실행할 수 없습니다. 기본적으로 이 작업에는 [자바스크립트](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration)가 필요합니다. AMP 페이지에서는 [`<amp-install-serviceworker>`](/ko/docs/reference/components/amp-install-serviceworker) 구성요소를 사용하여 동일한 작업을 처리할 수 있습니다.
+서비스 워커는 특정 페이지에 등록되어야 합니다. 그렇지 않으면 브라우저에서 서비스 워커를 찾거나 실행할 수 없습니다. 기본적으로 이 작업에는 [자바스크립트](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration)가 필요합니다. AMP 페이지에서는 [`<amp-install-serviceworker>`](/ko/docs/reference/components/amp-install-serviceworker.html) 구성요소를 사용하여 동일한 작업을 처리할 수 있습니다.
 
 우선 페이지의 `<head>`에 있는 스크립트를 통해 `<amp-install-serviceworker>` 구성요소를 포함시킵니다.
 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@ko.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@ko.md
@@ -1,0 +1,121 @@
+---
+$title: AMP 페이지에 프로그레시브 웹 앱 기능 사용 설정
+$order: 0
+toc: true
+---
+
+[TOC]
+
+{{ image('/static/img/docs/pwamp_add_to_homescreen.png', 848, 1500, align='right third', caption='"홈 화면에 추가" 메시지를 트리거하는 AMPbyExample.') }}
+
+대부분의 웹사이트에는 AMP 이외의 기능이 필요하지 않습니다. 예를 들어 [AMPbyExample](http://ampbyexample.com/)은 AMP이면서 프로그레시브 웹 앱이기도 합니다.
+
+1. [웹 앱 매니페스트](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/)가 있어서 '홈 화면에 추가' 배너가 표시됩니다.
+1. [서비스 워커](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers)가 있기 때문에 다른 기능은 물론 오프라인 액세스도 지원합니다.
+
+AMP를 지원하는 플랫폼 사용자가 [AMPbyExample](http://ampbyexample.com/)에 방문한 다음 클릭을 통해 해당 사이트에서 계속 탐색하면, AMP 캐시에서 원본으로 이동하게 됩니다. 웹사이트에서는 계속해서 AMP 라이브러리를 사용합니다. 하지만 이제 원본에서 게시되기 때문에 서비스 워커 사용, 설치 메시지 표시 등의 기능을 사용할 수 있습니다.
+
+{% call callout('주의사항', type='caution') %}
+서비스 워커는 AMP 캐시 버전의 페이지와 상호작용할 수 없습니다. 원본으로 이동할 때 서비스 워커를 사용하세요.
+{% endcall %}
+
+## 웹 앱 매니페스트 추가하기
+
+AMP 페이지에 [웹 앱 매니페스트](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/)를 추가하면 사용자가 기기 홈 화면에 사이트를 설치할 수 있습니다. AMP의 웹 앱 매니페스트는 일반 매니페스트와 동일합니다.
+
+먼저 매니페스트를 만듭니다.
+
+[sourcecode:json]
+{
+  "short_name": "ABE",
+  "name": "AMPByExample",
+  "icons": [
+    {
+      "src": "launcher-icon-1x.png",
+      "type": "image/png",
+      "sizes": "48x48"
+    },
+    {
+      "src": "launcher-icon-2x.png",
+      "type": "image/png",
+      "sizes": "96x96"
+    },
+    {
+      "src": "launcher-icon-4x.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    }
+  ],
+  "start_url": "index.html?launcher=true"
+}
+[/sourcecode]
+
+그런 다음 AMP 페이지의 `<head>`에서 매니페스트를 연결합니다.
+
+[sourcecode:html]
+<link rel="manifest" href="/manifest.json">
+[/sourcecode]
+
+{% call callout('팁', type='success') %}
+[WebFundamentals 웹 앱 매니페스트](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/)에 관해 자세히 알아보세요.
+{% endcall %}
+
+## 서비스 워커를 설치하여 오프라인 액세스 사용
+
+서비스 워커는 페이지와 서버 사이에 위치하는 클라이언트측 프록시로서 멋진 오프라인 환경을 구축하고, 앱 셸 시나리오를 빠르게 로드하고, 푸시 알림을 전송하는 데 사용할 수 있습니다.
+
+{% call callout('참고', type='note') %}
+서비스 워커라는 개념을 처음 접하시는 분은 [WebFundamentals 소개](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers)를 읽어보세요.
+{% endcall %}
+
+서비스 워커는 특정 페이지에 등록되어야 합니다. 그렇지 않으면 브라우저에서 서비스 워커를 찾거나 실행할 수 없습니다. 기본적으로 이 작업에는 [자바스크립트](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration)가 필요합니다. AMP 페이지에서는 [`<amp-install-serviceworker>`](/ko/docs/reference/components/amp-install-serviceworker) 구성요소를 사용하여 동일한 작업을 처리할 수 있습니다.
+
+우선 페이지의 `<head>`에 있는 스크립트를 통해 `<amp-install-serviceworker>` 구성요소를 포함시킵니다.
+
+[sourcecode:html]
+<script async custom-element="amp-install-serviceworker"
+  src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>
+[/sourcecode]
+
+그런 다음 `<body>` 안에 다음 항목을 추가합니다. 실제로 사용하는 서비스 워커를 가리키도록 수정하세요.
+
+[sourcecode:html]
+<amp-install-serviceworker
+      src="https://www.your-domain.com/serviceworker.js"
+      layout="nodisplay">
+</amp-install-serviceworker>
+[/sourcecode]
+
+사용자가 원본에 있는 AMP 페이지(AMP 캐시에서 제공되는 최초 클릭과는 다름)로 이동하면 서비스 워커가 중심이 되어 [여러 가지 멋진 작업](https://developers.google.com/web/fundamentals/instant-and-offline/offline-ux)을 할 수 있게 됩니다.
+
+## 서비스 워커를 통해 AMP 페이지 확장하기
+
+위에 설명된 방법을 사용하면 AMP 웹사이트에 오프라인으로 액세스할 수 있을 뿐만 아니라 **AMP 페이지가 원본에서 제공되는 즉시** 페이지를 확장할 수 있습니다. 서비스 워커의 `fetch` 이벤트를 사용하여 응답을 수정하고 원하는 응답을 반환할 수 있기 때문입니다.
+
+[sourcecode:js]
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    caches.open('mysite').then(function(cache) {
+      return cache.match(event.request).then(function(response) {
+        var fetchPromise = fetch(event.request).then(function(networkResponse) {
+          cache.put(event.request, networkResponse.clone());
+          return networkResponse;
+        })
+
+        // 응답을 반환하기 전에 여기에서 수정하세요..
+        ...
+
+        return response || fetchPromise;
+      })
+    })
+  );
+});
+[/sourcecode]
+
+이 방법을 사용하면 AMP 페이지에서
+[AMP 유효성 검사](/ko/docs/guides/validate.html)를 통과하지 못하는 모든 추가 기능을 수정할 수 있습니다.
+
+* 맞춤 JS를 필요로 하는 동적 기능
+* 내 사이트에 맞춤설정되었거나 내 사이트에만 관련이 있는 구성요소
+ 
+ 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@pt_BR.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@pt_BR.md
@@ -1,0 +1,121 @@
+---
+$title: Ativar os recursos de Progressive Web App nas suas páginas AMP
+$order: 0
+toc: true
+---
+
+[TOC]
+
+{{ image('/static/img/docs/pwamp_add_to_homescreen.png', 848, 1500, align='right third', caption='AMPbyExample acionando a solicitação "Adicione à tela inicial".') }}
+
+Muitos sites não precisam de recursos além dos oferecidos pelas AMP. [AMPbyExample](http://ampbyexample.com/), por exemplo, é uma página AMP e um Progressive Web App:
+
+1. Ela tem um [manifesto de app da Web](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/) e solicita o banner "Adicione à tela inicial".
+2. Ela tem um [service worker](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers) que possibilita acesso off-line, entre outras coisas.
+
+Quando o usuário visita [AMPbyExample](http://ampbyexample.com/) de uma plataforma compatível com AMP e clica para navegar no site, ele sai do cache de AMP e acessa a origem. O site ainda usa a biblioteca AMP, mas, como ele fica na origem, é possível usar um service worker, solicitar instalações e assim por diante.
+
+{% call callout('Lembre-se', type='caution') %}
+O service worker não poderá interagir com a versão AMP em cache da sua página. Use o recurso para caminhos direcionados à sua origem.
+{% endcall %}
+
+## Adicionar um manifesto de app da Web
+
+Adicionar um [manifesto de app da Web](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/) às suas páginas AMP permitirá que os usuários instalem seu site na tela inicial de dispositivos. Os manifestos de app da Web nas AMP são muito simples.
+
+Primeiro, crie o manifesto:
+
+[sourcecode:json]
+{
+  "short_name": "ABE",
+  "name": "AMPByExample",
+  "icons": [
+    {
+      "src": "launcher-icon-1x.png",
+      "type": "image/png",
+      "sizes": "48x48"
+    },
+    {
+      "src": "launcher-icon-2x.png",
+      "type": "image/png",
+      "sizes": "96x96"
+    },
+    {
+      "src": "launcher-icon-4x.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    }
+  ],
+  "start_url": "index.html?launcher=true"
+}
+[/sourcecode]
+
+Em seguida, vincule-o à seção `<head>` da página AMP:
+
+[sourcecode:html]
+<link rel="manifest" href="/manifest.json">
+[/sourcecode]
+
+{% call callout('Dica', type='success') %}
+Saiba mais sobre o [Manifesto de app da Web no WebFundamentals](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/).
+{% endcall %}
+
+## Instalar um service worker para permitir o acesso off-line
+
+O service worker é um proxy do lado do cliente que fica entre a página e o servidor. Ele pode ser usado para criar experiências off-line incríveis, cenários de shell do app com carregamento rápido e enviar notificações push.
+
+{% call callout('Observação', type='note') %}
+Se o conceito de service workers for novidade para você, leia [esta introdução no WebFundamentals](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers).
+{% endcall %}
+
+O service worker precisa ser registrado em uma página determinada, caso contrário, o navegador não será capaz de encontrá-lo ou executá-lo. Por padrão, isso é feito com [uma pequena ajuda do JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration). Em páginas AMP, use o componente [`<amp-install-serviceworker>`](/pt_br/docs/reference/components/amp-install-serviceworker) para alcançar o mesmo resultado.
+
+Para isso, primeiro inclua o componente `<amp-install-serviceworker>` por meio do script correspondente na seção `<head>` da sua página:
+
+[sourcecode:html]
+<script async custom-element="amp-install-serviceworker"
+  src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>
+[/sourcecode]
+
+Em seguida, adicione o código a seguir dentro da seção `<body>` (modifique-o para apontar para seu service worker):
+
+[sourcecode:html]
+<amp-install-serviceworker
+      src="https://www.your-domain.com/serviceworker.js"
+      layout="nodisplay">
+</amp-install-serviceworker>
+[/sourcecode]
+
+Se o usuário acessar as páginas AMP na origem (e não pelo primeiro clique, que normalmente é veiculado a partir de um cache de AMP), o service worker assumirá o controle e poderá fazer [várias coisas interessantes](https://developers.google.com/web/fundamentals/instant-and-offline/offline-ux).
+
+## Estender páginas AMP por meio do service worker
+
+Você pode usar a técnica acima para permitir acesso off-line ao site AMP e estender suas páginas **assim que elas forem exibidas a partir da origem**. Isso é possível porque você pode modificar a resposta usando o evento `fetch` do service worker e retornar qualquer resposta que você queira:
+
+[sourcecode:js]
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    caches.open('mysite').then(function(cache) {
+      return cache.match(event.request).then(function(response) {
+        var fetchPromise = fetch(event.request).then(function(networkResponse) {
+          cache.put(event.request, networkResponse.clone());
+          return networkResponse;
+        })
+
+        // Modify the response here before it goes out..
+        …
+
+        return response || fetchPromise;
+      })
+    })
+  );
+});
+[/sourcecode]
+
+Com essa técnica, você poderá alterar sua página AMP com várias
+funcionalidades adicionais que não passariam na [validação de AMP](/pt_br/docs/guides/validate.html) se fossem usadas de outra forma. Por exemplo:
+
+* recursos dinâmicos que exigem JS personalizado
+* componentes personalizados/relevantes apenas para seu site
+ 
+ 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@pt_BR.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@pt_BR.md
@@ -1,7 +1,5 @@
 ---
 $title: Ativar os recursos de Progressive Web App nas suas páginas AMP
-$order: 0
-toc: true
 ---
 
 [TOC]
@@ -68,7 +66,7 @@ O service worker é um proxy do lado do cliente que fica entre a página e o ser
 Se o conceito de service workers for novidade para você, leia [esta introdução no WebFundamentals](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers).
 {% endcall %}
 
-O service worker precisa ser registrado em uma página determinada, caso contrário, o navegador não será capaz de encontrá-lo ou executá-lo. Por padrão, isso é feito com [uma pequena ajuda do JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration). Em páginas AMP, use o componente [`<amp-install-serviceworker>`](/pt_br/docs/reference/components/amp-install-serviceworker) para alcançar o mesmo resultado.
+O service worker precisa ser registrado em uma página determinada, caso contrário, o navegador não será capaz de encontrá-lo ou executá-lo. Por padrão, isso é feito com [uma pequena ajuda do JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration). Em páginas AMP, use o componente [`<amp-install-serviceworker>`](/pt_br/docs/reference/components/amp-install-serviceworker.html) para alcançar o mesmo resultado.
 
 Para isso, primeiro inclua o componente `<amp-install-serviceworker>` por meio do script correspondente na seção `<head>` da sua página:
 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@zh_CN.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@zh_CN.md
@@ -1,0 +1,121 @@
+---
+$title: 为 AMP 网页启用渐进式网页应用功能
+$order: 0
+toc: true
+---
+
+[TOC]
+
+{{ image('/static/img/docs/pwamp_add_to_homescreen.png', 848, 1500, align='right third', caption='AMPbyExample 触发了“添加到主屏幕”提示。') }}
+
+很多网站根本不需要 AMP 范畴之外的功能。例如，[AMPbyExample](http://ampbyexample.com/) 既是一个 AMP 网站，又是一款渐进式网页应用。
+
+1. 它具有[网络应用清单](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/)，因此会向用户显示“添加到主屏幕”这一横幅提示。
+1. 它具有 [Service Worker](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers)，因此可实现诸多功能（其中包括允许离线访问）。
+
+如果某位用户通过某个支持 AMP 的平台访问 [AMPbyExample](http://ampbyexample.com/)，然后通过执行点击操作进入该网站以继续进行浏览之旅，该用户就会从 AMP 缓存转到源网域。当然，该网站仍会使用 AMP 库，但由于该网站现在位于源网域，它就可以使用 Service Worker、可以提示用户进行安装，等等。
+
+{% call callout('注意', type='caution') %}
+Service Worker 无法与网页的 AMP 缓存版本互动。请在用户进入您的源网域以继续进行浏览之旅时使用 Service Worker。
+{% endcall %}
+
+## 添加网络应用清单
+
+向您的 AMP 网页添加[网络应用清单](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/)可确保用户能够将您的网站安装到其设备的主屏幕上。AMP 网页中的网络应用清单并无任何特别之处。
+
+首先，创建以下清单：
+
+[sourcecode:json]
+{
+  "short_name": "ABE",
+  "name": "AMPByExample",
+  "icons": [
+    {
+      "src": "launcher-icon-1x.png",
+      "type": "image/png",
+      "sizes": "48x48"
+    },
+    {
+      "src": "launcher-icon-2x.png",
+      "type": "image/png",
+      "sizes": "96x96"
+    },
+    {
+      "src": "launcher-icon-4x.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    }
+  ],
+  "start_url": "index.html?launcher=true"
+}
+[/sourcecode]
+
+然后，从您 AMP 网页的 `<head>` 链接到该清单。
+
+[sourcecode:html]
+<link rel="manifest" href="/manifest.json">
+[/sourcecode]
+
+{% call callout('提示', type='success') %}
+如有需要，请[在“网页基础知识”网站上详细了解网络应用清单](https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/)。
+{% endcall %}
+
+## 安装 Service Worker 以允许离线访问
+
+Service Worker 是您的网页与服务器之间的客户端代理，可用于打造出色的离线体验、快速加载应用 Shell 场景以及发送推送通知。
+
+{% call callout('注意', type='note') %}
+如果您不熟悉 Service Worker 这一概念，请[在“网页基础知识”网站上阅读相关简介](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers)。
+{% endcall %}
+
+您需要在一个给定的网页上注册 Service Worker，否则浏览器将无法找到或运行该文件。默认情况下，注册过程是借助[少量 JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration) 完成的。在 AMP 网页上，您可以使用 [`<amp-install-serviceworker>`](/zh_cn/docs/reference/components/amp-install-serviceworker) 组件实现同样的目的。
+
+为此，请先通过 `<amp-install-serviceworker>` 组件的脚本在您网页的 `<head>`中添加该组件：
+
+[sourcecode:html]
+<script async custom-element="amp-install-serviceworker"
+  src="https://cdn.ampproject.org/v0/amp-install-serviceworker-0.1.js"></script>
+[/sourcecode]
+
+然后，在您 `<body>` 中的某个位置添加以下内容（请酌情进行修改以使其指向您的实际 Service Worker）：
+
+[sourcecode:html]
+<amp-install-serviceworker
+      src="https://www.your-domain.com/serviceworker.js"
+      layout="nodisplay">
+</amp-install-serviceworker>
+[/sourcecode]
+
+如果用户已转到您的源网域中的 AMP 网页上（此时的情况已不同于通常由 AMP 缓存提供的首次点击），Service Worker 便会接管后续工作，并可完成[无数的精彩操作](https://developers.google.com/web/fundamentals/instant-and-offline/offline-ux)。
+
+## 通过 Service Worker 扩展 AMP 网页
+
+借助上述方法，您既可允许用户离线访问您的 AMP 网站，也可**在您的网页由源网域提供后**立即扩展这些网页。这是因为您可通过 Service Worker 的 `fetch` 事件修改响应，并返回您想发出的任何响应：
+
+[sourcecode:js]
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    caches.open('mysite').then(function(cache) {
+      return cache.match(event.request).then(function(response) {
+        var fetchPromise = fetch(event.request).then(function(networkResponse) {
+          cache.put(event.request, networkResponse.clone());
+          return networkResponse;
+        })
+
+        // Modify the response here before it goes out..
+        ...
+
+        return response || fetchPromise;
+      })
+    })
+  );
+});
+[/sourcecode]
+
+通过这种方法，您可以修改您的 AMP 网页以及相关的各种附加功能
+（如果不修改，则会无法顺利通过 [AMP 验证](/zh_cn/docs/guides/validate.html)），例如：
+
+* 需要使用自定义 JS 的动态功能。
+* 专为您的网站定制/仅与您的网站相关的组件。
+ 
+ 

--- a/content/docs/guides/pwa-amp/amp-as-pwa@zh_CN.md
+++ b/content/docs/guides/pwa-amp/amp-as-pwa@zh_CN.md
@@ -1,7 +1,5 @@
 ---
 $title: 为 AMP 网页启用渐进式网页应用功能
-$order: 0
-toc: true
 ---
 
 [TOC]
@@ -68,7 +66,7 @@ Service Worker 是您的网页与服务器之间的客户端代理，可用于�
 如果您不熟悉 Service Worker 这一概念，请[在“网页基础知识”网站上阅读相关简介](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers)。
 {% endcall %}
 
-您需要在一个给定的网页上注册 Service Worker，否则浏览器将无法找到或运行该文件。默认情况下，注册过程是借助[少量 JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration) 完成的。在 AMP 网页上，您可以使用 [`<amp-install-serviceworker>`](/zh_cn/docs/reference/components/amp-install-serviceworker) 组件实现同样的目的。
+您需要在一个给定的网页上注册 Service Worker，否则浏览器将无法找到或运行该文件。默认情况下，注册过程是借助[少量 JavaScript](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration) 完成的。在 AMP 网页上，您可以使用 [`<amp-install-serviceworker>`](/zh_cn/docs/reference/components/amp-install-serviceworker.html) 组件实现同样的目的。
 
 为此，请先通过 `<amp-install-serviceworker>` 组件的脚本在您网页的 `<head>`中添加该组件：
 


### PR DESCRIPTION
Six translations (ja, es, ko, id, pt-BR, zh-CN)