### PR TITLE
Remove Orgin Trial information from amp-story.

### DIFF
--- a/content/docs/getting_started/visual_story/congratulations.md
+++ b/content/docs/getting_started/visual_story/congratulations.md
@@ -21,4 +21,4 @@ Learn more about AMP story from these resources:
 - [amp-story reference documentation](/docs/reference/components/amp-story.html)
 - [AMP story best practices]({{g.doc('/content/docs/fundamentals/amp_story_best_practices.md', locale=doc.locale).url.path}})
 
-Note: The [amp-story](/docs/reference/components/amp-story.html) component is **experimental**. To sign up for the origin trial to publish pages with this component, please visit <a href="http://bit.ly/amp-story-signup">bit.ly/amp-story-signup</a>.
+Note: The [amp-story](/docs/reference/components/amp-story.html) component is **experimental**.


### PR DESCRIPTION
amp-story is no longer on origin trials. The notes have been removed by https://github.com/ampproject/docs/pull/1079. 