### PR TITLE
Update and lock down package versions used by `ampproject/docs`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
         - ./build_scripts/build.sh tr zh_CN ru
     - stage: deploy
       install:
-        - npm install -g firebase-tools
+        - yarn global add firebase-tools
       script:
         - ./build_scripts/deploy.sh
 branches:

--- a/build_scripts/check-package-manager.js
+++ b/build_scripts/check-package-manager.js
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const childProcess = require('child_process');
+const https = require('https');
+
+const setupInstructionsUrl = 'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-quick.md#one-time-setup';
+const nodeDistributionsUrl = 'https://nodejs.org/dist/index.json';
+const growReleasesUrl = 'https://api.github.com/repos/grow/grow/releases';
+
+const yarnExecutable = 'npx yarn';
+const growExecutable = '~/bin/grow';
+
+const shellCmd = (process.platform == 'win32') ? 'cmd' : '/bin/sh';
+const shellFlag = (process.platform == 'win32') ? '/C' : '-c';
+
+// Color formatting libraries may not be available when this script is run.
+function red(text) {return '\x1b[31m' + text + '\x1b[0m';}
+function cyan(text) {return '\x1b[36m' + text + '\x1b[0m';}
+function green(text) {return '\x1b[32m' + text + '\x1b[0m';}
+function yellow(text) {return '\x1b[33m' + text + '\x1b[0m';}
+
+function getStdout(cmd) {
+  const p = childProcess.spawnSync(shellCmd, [shellFlag, cmd], {
+    'cwd': process.cwd(),
+    'env': process.env,
+    'stdio': 'pipe',
+    'encoding': 'utf-8',
+  });
+  return p.stdout;
+}
+
+/**
+ * @fileoverview Perform checks on the AMP toolchain.
+ */
+
+// If npm is being run, print a message and cause 'npm install' to fail.
+function ensureYarn() {
+  if (process.env.npm_execpath.indexOf('yarn') === -1) {
+    console.log(red(
+        '*** The AMP project uses yarn for package management ***'), '\n');
+    console.log(yellow('To install all packages:'));
+    console.log(cyan('$'), 'yarn', '\n');
+    console.log(
+        yellow('To install a new (runtime) package to "dependencies":'));
+    console.log(cyan('$'), 'yarn add --exact [package_name@version]', '\n');
+    console.log(
+        yellow('To install a new (toolset) package to "devDependencies":'));
+    console.log(cyan('$'),
+        'yarn add --dev --exact [package_name@version]', '\n');
+    console.log(yellow('To upgrade a package:'));
+    console.log(cyan('$'), 'yarn upgrade --exact [package_name@version]', '\n');
+    console.log(yellow('To remove a package:'));
+    console.log(cyan('$'), 'yarn remove [package_name]', '\n');
+    console.log(yellow('For detailed instructions, see'),
+        cyan(setupInstructionsUrl), '\n');
+    process.exit(1);
+  }
+}
+
+// Check the node version and print a warning if it is not the latest LTS.
+function checkNodeVersion() {
+  const nodeVersion = getStdout('node --version').trim();
+  return new Promise(resolve => {
+    https.get(nodeDistributionsUrl, res => {
+      res.setEncoding('utf8');
+      let distributions = '';
+      res.on('data', data => {
+        distributions += data;
+      });
+      res.on('end', () => {
+        const distributionsJson = JSON.parse(distributions);
+        const latestLtsVersion = getNodeLatestLtsVersion(distributionsJson);
+        if (latestLtsVersion === '') {
+          console.log(yellow('WARNING: Something went wrong. ' +
+              'Could not determine the latest LTS version of node.'));
+        } else if (nodeVersion !== latestLtsVersion) {
+          console.log(yellow('WARNING: Detected node version'),
+              cyan(nodeVersion) +
+              yellow('. Recommended (latest LTS) version is'),
+              cyan(latestLtsVersion) + yellow('.'));
+          console.log(yellow('⤷ To fix this, run'),
+              cyan('"nvm install --lts"'), yellow('or see'),
+              cyan('https://nodejs.org/en/download/package-manager'),
+              yellow('for instructions.'));
+        } else {
+          console.log(green('Detected'), cyan('node'), green('version'),
+              cyan(nodeVersion + ' (latest LTS)') +
+              green('.'));
+        }
+        resolve();
+      });
+    }).on('error', () => {
+      console.log(yellow('WARNING: Something went wrong. ' +
+          'Could not download node version info from ' +
+          cyan(nodeDistributionsUrl) + yellow('.')));
+      console.log(yellow('⤷ Detected node version'), cyan(nodeVersion) +
+          yellow('.'));
+      resolve();
+    });
+  });
+}
+
+function getNodeLatestLtsVersion(distributionsJson) {
+  if (distributionsJson) {
+    // Versions are in descending order, so the first match is the latest lts.
+    return distributionsJson.find(function(distribution) {
+      return distribution.hasOwnProperty('version') &&
+          distribution.hasOwnProperty('lts') &&
+          distribution.lts;
+    }).version;
+  } else {
+    return '';
+  }
+}
+
+// If yarn is being run, perform a version check and proceed with the install.
+function checkYarnVersion() {
+  const yarnVersion = getStdout(yarnExecutable + ' --version').trim();
+  const yarnInfo = getStdout(yarnExecutable + ' info --json yarn').trim();
+  const yarnInfoJson = JSON.parse(yarnInfo.split('\n')[0]); // First line
+  const stableVersion = getYarnStableVersion(yarnInfoJson);
+  if (stableVersion === '') {
+    console.log(yellow('WARNING: Something went wrong. ' +
+        'Could not determine the stable version of yarn.'));
+  } else if (yarnVersion !== stableVersion) {
+    console.log(yellow('WARNING: Detected yarn version'),
+        cyan(yarnVersion) + yellow('. Recommended (stable) version is'),
+        cyan(stableVersion) + yellow('.'));
+    console.log(yellow('⤷ To fix this, run'),
+        cyan('"curl -o- -L https://yarnpkg.com/install.sh | bash"'),
+        yellow('or see'), cyan('https://yarnpkg.com/docs/install'),
+        yellow('for instructions.'));
+    console.log(yellow('Attempting to install packages...'));
+  } else {
+    console.log(green('Detected'), cyan('yarn'), green('version'),
+        cyan(yarnVersion + ' (stable)') +
+        green('. Installing packages...'));
+  }
+}
+
+function getYarnStableVersion(infoJson) {
+  if (infoJson &&
+      infoJson.hasOwnProperty('data') &&
+      infoJson.data.hasOwnProperty('version')) {
+    return infoJson.data.version;
+  } else {
+    return '';
+  }
+}
+
+function checkGrowVersion1() {
+  const growVersion = getStdout(growExecutable + ' --version').trim();
+  console.log(green('Detected'), cyan('grow'), green('version'),
+      cyan(growVersion) + green('.'));
+}
+function checkGrowVersion() {
+  const growVersion = getStdout(growExecutable + ' --version').trim();
+  const growReleases = getStdout('curl ' + growReleasesUrl).trim();
+  const growReleasesJson = JSON.parse(growReleases);
+  const latestVersion = getGrowLatestVersion(growReleasesJson);
+  if (latestVersion === '') {
+    console.log(yellow('WARNING: Something went wrong. ' +
+        'Could not determine the latest version of grow.'));
+  } else if (growVersion !== latestVersion) {
+    console.log(yellow('WARNING: Detected grow version'),
+        cyan(growVersion) + yellow('. Recommended (latest) version is'),
+        cyan(latestVersion) + yellow('.'));
+    console.log(yellow('⤷ To fix this, run'),
+        cyan('"curl https://install.growsdk.org | bash"'),
+        yellow('or see'), cyan('http://grow.io/start/1'),
+        yellow('for instructions.'));
+  } else {
+    console.log(green('Detected'), cyan('grow'), green('version'),
+        cyan(growVersion + ' (latest)') + green('.'));
+  }
+}
+
+function getGrowLatestVersion(growReleasesJson) {
+  // Versions are in descending order, so the first one is the latest.
+  if (growReleasesJson &&
+      growReleasesJson.length > 0 &&
+      growReleasesJson[0].hasOwnProperty('name')) {
+    return growReleasesJson[0].name;
+  } else {
+    return '';
+  }
+}
+
+
+function main() {
+  // Yarn is already used by default on Travis, so there is nothing more to do.
+  if (process.env.TRAVIS) {
+    return 0;
+  }
+  ensureYarn();
+  return checkNodeVersion().then(() => {
+    return checkGrowVersion();
+  }).then(() => {
+    checkYarnVersion();
+  });
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -1,20 +1,23 @@
 {
   "name": "AMPProject.org",
   "private": true,
+  "scripts": {
+    "preinstall": "node build_scripts/check-package-manager.js"
+  },
   "dependencies": {
-    "feedparser": "^2.2.9",
-    "gulp": "^4.0.0",
-    "gulp-autoprefixer": "^5.0.0",
-    "gulp-plumber": "^1.2.0",
-    "gulp-sass": "^3.2.1",
-    "gulp-svg-sprite": "^1.4.0",
-    "moment": "^2.21.0",
-    "octonode": "^0.9.2",
-    "request": "^2.85.0"
+    "feedparser": "2.2.9",
+    "gulp": "4.0.0",
+    "gulp-autoprefixer": "5.0.0",
+    "gulp-plumber": "1.2.0",
+    "gulp-sass": "4.0.1",
+    "gulp-svg-sprite": "1.4.0",
+    "moment": "2.22.1",
+    "octonode": "0.9.2",
+    "request": "2.87.0"
   },
   "devDependencies": {
+    "amp-by-example": "*",
     "workbox-build": "*",
-    "workbox-sw": "*",
-    "amp-by-example": "*"
+    "workbox-sw": "*"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,10 +155,6 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
-array-differ@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
-
 array-each@^1.0.0, array-each@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
@@ -203,10 +199,6 @@ array-sort@^1.0.0:
 array-uniq@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.2.tgz#5fcc373920775723cfd64d65c64bef53bf9eba6d"
-
-array-uniq@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -270,8 +262,8 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
 autoprefixer@^8.0.0:
-  version "8.5.1"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.5.1.tgz#45b0271b0e634af66613d5a4f99d96f3dcd94474"
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.5.2.tgz#52d86a5ea51a6191024d843f88f2748ce3ab39e5"
   dependencies:
     browserslist "^3.2.8"
     caniuse-lite "^1.0.30000846"
@@ -334,10 +326,6 @@ bcrypt-pbkdf@^1.0.0:
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
   dependencies:
     tweetnacl "^0.14.3"
-
-beeper@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
 
 binary-extensions@^1.0.0:
   version "1.11.0"
@@ -462,7 +450,7 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -472,7 +460,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.4.1:
+chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -537,17 +525,9 @@ clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
 
-clone-stats@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
-
 clone-stats@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
-
-clone@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
 clone@^2.1.1:
   version "2.1.1"
@@ -773,10 +753,6 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-dateformat@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
-
 dateformat@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
@@ -876,12 +852,6 @@ domutils@1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
-
-duplexer2@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
-  dependencies:
-    readable-stream "~1.1.9"
 
 duplexify@^3.6.0:
   version "3.6.0"
@@ -1084,7 +1054,7 @@ eyes@0.1.x:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
 
-fancy-log@^1.1.0, fancy-log@^1.3.2:
+fancy-log@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:
@@ -1106,7 +1076,7 @@ fd-slicer@~1.0.1:
   dependencies:
     pend "~1.2.0"
 
-feedparser@^2.2.9:
+feedparser@2.2.9:
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/feedparser/-/feedparser-2.2.9.tgz#9138197dafdae05fcadde0036beeaf6066c2c5e9"
   dependencies:
@@ -1404,7 +1374,7 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6,
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-gulp-autoprefixer@^5.0.0:
+gulp-autoprefixer@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/gulp-autoprefixer/-/gulp-autoprefixer-5.0.0.tgz#8237c278a69775270a1cafe7d6f101cfcd585544"
   dependencies:
@@ -1438,7 +1408,7 @@ gulp-cli@^2.0.0:
     v8flags "^3.0.1"
     yargs "^7.1.0"
 
-gulp-plumber@^1.2.0:
+gulp-plumber@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gulp-plumber/-/gulp-plumber-1.2.0.tgz#18ea03912c9ee483f8a5499973b5954cd90f6ad8"
   dependencies:
@@ -1447,17 +1417,20 @@ gulp-plumber@^1.2.0:
     plugin-error "^0.1.2"
     through2 "^2.0.3"
 
-gulp-sass@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/gulp-sass/-/gulp-sass-3.2.1.tgz#2e3688a96fd8be1c0c01340750c191b2e79fab94"
+gulp-sass@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/gulp-sass/-/gulp-sass-4.0.1.tgz#7f43d117eb2d303524968a1b48494af1bc64d1d9"
   dependencies:
-    gulp-util "^3.0"
+    chalk "^2.3.0"
     lodash.clonedeep "^4.3.2"
     node-sass "^4.8.3"
+    plugin-error "^1.0.1"
+    replace-ext "^1.0.0"
+    strip-ansi "^4.0.0"
     through2 "^2.0.0"
     vinyl-sourcemaps-apply "^0.2.0"
 
-gulp-svg-sprite@^1.4.0:
+gulp-svg-sprite@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/gulp-svg-sprite/-/gulp-svg-sprite-1.4.0.tgz#d942ba508b128050e3227f10be8f58c2ee0243bd"
   dependencies:
@@ -1465,30 +1438,7 @@ gulp-svg-sprite@^1.4.0:
     svg-sprite "~1.4.0"
     through2 "^2.0.3"
 
-gulp-util@^3.0:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
-  dependencies:
-    array-differ "^1.0.0"
-    array-uniq "^1.0.2"
-    beeper "^1.0.0"
-    chalk "^1.0.0"
-    dateformat "^2.0.0"
-    fancy-log "^1.1.0"
-    gulplog "^1.0.0"
-    has-gulplog "^0.1.0"
-    lodash._reescape "^3.0.0"
-    lodash._reevaluate "^3.0.0"
-    lodash._reinterpolate "^3.0.0"
-    lodash.template "^3.0.0"
-    minimist "^1.1.0"
-    multipipe "^0.1.2"
-    object-assign "^3.0.0"
-    replace-ext "0.0.1"
-    through2 "^2.0.0"
-    vinyl "^0.5.0"
-
-gulp@^4.0.0:
+gulp@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/gulp/-/gulp-4.0.0.tgz#95766c601dade4a77ed3e7b2b6dc03881b596366"
   dependencies:
@@ -1532,12 +1482,6 @@ has-ansi@^2.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-
-has-gulplog@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce"
-  dependencies:
-    sparkles "^1.0.0"
 
 has-symbols@^1.0.0:
   version "1.0.0"
@@ -2129,10 +2073,6 @@ lodash._basecallback@^3.0.0:
     lodash.isarray "^3.0.0"
     lodash.pairs "^3.0.0"
 
-lodash._basecopy@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
-
 lodash._baseeach@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz#cf8706572ca144e8d9d75227c990da982f932af3"
@@ -2151,14 +2091,6 @@ lodash._baseisequal@^3.0.0:
     lodash.istypedarray "^3.0.0"
     lodash.keys "^3.0.0"
 
-lodash._basetostring@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz#d1861d877f824a52f669832dcaf3ee15566a07d5"
-
-lodash._basevalues@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz#5b775762802bde3d3297503e26300820fdf661b7"
-
 lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
@@ -2167,25 +2099,9 @@ lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
-lodash._isiterateecall@^3.0.0:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
-
-lodash._reescape@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reescape/-/lodash._reescape-3.0.0.tgz#2b1d6f5dfe07c8a355753e5f27fac7f1cde1616a"
-
-lodash._reevaluate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz#58bc74c40664953ae0b124d806996daca431e2ed"
-
-lodash._reinterpolate@^3.0.0, lodash._reinterpolate@~3.0.0:
+lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-
-lodash._root@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
 
 lodash._topath@^3.0.0:
   version "3.8.1"
@@ -2200,12 +2116,6 @@ lodash.assign@^4.2.0:
 lodash.clonedeep@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-
-lodash.escape@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-3.2.0.tgz#995ee0dc18c1b48cc92effae71a10aab5b487698"
-  dependencies:
-    lodash._root "^3.0.0"
 
 lodash.get@^4.4.2:
   version "4.4.2"
@@ -2264,37 +2174,12 @@ lodash.pluck@^3.1.2:
     lodash.isarray "^3.0.0"
     lodash.map "^3.0.0"
 
-lodash.restparam@^3.0.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-
-lodash.template@^3.0.0:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-3.6.2.tgz#f8cdecc6169a255be9098ae8b0c53d378931d14f"
-  dependencies:
-    lodash._basecopy "^3.0.0"
-    lodash._basetostring "^3.0.0"
-    lodash._basevalues "^3.0.0"
-    lodash._isiterateecall "^3.0.0"
-    lodash._reinterpolate "^3.0.0"
-    lodash.escape "^3.0.0"
-    lodash.keys "^3.0.0"
-    lodash.restparam "^3.0.0"
-    lodash.templatesettings "^3.0.0"
-
 lodash.template@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
   dependencies:
     lodash._reinterpolate "~3.0.0"
     lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz#fb307844753b66b9f1afa54e262c745307dba8e5"
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-    lodash.escape "^3.0.0"
 
 lodash.templatesettings@^4.0.0:
   version "4.1.0"
@@ -2434,7 +2319,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -2468,7 +2353,7 @@ mkdirp@0.5.1, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-moment@^2.21.0:
+moment@2.22.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
 
@@ -2479,12 +2364,6 @@ mri@^1.1.0:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-
-multipipe@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/multipipe/-/multipipe-0.1.2.tgz#2a8f2ddf70eed564dff2d57f1e1a137d9f05078b"
-  dependencies:
-    duplexer2 "0.0.2"
 
 mustache@^2.3.0:
   version "2.3.0"
@@ -2678,10 +2557,6 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
-
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -2762,7 +2637,7 @@ object.values@^1.0.4:
     function-bind "^1.1.0"
     has "^1.0.1"
 
-octonode@^0.9.2:
+octonode@0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/octonode/-/octonode-0.9.2.tgz#08c44a8ccf4cdecdfdf7cca4fcc1720c45592dd8"
   dependencies:
@@ -3187,10 +3062,6 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-replace-ext@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
-
 replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
@@ -3209,7 +3080,7 @@ request-progress@^2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@2, request@^2.72.0, request@^2.81.0, request@^2.85.0:
+request@2, request@2.87.0, request@^2.72.0, request@^2.81.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -3958,14 +3829,6 @@ vinyl-sourcemaps-apply@^0.2.0:
   resolved "https://registry.yarnpkg.com/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz#ab6549d61d172c2b1b87be5c508d239c8ef87705"
   dependencies:
     source-map "^0.5.1"
-
-vinyl@^0.5.0:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-0.5.3.tgz#b0455b38fc5e0cf30d4325132e461970c2091cde"
-  dependencies:
-    clone "^1.0.0"
-    clone-stats "^0.0.1"
-    replace-ext "0.0.1"
 
 vinyl@^2.0.0, vinyl@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This PR does the following:
- Locks down the versions in `package.json` so that upgrades to dependencies cannot break the build
- Updates `yarn.lock` with the result of running `yarn`
    - Since caching is already enabled for `yarn` on Travis, the install step during Travis builds will be much faster
- Adds a new script `build_scripts/check_package_manager.js`, which is run prior to the installation of packages.
    - Detects and prints the versions of `node`, `yarn`, and `grow`
    - Suggests upgrades if `node` is not LTS, or if `yarn` is not stable, or if `grow` is not latest
    - Makes sure that `yarn` is being used to add / install packages during local development
    - Fails the install and prints a useful message if `npm` is run instead of `yarn`

Fixes #894