### PR TITLE
🐛 kpi list scrolling issue

### DIFF
--- a/frontend/scss/components/organisms/kpi-list.scss
+++ b/frontend/scss/components/organisms/kpi-list.scss
@@ -26,6 +26,7 @@
     &.#{utility('container')} {
       flex-wrap: nowrap;
       padding: 0;
+      overflow-x: scroll;
 
       @media (min-width: 768px) {
         padding: 0 30px;


### PR DESCRIPTION
Kpi list was unscrollable across success stories and other pages that used the organism. The issue is fixed with an overflow scroll feature, but should be replaced in the future with amp-carousel if/when a responsive layout is supported by the carousel type. Should solve the first issue in #1548 