### PR TITLE
Update main page banner to point to AMP Contributor Summit instead of AMP Conf

### DIFF
--- a/views/partials/promo_banner.html
+++ b/views/partials/promo_banner.html
@@ -1,13 +1,13 @@
 <div class="promo">
 
-  <a href="https://www.youtube.com/playlist?list=PLXTOW_XMsIDSl5iyPxgtEI0ts5HfBTH8c" class="left">
+  <a href="https://events.withgoogle.com/amp-contributor-summit/" class="left">
     <div class="description desktop-up">
-      {{_('AMP Conf 2018. Feb 13/14.')}}
+      {{_('AMP Contributor Summit. Sep 25/26.')}}
     </div>
     <div class="description mobile-down">
-      {{_('AMP Conf.')}}
+      {{_('Contributor Summit')}}
     </div>
-    <div class="link">{{_('See all videos')}}</div>
+    <div class="link">{{_('Sign up')}}</div>
   </a>
 
   <a href="{{g.doc('/content/pages/amp-roadshow.html').url.path}}" class="right">
@@ -15,7 +15,7 @@
       {{_('New AMP Roadshows.')}}
     </div>
     <div class="description mobile-down">
-      {{_('AMP Roadshows.')}}
+      {{_('AMP Roadshows')}}
     </div>
     <div class="link">{{_('Sign up')}}</div>
   </a>


### PR DESCRIPTION
Updates the main page banner to point to the AMP Contributor Summit instead of AMP Conf.

I tested on desktop and on simulated mobile devices in Chrome.  It's a bit tight on mobile, but it generally works.