### PR TITLE
Added Google Tag Manager links to vendors, changed AdWords to Google Ads

### DIFF
--- a/content/docs/analytics/analytics-vendors.md
+++ b/content/docs/analytics/analytics-vendors.md
@@ -150,7 +150,7 @@ Adds support for Google Analytics. More details for adding Google Analytics supp
 
 Type attribute value: N/A
 
-Google Tag Manager is [supported](https://developers.google.com/google-ads/amp/landing-pages#google_tag_manager) in AMP, and a list of supported tags can be found [here](https://support.google.com/tagmanager/answer/6106924). To add Google Tag Manager to your AMP page, follow the instructions [here](https://support.google.com/tagmanager/answer/6103696). Unlike other vendors, Google Tag Manager does not require the `type` attribute to be set.
+Unlike other analytics vendors, Google Tag Manager is a tag management service, and does not require the `type` attribute. Google Tag Manager is [supported](https://developers.google.com/google-ads/amp/landing-pages#google_tag_manager) in AMP.  Consult the Google Tag Manager documentation for [supported tags](https://support.google.com/tagmanager/answer/6106924) and for instructions on [adding Google Tag Manager to your AMP page](https://support.google.com/tagmanager/answer/6103696). 
 
 ### INFOnline / IVW
 

--- a/content/docs/analytics/analytics-vendors.md
+++ b/content/docs/analytics/analytics-vendors.md
@@ -134,17 +134,23 @@ Type attribute value: `gemius`
 
 Adds support for Gemius Audience/Prism analytics. Additionally, the gemius-provided `prefix` and `identifier` variables must be specified. It's also possible to specify the optional variable `extraparams` (key1=value1|key2=value2). More details can be found at [gemius.com](https://www.gemius.com).
 
-### Google AdWords
+### Google Ads
 
 Type attribute value: `googleadwords`
 
-Adds support for Google AdWords conversion tracking and remarketing. See more details in the AdWords help center for [conversion tracking](https://support.google.com/adwords/answer/1722054?hl=en) and [remarketing](https://support.google.com/adwords/answer/2453998?hl=en). Both tags can be used independent of each other.
+Adds support for Google Ads conversion tracking and remarketing. See more details in the Google Ads help center for [conversion tracking](https://support.google.com/adwords/answer/1722054?hl=en) and [remarketing](https://support.google.com/adwords/answer/2453998?hl=en). Both tags can be used independent of each other.
 
 ### Google Analytics
 
 Type attribute value: `googleanalytics`
 
 Adds support for Google Analytics. More details for adding Google Analytics support can be found at [developers.google.com](https://developers.google.com/analytics/devguides/collection/amp-analytics/).
+
+### Google Tag Manager
+
+Type attribute value: N/A
+
+Google Tag Manager is [supported](https://developers.google.com/google-ads/amp/landing-pages#google_tag_manager) in AMP, and a list of supported tags can be found [here](https://support.google.com/tagmanager/answer/6106924). To add Google Tag Manager to your AMP page, follow the instructions [here](https://support.google.com/tagmanager/answer/6103696). Unlike other vendors, Google Tag Manager does not require the `type` attribute to be set.
 
 ### INFOnline / IVW
 


### PR DESCRIPTION
Fixes #1101 

Google AdWords had been rebranded, so this change needs to be reflected across the site. I'm adding in Google Tag Manager for a discussion about how to incorporate it here. Unlike other vendors, it doesn't have a type attribute to set, you simply paste in what GTM gives you, such as:

<!-- Google Tag Manager -->
<amp-analytics config="https://www.googletagmanager.com/amp.json?id=GTM-T5FMS6S&gtm.url=SOURCE_URL" data-credentials="include"></amp-analytics>

Does it fit on this page? If not, where should it go? The ability to use GTM in AMP should be less difficult to discover.