### PR TITLE
Remove logic for changing abs links to rel links for extensions

### DIFF
--- a/scripts/import_docs.js
+++ b/scripts/import_docs.js
@@ -126,9 +126,6 @@ function convertMarkdown(content, relativePath, headingToStrip) {
   // create absolute urls from relative github urls
   content = content.replace(/\[([^\]]+)\]\((?!http|#)([^\)]+)\)/g, '[$1](https://github.com/ampproject/amphtml/blob/master/' + relativePath + '/$2)');
 
-  // now substitute links going to extensions with relative urls to the downloaded ones
-  content = content.replace(/https\:\/\/github.com\/ampproject\/amphtml\/blob\/master\/extensions\/[^\/]+\/([^\.]+)\.md/g, "components/$1.html");
-
   return content;
 }
 


### PR DESCRIPTION
Fixes #872 

Ran comparison by turning off logic to change relative links for extensions and there's only two affected docs.  Rather than have breaking links, I'll leave absolute URLs as they are, but will fix links to components in the two docs.

1) Fix links in spec for "amp-form"
2) Fix link in amp-ad for amp-ima-video