### PR TITLE
Fix build by replacing getFileManifestEntries with getManifest

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,17 +90,16 @@ gulp.task('update-platforms-page', ['import-docs'], function (cb) {
 });
 
 gulp.task('generate-asset-manifest', function (cb) {
-  swBuild.getFileManifestEntries({
+  swBuild.getManifest({
     globDirectory: './assets',
-    staticFileGlobs: [
+    globPatterns: [
       'img/*.{svg,png,jpg}',
       'img/nav/*.{svg,png,jpg}',
       'img/footer/*.{svg,png,jpg}'
     ]
-  }).then(entries => {
-
+  }).then((entries) => {
     // Add "static" to the path
-    entries.forEach(entry => {
+    entries['manifestEntries'].forEach(entry => {
       entry.url = '/static/' + entry.url;
     });
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "request": "*"
   },
   "devDependencies": {
-    "workbox-build": "2.1.3",
-    "workbox-sw": "2.1.3",
+    "workbox-build": "*",
+    "workbox-sw": "*",
     "amp-by-example": "*"
   }
 }


### PR DESCRIPTION
This PR replaces the deprecated `getFileManifestEntries` with `getManifest`. It also switches back to the latest versions of `workbox-build` and `workbox-sw`

Follow up to https://github.com/ampproject/docs/commit/18245baeca833e6cfc4dbf7c39aff7ca6adfc567
Fixes #878 