### PR TITLE
🔧 Enable all languages to be built

### DIFF
--- a/platform/config/podspec.yaml
+++ b/platform/config/podspec.yaml
@@ -7,16 +7,16 @@ localization:
   locales:
   - en
   - fr
-  # - ar
-  # - es
-  # - it
-  # - id
-  # - ja
-  # - ko
-  # - pt_BR
-  # - ru
-  # - tr
-  # - zh_CN
+  - ar
+  - es
+  - it
+  - id
+  - ja
+  - ko
+  - pt_BR
+  - ru
+  - tr
+  - zh_CN
 
 sitemap:
   enabled: yes


### PR DESCRIPTION
Uncomments languages in the podspec template. Through this change all language versions are built when performing a build.