### PR TITLE
Improve KO translation for a menu text.

### DIFF
--- a/translations/ko/LC_MESSAGES/messages.po
+++ b/translations/ko/LC_MESSAGES/messages.po
@@ -298,7 +298,7 @@ msgstr "광고주:<br>캠페인 ROI 향상"
 
 #: /content/docs/ads.md /content/docs/ads/_blueprint.yaml
 msgid "Advertising"
-msgstr "광고하는"
+msgstr "광고"
 
 #: /content/learn/who/amp-ads.yaml
 msgid ""


### PR DESCRIPTION
The menu text for "Advertising" is translated to "광고하는" in KO, which doesn't make sense without an additional noun. The current form is an adjective that expects a noun at the end which is missing. So it looks incomplete. 
<img width="586" alt="screenshot" src="https://user-images.githubusercontent.com/772578/43985134-e22ea004-9cb9-11e8-8c7d-e197c6ace232.png">

Instead, it should be good to make it as "광고" as a noun. Yes, it's the same meaning with "advertisement", but in this case, it's better and it works.
