### PR TITLE
Remove unnecessary sidebar links

### DIFF
--- a/content/docs/contribute/file-a-bug.md
+++ b/content/docs/contribute/file-a-bug.md
@@ -1,5 +1,0 @@
----
-$title@: File a bug
-$order: 2
-goto: https://github.com/ampproject/amphtml/issues/new
----

--- a/content/docs/contribute/github.md
+++ b/content/docs/contribute/github.md
@@ -1,5 +1,0 @@
----
-$title@: GitHub
-$order: 3
-goto: https://github.com/ampproject/amphtml
----

--- a/scripts/import_docs.json
+++ b/scripts/import_docs.json
@@ -1,7 +1,7 @@
 [
     {
         "title": "Open Source Governance",
-        "order": 5,
+        "order": 2,
         "from": "GOVERNANCE.md",
         "to": "docs/contribute/governance.md"
     },


### PR DESCRIPTION
Removing "GitHub" and "File a bug" links from docs side nav; it's not needed and may confuse readers.  Details for filing bugs or contributing already in the "How to contribute" doc.