### PR TITLE
Update page title for homepage

### DIFF
--- a/frontend/templates/layouts/default.j2
+++ b/frontend/templates/layouts/default.j2
@@ -24,7 +24,12 @@
     {% block head %}
     <meta charset="utf-8"/>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
-    <title>{{ doc.title }}</title>
+    {# If there is a special title use that one without a postfix #}
+    {% if doc.titles('title') != doc.title %}
+    <title>{{ doc.titles('title') }}</title>
+    {% else %}
+    <title>{{ doc.title }} - AMP</title>
+    {% endif %}
     {% if podspec.env.name == 'development' %}
     <link rel="shortcut icon" href="/static/img/favicon-local.png"/>
     {% else %}
@@ -125,7 +130,7 @@
     {% if podspec.env.name == 'staging' or podspec.env.name == 'development' %}
     {% do doc.styles.addCssFile('/css/components/molecules/banner.css') %}
     <div class="ap-m-banner" style="position: fixed; bottom: 0; z-index: 999; width: 100%; background: #C8114D;">
-      This is a staging version of 
+      This is a staging version of
       <a href="http://amp.dev" class="ap-m-banner-link">
         https://amp.dev
       </a> [{{ podspec.env.name|upper }}].

--- a/pages/content/amp-dev/index.html
+++ b/pages/content/amp-dev/index.html
@@ -1,5 +1,7 @@
 ---
 $title: Start
+$titles:
+  title: AMP - a web component framework to easily create user-first web experiences
 $view: /views/custom.j2
 
 news: !g.yaml /content/shared/data/blog.yaml


### PR DESCRIPTION
This one fixes #1389 while at the same time introducing the functionality to define special titles for specific pages by using 

```yaml
---
$title: Start
$titles:
  title: AMP - a web component framework to easily create user-first web experiences
```

in their frontmatter. At the same time all page titles just defined by `$title` will be postfixed by " - AMP" just like on ampproject.org.