### PR TITLE
Fixes for build

### DIFF
--- a/examples/source/advanced/Favorite_Button.html
+++ b/examples/source/advanced/Favorite_Button.html
@@ -2,6 +2,7 @@
 
 category: 'dynamic-content'
 teaserImage: '/static/samples/img/teaser/favorite_button.jpg'
+draft: true
 
 --->
 <!--

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:boilerplate": "cd boilerplate && node build.js",
     "build:local": "NODE_ENV=local npm run build:site",
     "build:playground": "cd playground && webpack --config webpack.config.js --mode production --optimize-minimize --progress",
-    "build:site": "cd platform && node build.js --import",
+    "build:site": "cd platform && node build.js --import --clean-samples",
     "build:staging": "NODE_ENV=staging npm-run-all build:site build:boilerplate build:playground --aggregate-output --parallel",
     "deploy:staging": "gcloud app deploy --project=amp-dev-staging --quiet",
     "log:staging": "gcloud app logs tail -s default --project amp-dev-staging",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:boilerplate": "cd boilerplate && node build.js",
     "build:local": "NODE_ENV=local npm run build:site",
     "build:playground": "cd playground && webpack --config webpack.config.js --mode production --optimize-minimize --progress",
-    "build:site": "cd platform && node build.js -- --import",
+    "build:site": "cd platform && node build.js --import",
     "build:staging": "NODE_ENV=staging npm-run-all build:site build:boilerplate build:playground --aggregate-output --parallel",
     "deploy:staging": "gcloud app deploy --project=amp-dev-staging --quiet",
     "log:staging": "gcloud app logs tail -s default --project amp-dev-staging",

--- a/pages/content/amp-dev/offline.html
+++ b/pages/content/amp-dev/offline.html
@@ -16,7 +16,7 @@ $view: /views/custom.j2
       </div>
       <h1 class="ap-m-biggy-headline">offline</h1>
       <h2 class="ap-m-jumbo-subline">{{ _('Something cut the line.') }}</h2>
-      <p class="ap-m-jumbo-copy">{{ _('You're currently not connected to the internet.') }}</p>
+      <p class="ap-m-jumbo-copy">{{ _('You\'re currently not connected to the internet.') }}</p>
     </div>
   </section>
 </main>

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -108,6 +108,12 @@ class SamplesBuilder {
       stream = stream.pipe(through.obj(async (sample, encoding, callback) => {
         this._log.await(`Building sample ${sample.relative} ...`);
         await this._parseSample(sample.path, sample.relative).then((parsedSample) => {
+          // Skip samples that have draft: true set
+          if (parsedSample.document.metadata.draft) {
+            callback();
+            return;
+          }
+
           // Build various documents and sources that are needed for Grow
           // to successfully render the example and for the playground
           const files = [

--- a/platform/lib/pipeline.js
+++ b/platform/lib/pipeline.js
@@ -215,12 +215,12 @@ class Pipeline {
       // During development start Grow's dev server
       return grow.run().when('Server ready.');
     } else {
-      let deployment = grow.deploy();
+      const deployment = grow.deploy();
 
       deployment.when('Error rendering').then(() => {
         signale.fatal('There were errors rendering the pages.');
         process.exit(1);
-      })
+      });
 
       return deployment.when('Deploying:').then(() => {
         // There is no "easy" way to determine when

--- a/platform/lib/pipeline.js
+++ b/platform/lib/pipeline.js
@@ -215,7 +215,14 @@ class Pipeline {
       // During development start Grow's dev server
       return grow.run().when('Server ready.');
     } else {
-      return grow.deploy().when('Deploying:').then(() => {
+      let deployment = grow.deploy();
+
+      deployment.when('Error rendering').then(() => {
+        signale.fatal('There were errors rendering the pages.');
+        process.exit(1);
+      })
+
+      return deployment.when('Deploying:').then(() => {
         // There is no "easy" way to determine when
         // Grow has finished putting the files in place
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
- If Grow had errors during rendering the process exits with error code now and hinders deployment
- The CLI argument to start import is passed correctly to the script
- Samples builder always builds freshly for a complete build
- Samples builder skips samples marked as draft
- `Favorite_Button.html` has been marked as draft as it uses a mustache template that breaks jijnja2 - this needs to be escaped in the Samples Builder but I don't want to break other things with a rushed RegEx now

Local test build is currently running, I'll give you a hint if it worked.