### PR TITLE
Created an amp-recaptcha-input example

### DIFF
--- a/examples/source/components/amp-recaptcha-input.html
+++ b/examples/source/components/amp-recaptcha-input.html
@@ -25,18 +25,10 @@ experiments:
 <style amp-custom>
   :root {
     --color-primary: #005AF0;
-    --color-secondary: #00DCC0;
-    --color-text-light: #fff;
-    --color-text-dark: #000;
     --color-error: #B00020;
-    --color-bg-light: #FAFAFC;
 
     --space-1: .5rem;  /* 8px */
     --space-2: 1rem;   /* 16px */
-    --space-3: 1.5rem; /* 24px */
-    --space-4: 2rem;   /* 32px */
-
-    --box-shadow-1: 0 1px 1px 0 rgba(0,0,0,.14), 0 1px 1px -1px rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12);
   }
 
   #amp-recaptcha-input-form {

--- a/examples/source/components/amp-recaptcha-input.html
+++ b/examples/source/components/amp-recaptcha-input.html
@@ -13,7 +13,7 @@ experiments:
 <head>
   <meta charset="utf-8">
   <title>amp-recaptcha-input</title>
-  <link rel="canonical" href="s/host/hosts.platform/components/amp-recaptcha-input/">
+  <link rel="canonical" href="<%host.platform%>/components/amp-recaptcha-input/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
@@ -23,6 +23,22 @@ experiments:
   <script async custom-element="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 <style amp-custom>
+  :root {
+    --color-primary: #005AF0;
+    --color-secondary: #00DCC0;
+    --color-text-light: #fff;
+    --color-text-dark: #000;
+    --color-error: #B00020;
+    --color-bg-light: #FAFAFC;
+
+    --space-1: .5rem;  /* 8px */
+    --space-2: 1rem;   /* 16px */
+    --space-3: 1.5rem; /* 24px */
+    --space-4: 2rem;   /* 32px */
+
+    --box-shadow-1: 0 1px 1px 0 rgba(0,0,0,.14), 0 1px 1px -1px rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12);
+  }
+
   #amp-recaptcha-input-form {
     width: 100%;
     padding: var(--space-1);

