### PR TITLE
h6 too tiny

### DIFF
--- a/assets/sass/_content.scss
+++ b/assets/sass/_content.scss
@@ -59,6 +59,10 @@
     margin-top: 30px;
   }
 
+  h6 {
+    font-size: 14px;
+  }
+
 
   a {
     font-size: 16px;


### PR DESCRIPTION
H6 font size is too small ([example](https://www.ampproject.org/docs/reference/components/amp-date-picker#template-definition-objects). 