### PR TITLE
Updated documents to include inline styling 

### DIFF
--- a/content/docs/design/responsive_amp.md
+++ b/content/docs/design/responsive_amp.md
@@ -22,7 +22,7 @@ It is super easy to make elements responsive in AMP. Just put `layout="responsiv
 
 ## Add styles to a page
 
-Add all CSS inside a `<style amp-custom>` tag in the head of the document.
+Migrate CSS inside a `<style amp-custom>` tag in the head of the document.
 For example:
 
 [sourcecode:html]
@@ -74,6 +74,14 @@ Check that your styles are supported in AMP;
 some styles aren't for performance reasons
 (see also [Supported CSS](/docs/design/responsive/style_pages.html)).
 {% endcall %}
+
+If needed, AMP also allows inline styles. For example:
+
+[sourcecode:html]
+<body>
+  <p style="color:pink;margin-left:30px;>Hello, Kitty.</p>
+</body>
+[/sourcecode]
 
 ## Layout elements responsively
 

--- a/content/docs/design/responsive_amp.md
+++ b/content/docs/design/responsive_amp.md
@@ -22,7 +22,7 @@ It is super easy to make elements responsive in AMP. Just put `layout="responsiv
 
 ## Add styles to a page
 
-Migrate CSS inside a `<style amp-custom>` tag in the head of the document.
+Add your CSS inside a `<style amp-custom>` tag in the head of the document.
 For example:
 
 [sourcecode:html]

--- a/content/docs/design/responsive_amp.md
+++ b/content/docs/design/responsive_amp.md
@@ -79,7 +79,7 @@ If needed, AMP also allows inline styles. For example:
 
 [sourcecode:html]
 <body>
-  <p style="color:pink;margin-left:30px;>Hello, Kitty.</p>
+  <p style="color:pink;margin-left:30px;">Hello, Kitty.</p>
 </body>
 [/sourcecode]
 

--- a/content/docs/fundamentals/converting/resolving-errors.md
+++ b/content/docs/fundamentals/converting/resolving-errors.md
@@ -114,7 +114,7 @@ Specifically, this error is complaining about the following stylesheet link tag 
 <link href="base.css" rel="stylesheet" />
 ```
 
-The problem is that this is an external stylesheet reference. In AMP, to keep the load times of documents as fast as possible, you cannot include external stylesheets. Instead, all stylesheet rules must be added inline in the AMP document using `<style amp-custom></style>` tags.
+The problem is that this is an external stylesheet reference. In AMP, to keep the load times of documents as fast as possible, you cannot include external stylesheets. Instead, all stylesheet rules must be embedded in the AMP document using `<style amp-custom></style>` tags, or as inline styles.
 
 ```html
 <style amp-custom>
@@ -132,7 +132,7 @@ So, let's resolve the error:
 Once again, **reload** the page and verify that the stylesheets error has disappeared.
 
 {% call callout('Note', type='note') %}
-Not only is inline styling required but there is a file size limit of 50 kilobytes for all styling information. You should use CSS preprocessors such as [SASS](http://sass-lang.com/) to minify your CSS before inlining the CSS in your AMP pages.
+Not only is embedded styling required but there is a file size limit of 50 kilobytes for all styling information. You should use CSS preprocessors such as [SASS](http://sass-lang.com/) to minify your CSS before inlining the CSS in your AMP pages.
 {% endcall %}
 
 {% call callout('Important', type='caution') %}

--- a/content/docs/getting_started/create/presentation_layout.md
+++ b/content/docs/getting_started/create/presentation_layout.md
@@ -5,7 +5,7 @@ $order: 2
 
 ## Modify the presentation
 
-AMP pages are web pages; any styling to the page and its elements is done using common CSS properties. Style elements using class or element selectors in an inline stylesheet in the `<head>`, called `<style amp-custom>`:
+AMP pages are web pages; any styling to the page and its elements is done using common CSS properties. Style elements using class or element selectors in an embedded stylesheet in the `<head>`, called `<style amp-custom>`:
 
 [sourcecode:html]
 <style amp-custom>
@@ -20,7 +20,7 @@ AMP pages are web pages; any styling to the page and its elements is done using 
 </style>
 [/sourcecode]
 
-Every AMP page can only have a single embedded stylesheet, and there are certain selectors you’re not allowed to use. [Learn all about styling](/docs/design/responsive/style_pages.html).
+Every AMP page can only have a single embedded stylesheet and inline styles, but there are certain selectors you’re not allowed to use. [Learn all about styling](/docs/design/responsive/style_pages.html).
 
 ## Control the layout
 


### PR DESCRIPTION
AMP now allows inline style attributes in HTML. This request adds this as an option to documentation. 
Contributes to issue #1027