### PR TITLE
Fix table wrapping + figure images

### DIFF
--- a/assets/sass/_content.scss
+++ b/assets/sass/_content.scss
@@ -122,7 +122,7 @@
     &.left {
       float: left;
       margin-right: 1em;
-      @include max-screen($mobile-breakpoint) {
+      @include max-screen($mobile-medium-breakpoint) {
         float: none;
         margin-right: 0;
       }
@@ -130,24 +130,24 @@
     &.right {
       float: right;
       margin-left: 1em;
-      @include max-screen($mobile-breakpoint) {
+      @include max-screen($mobile-medium-breakpoint) {
         float: none;
         margin-left: 0;
       }
     }
     &.center {
       margin: 0 auto;
-      @include max-screen($mobile-breakpoint) {
+      @include max-screen($mobile-medium-breakpoint) {
         float: none;
         margin-left: 0;
       }
     }
-    &.half { width: calc(50% - 0.5em); @include max-screen($mobile-breakpoint) { width: auto; }  }
-    &.third { width: calc(33% - 0.5em); @include max-screen($mobile-breakpoint) { width: auto; } }
+    &.half { width: calc(50% - 0.5em); @include max-screen($mobile-medium-breakpoint) { width: auto; }  }
+    &.third { width: calc(33% - 0.5em); @include max-screen($mobile-medium-breakpoint) { width: auto; } }
     &.margin-none { margin: 0; }
-    &.ninety { width: calc(90% - 0.5em); @include max-screen($mobile-breakpoint) { width: auto; } }
-    &.seventyfive { width: calc(75% - 0.5em); @include max-screen($mobile-breakpoint) { width: auto; } }
-    &.forty { width: calc(40% - 0.5em); @include max-screen($mobile-breakpoint) { width: auto; } }
+    &.ninety { width: calc(90% - 0.5em); @include max-screen($mobile-medium-breakpoint) { width: auto; } }
+    &.seventyfive { width: calc(75% - 0.5em); @include max-screen($mobile-medium-breakpoint) { width: auto; } }
+    &.forty { width: calc(40% - 0.5em); @include max-screen($mobile-medium-breakpoint) { width: auto; } }
 
     amp-img {
       margin: 0;

--- a/assets/sass/_tables.scss
+++ b/assets/sass/_tables.scss
@@ -1,6 +1,9 @@
 table {
   border-collapse: collapse;
-  width: 100%;
+  max-width: 100%;
+  display: block;
+  overflow-x: auto;
+  word-break: keep-all;
 }
 
 td, th {
@@ -30,7 +33,7 @@ td.col-thirty {
 
 th.col-twenty,
 td.col-twenty,
- {
+{
   width: 20%;
 }
 
@@ -79,20 +82,5 @@ html, body {
 @include max-screen($tablet-breakpoint) {
     td, th {
       padding: 10px;
-    }
-    td > pre {
-      white-space: pre-line;
-    }
-    td > pre.nopreline {
-      white-space: pre;
-    }
-}
-
-@include min-screen($tablet-breakpoint) {
-    td > pre {
-      white-space: pre-line;
-    }
-    td > pre.nopreline {
-      white-space: pre;
     }
 }


### PR DESCRIPTION
- Fixes #988 - Change table SCSS so that table doesn't scrunch when mobile, it wraps and is scrollable 
  - tested on numerous docs - guides, tuts, and ref docs

- Improve alignment wrapper for images so they don't appear massive on tablet viewport widths, only use width auto for mobile widths (460px and less). Tested in PWA guide and tutorials.