### PR TITLE
Fix regex for mustache code syntax

### DIFF
--- a/scripts/import_docs.js
+++ b/scripts/import_docs.js
@@ -118,7 +118,7 @@ function convertMarkdown(content, relativePath, headingToStrip) {
   });
 
   // replace mustache-style code elements
-  content = content.replace(/\`[^\s{`]*(\{\{[^`]*\}\})[^`]*\`/g, '{% raw %}`$1`{% endraw %}');
+  content = content.replace(/\`([^{`]*)(\{\{[^`]*\}\})([^`]*)\`/g, '{% raw %}`$1$2$3`{% endraw %}');
 
   // horizontal rules like --- will break front matter
   content = content.replace(/\n---\n/gm, '\n- - -\n');


### PR DESCRIPTION
Fix regex syntax so mustache code syntax can render correctly in Grow.
Performed diff and expected changes rendered.

Expect to render these inline code elements correctly: `<{{tagName}}>` and `<div {{attrName}}=something>` and `{{{unescaped}}}`.


fixes: #903 