### PR TITLE
💄 Decrease space in front of rolling formats

### DIFF
--- a/frontend/scss/components/molecules/rolling-formats.scss
+++ b/frontend/scss/components/molecules/rolling-formats.scss
@@ -8,6 +8,14 @@ $showTime: 2s;
 .#{molecule('rolling-formats')} {
   display: inline-block;
 
+  &-space {
+
+    @media (min-width: 768px) {
+      display: inline-block;
+      width: 10px;
+    }
+  }
+
   &-list {
     display: grid;
     grid-template-columns: 1fr;
@@ -23,6 +31,15 @@ $showTime: 2s;
     animation-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1);
     animation-iteration-count: infinite;
     animation-fill-mode: backwards;
+
+    @media (min-width: 768px) {
+      margin-left: auto;
+    }
+
+    @media (min-width: 1024px) {
+      margin-left: 0;
+    }
+
 
     &:nth-child(2) { animation-delay: $showTime * 4 * 1 / 4; }
     &:nth-child(3) { animation-delay: $showTime * 4 * 1 / 2; }

--- a/frontend/templates/views/partials/rolling-formats.j2
+++ b/frontend/templates/views/partials/rolling-formats.j2
@@ -2,10 +2,11 @@
 
 {% set formats = ['websites', 'stories', 'ads', 'emails'] %}
 
+<span class="ap-m-rolling-formats-space"></span>
 <div class="ap-m-rolling-formats">
   <div class="ap-m-rolling-formats-list">
     {% for format in formats %}
-    <span class="ap-m-rolling-formats-item">&ensp;{{ format }}.</span>
+    <span class="ap-m-rolling-formats-item">{{ format }}.</span>
     {% endfor %}
   </div>
 </div>


### PR DESCRIPTION
This should get rid of the extra space in front of the rolling-formats on the homepage 😉 