### PR TITLE
Playground fixes

### DIFF
--- a/platform/config/environments/production.json
+++ b/platform/config/environments/production.json
@@ -8,7 +8,7 @@
 		},
 		"api": {
 			"scheme": "https",
-			"host": "api-dot-amp-dev-staging.appspot.com",
+			"host": "amp-dev-230314.appspot.com",
 			"port": ""
 		},
 		"platform": {

--- a/playground/src/document/controller.js
+++ b/playground/src/document/controller.js
@@ -33,7 +33,7 @@ export default class DocumentController {
     this.editor = editor;
     this.srcDoc = PlaygroundDocument.createDocument();
     this._setupDocument(runtime).then(() => {
-      this.editor.setCursorAndFocus(params.get('line', 0), 1);
+      this.editor.scrollToLine(params.get('line', 0), 1);
     });
     this._configureStatemachine();
     events.subscribe(

--- a/playground/src/editor/editor.js
+++ b/playground/src/editor/editor.js
@@ -136,8 +136,12 @@ class Editor {
     return this.codeMirror.getValue();
   }
 
+  scrollToLine(line) {
+    this.codeMirror.setCursor(line - 1, 1);
+  }
+
   setCursorAndFocus(line, col) {
-    this.codeMirror.setCursor(line - 1, col, {'scroll': true});
+    this.codeMirror.setCursor(line - 1, col);
     this.codeMirror.focus();
   }
 

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -68,7 +68,7 @@ module.exports = (env, argv) => {
         rel: 'preload',
         include: ['main'],
       }),
-      new CleanWebpackPlugin([path.join(__dirname, 'dist')]),
+      new CleanWebpackPlugin(),
     ],
     module: {
       rules: [


### PR DESCRIPTION
Two important fixes:

1. Use the appspot domain for embeds (serves the same content as amp.dev)
2. Avoid that homepage jumps to playground