### PR TITLE
Allow inline styles

### DIFF
--- a/content/docs/design/responsive_amp/style_pages.md
+++ b/content/docs/design/responsive_amp/style_pages.md
@@ -10,7 +10,7 @@ but you can’t reference external stylesheets
 (with the exception of [custom fonts](#the-custom-fonts-exception)).
 Also certain styles are disallowed due to performance implications.
 
-All styles must live in the head of the document
+Styles may live in the head of the document or as inline `style` attributes
 (see [Add styles to a page](/docs/guides/responsive_amp.html#add-styles-to-a-page)).
 But you can use CSS preprocessors and templating to build static pages
 to better manage your content.

--- a/content/docs/design/responsive_amp/style_pages.md
+++ b/content/docs/design/responsive_amp/style_pages.md
@@ -8,8 +8,7 @@ toc: true
 Like all web pages, AMP pages are styled with CSS,
 but you can’t reference external stylesheets
 (with the exception of [custom fonts](#the-custom-fonts-exception)).
-Also certain styles are disallowed due to performance implications;
-inline style attributes aren't allowed.
+Also certain styles are disallowed due to performance implications.
 
 All styles must live in the head of the document
 (see [Add styles to a page](/docs/guides/responsive_amp.html#add-styles-to-a-page)).

--- a/content/docs/design/responsive_amp/style_pages.md
+++ b/content/docs/design/responsive_amp/style_pages.md
@@ -35,11 +35,6 @@ The following styles aren’t allowed in AMP pages:
   </thead>
   <tbody>
     <tr>
-      <td data-th="Banned style">Inline style attributes</td>
-      <td data-th="Description">All styles must be defined in the <code>&lt;head&gt;</code> of the page,
-        within a <code>&lt;style amp-custom&gt;</code> tag.</td>
-    </tr>
-    <tr>
       <td data-th="Banned style"><code>!important</code> qualifier </td>
       <td data-th="Description">Usage is not allowed.
       This is a necessary requirement to enable AMP to enforce its element sizing rules.</td>

--- a/content/docs/interaction_dynamic/amp-email-format.md
+++ b/content/docs/interaction_dynamic/amp-email-format.md
@@ -218,7 +218,7 @@ The following is a proposed list of AMP components that are supported in AMP ema
 
 ### Specifying CSS in an AMP document
 
-All CSS in any AMP document must be included in a `<style amp-custom>` tag within the header. Inline style attributes are not allowed in AMP.
+All CSS in any AMP document must be included in a `<style amp-custom>` tag within the header or as inline `style` attributes.
 
 [sourcecode:html]
 ...


### PR DESCRIPTION
Inline styles are now allowed in the AMP validator. They share the same 50KB limit as `<style amp-custom>`. 

We probably should also add some language to https://www.ampproject.org/docs/design/responsive_amp#add-styles-to-a-page.

I'm not sure if there are other places in the docs that reference this. Please update those too! 

/to @bpaduch 