--- a/examples/source/components/amp-recaptcha-input.html
+++ b/examples/source/components/amp-recaptcha-input.html
@@ -1,8 +1,7 @@
-<!--
-  ## Experimental
-
-  This component requires the following experiment: `amp-recaptcha-input`. Please read about [experimental features here](https://www.ampproject.org/docs/reference/experimental).
--->
+<!---
+experiments:
+  - amp-recaptcha-input
+--->
 <!--
   ## Introduction
 
@@ -14,7 +13,7 @@
 <head>
   <meta charset="utf-8">
   <title>amp-recaptcha-input</title>
-  <link rel="canonical" href="<%host%>/components/amp-recaptcha-input/">
+  <link rel="canonical" href="s/host/hosts.platform/components/amp-recaptcha-input/">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- ## Setup -->
@@ -24,62 +23,41 @@
   <script async custom-element="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 <style amp-custom>
-  form {
+  #amp-recaptcha-input-form {
     width: 100%;
-    height: 300px;
-    overflow: auto;
+    padding: var(--space-1);
   }
 
-  form.amp-form-submit-success [submit-success],
-  form.amp-form-submit-error [submit-error]{
+  #amp-recaptcha-input-form.amp-form-submit-success [submit-success],
+  #amp-recaptcha-input-form.amp-form-submit-error [submit-error]{
     width: 100%;
-    margin-top: 16px;
+    margin-top: var(--space-2);
   }
 
-  form.amp-form-submit-success [submit-success] {
-    color: green;
+  #amp-recaptcha-input-form.amp-form-submit-success [submit-success] {
+    color: var(--color-primary);
   }
 
-  form.amp-form-submit-success [submit-success] div {
-    margin-top: 10px;
-    margin-bottom: 10px;
+  #amp-recaptcha-input-form.amp-form-submit-success [submit-success] div {
+    margin-top: var(--space-1);
+    margin-bottom: var(--space-1);
     word-break: break-all;
   }
 
-  form.amp-form-submit-error [submit-error] {
-    color: red;
+  #amp-recaptcha-input-form.amp-form-submit-error [submit-error] {
+    color: var(--color-error);
   }
 
-  fieldset {
-    margin-top: 10px;
+  #amp-recaptcha-input-form > fieldset {
+    margin-top: var(--space-1);
   }
 
-  @keyframes donut-spin {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-
-  .donut {
-    display: inline-block;
-    border: 4px solid rgba(0, 0, 0, 0.1);
-    border-left-color: #7983ff;
-    border-radius: 50%;
-    width: 30px;
-    height: 30px;
-    animation: donut-spin 1.2s linear infinite;
-  }
-
-  .loading-spinner {
+  .loading-message {
     display: none;
-    text-align: center;
-    margin: 5px;
+    margin-top: var(--space-1);
   }
 
-  form.amp-form-submitting > .loading-spinner {
+  #amp-recaptcha-input-form.amp-form-submitting > .loading-message {
     display: block;
   }
 </style>
@@ -89,7 +67,7 @@
 
   <!-- ## Basic usage -->
     <!-- POST Form request, that responds with the resolved recaptcha items. See the [reference documentation](https://amp.dev/documentation/components/reference/amp-recaptcha-input.html) for a walkthrough on the corresponding `grecaptcha` calls. -->
-  <form method="POST" action-xhr="https://torch2424-amp-glitch-express.glitch.me/api/recaptcha" target="_top">
+  <form id="amp-recaptcha-input-form" method="POST" action-xhr="https://torch2424-amp-glitch-express.glitch.me/api/recaptcha" target="_top">
     <fieldset>
       <label>
         <span>Search for</span>
@@ -100,9 +78,8 @@
       </amp-recaptcha-input>
     </fieldset>
 
-    <div class="loading-spinner">
-      <div class="donut">
-      </div>
+    <div class="loading-message">
+      Loading...
     </div>
 
     <div submit-success>

--- a/examples/source/components/amp-recaptcha-input.html
+++ b/examples/source/components/amp-recaptcha-input.html
@@ -1,4 +1,9 @@
 <!--
+  ## Experimental
+
+  This component requires the following experiment: `amp-recaptcha-input`. Please read about [experimental features here](https://www.ampproject.org/docs/reference/experimental).
+-->
+<!--
   ## Introduction
 
   The [`amp-recaptcha-input`](https://amp.dev/documentation/components/reference/amp-recaptcha-input.html) component appends a [reCAPTCHA v3](https://developers.google.com/recaptcha/docs/v3) token to AMP form submissions. `amp-recaptcha-input` does this by creating an iframe to load the reCAPTCHA v3 api script using the provided site key, and calling `grecaptcha.execute` with the provided site key and action.

--- a/examples/source/components/amp-recaptcha-input.html
+++ b/examples/source/components/amp-recaptcha-input.html
@@ -1,0 +1,121 @@
+<!--
+  ## Introduction
+
+  The [`amp-recaptcha-input`](https://amp.dev/documentation/components/reference/amp-recaptcha-input.html) component appends a [reCAPTCHA v3](https://developers.google.com/recaptcha/docs/v3) token to AMP form submissions. `amp-recaptcha-input` does this by creating an iframe to load the reCAPTCHA v3 api script using the provided site key, and calling `grecaptcha.execute` with the provided site key and action.
+-->
+<!-- -->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>amp-recaptcha-input</title>
+  <link rel="canonical" href="<%host%>/components/amp-recaptcha-input/">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <!-- ## Setup -->
+    <!-- Import the amp-recaptcha-input component, on an AMP Page using [AMP Form](https://amp.dev/documentation/components/reference/amp-form.html) -->
+  <script async custom-element="amp-recaptcha-input" src="https://cdn.ampproject.org/v0/amp-recaptcha-input-0.1.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async custom-element="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.2.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+<style amp-custom>
+  form {
+    width: 100%;
+    height: 300px;
+    overflow: auto;
+  }
+
+  form.amp-form-submit-success [submit-success],
+  form.amp-form-submit-error [submit-error]{
+    width: 100%;
+    margin-top: 16px;
+  }
+
+  form.amp-form-submit-success [submit-success] {
+    color: green;
+  }
+
+  form.amp-form-submit-success [submit-success] div {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    word-break: break-all;
+  }
+
+  form.amp-form-submit-error [submit-error] {
+    color: red;
+  }
+
+  fieldset {
+    margin-top: 10px;
+  }
+
+  @keyframes donut-spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  .donut {
+    display: inline-block;
+    border: 4px solid rgba(0, 0, 0, 0.1);
+    border-left-color: #7983ff;
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    animation: donut-spin 1.2s linear infinite;
+  }
+
+  .loading-spinner {
+    display: none;
+    text-align: center;
+    margin: 5px;
+  }
+
+  form.amp-form-submitting > .loading-spinner {
+    display: block;
+  }
+</style>
+
+</head>
+<body>
+
+  <!-- ## Basic usage -->
+    <!-- POST Form request, that responds with the resolved recaptcha items. See the [reference documentation](https://amp.dev/documentation/components/reference/amp-recaptcha-input.html) for a walkthrough on the corresponding `grecaptcha` calls. -->
+  <form method="POST" action-xhr="https://torch2424-amp-glitch-express.glitch.me/api/recaptcha" target="_top">
+    <fieldset>
+      <label>
+        <span>Search for</span>
+        <input type="search" name="term" required>
+      </label>
+      <input name="submit-button" type="submit" value="Search">
+      <amp-recaptcha-input layout="nodisplay" name="recaptcha_token" data-sitekey="6LebBGoUAAAAAHbj1oeZMBU_rze_CutlbyzpH8VE" data-action="recaptcha_example">
+      </amp-recaptcha-input>
+    </fieldset>
+
+    <div class="loading-spinner">
+      <div class="donut">
+      </div>
+    </div>
+
+    <div submit-success>
+      <template type="amp-mustache">
+        <h1>You searched for: {{term}}</h1>
+        <div><b>Score:</b> {{score}}</div>
+        <div><b>Recaptcha token:</b> {{recaptcha_token}}</div>
+        <div><b>Action:</b> {{action}}</div>
+      </template>
+    </div>
+
+    <div submit-error>
+      <template type="amp-mustache">
+        <h1>Error! Please check the JS Console in your dev tools.</h1>
+        <p>{{message}}</p>
+      </template>
+    </div>
+  </form>
+
+</body>
+</html>


### PR DESCRIPTION
This creates an example for the upcoming `amp-recaptcha-input`. However, this requires a backend, and is currently using [my glitch AMP recaptcha endpoint](https://glitch.com/edit/#!/torch2424-amp-glitch-express). Waiting for some direction on how to implement this in this project's express server

# Notes

cc @sebastianbenz

* Want me to open a PR in ABE as well? If anything, I can leave the ABE on glitch, and then write the glitch endpoint here?

* The experiment blurb was written by me. Please let me know if there is a new way of handling this. (The old way from ABE didn't work).

# Example

![ampdevrecaptchaexample](https://user-images.githubusercontent.com/1448289/53775041-c9f03780-3ea5-11e9-8125-66694d7a97ad.gif)
