### PR TITLE
Fail Travis when `grow build` doesn't successfully complete

### DIFF
--- a/build_scripts/build.sh
+++ b/build_scripts/build.sh
@@ -41,8 +41,7 @@ build_file="${build_file}.zip"
 echo $(GREEN "Building locales: ") $(CYAN "${locales}")
 echo -e 'travis_fold:start:build\n'
 echo "Running \"${cmd}\"..."
-# TODO(rsimha): Remove "|| true" after #968 is fixed.
-${cmd} || true
+${cmd}
 echo -e 'travis_fold:end:build\n'
 
 # Compress build output


### PR DESCRIPTION
With this PR, the Travis build will fail if `grow build` doesn't complete. This will prevent bogus zipping errors like the one in #978.

Fixes #978
Related to #968