### PR TITLE
Update analytics-vendors.md

### DIFF
--- a/content/docs/analytics/analytics-vendors.md
+++ b/content/docs/analytics/analytics-vendors.md
@@ -337,7 +337,7 @@ Adds support for Treasure Data. Configuration details can be found at [treasured
 
 ### Webtrekk
 
-The attribute value ~~`webtrekk`~~ is deprecated (will remove on 31/12/2018) - use `webtrekk_2` instead
+The attribute value ~~`webtrekk`~~ is deprecated (will remove on 31/12/2018) - use `webtrekk_v2` instead
 
 Adds support for Webtrekk. Configuration details can be found at [supportcenter.webtrekk.com](https://supportcenter.webtrekk.com/en/public/amp-analytics.html).
 


### PR DESCRIPTION
It seems the webtrekk documentation was off - it's not 'webtrekk_2' but rather 'webtrekk_v2' instead, see here:

https://github.com/ampproject/amphtml/blob/f49d24c00177048050bbd0911c68190d05df8a3c/examples/analytics-vendors.amp.html#L1326

I've one publisher who lost tracking for a while because of this mismatch, would be good to get this fixed!