### PR TITLE
Fix the lines that are highlighted on the animate-in-delay step of the story tutorial

### DIFF
--- a/content/docs/tutorials/visual_story/animating_elements.md
+++ b/content/docs/tutorials/visual_story/animating_elements.md
@@ -191,7 +191,7 @@ If you refresh and reload the page, each of the images fade in.  That's great bu
 
 Let's delay the entrance of the first image so that it comes in close to when the text banner finishes entering, say .4s. The remaining three images can come .2s after the previous image's entrance. For each of the amp-img elements, add `animate-in-delay=""` with the appropriate time delay value. Your code should look like this:
 
-```html hl_lines="5 10 15 20"
+```html hl_lines="5 11 17 23"
 <amp-img src="assets/cat.jpg"
     width="720" height="1280"
     layout="responsive"


### PR DESCRIPTION
I think this section was meant to highlight the "animate-in-delay" on all amp-imgs, but it currently highlights one line earlier in each amp-img.

https://www.ampproject.org/docs/tutorials/visual_story/animating_elements