### PR TITLE
Perf documentation landing pages.

### DIFF
--- a/frontend/scss/components/organisms/resources-grid.scss
+++ b/frontend/scss/components/organisms/resources-grid.scss
@@ -29,7 +29,7 @@
     flex-direction: column;
   }
   @media (min-width: 930px) {
-    margin: 60px 60px 30px 60px;
+    margin: 0 60px 30px 60px;
   }
   @media (min-width: 1024px) {
     flex-direction: row;

--- a/frontend/templates/views/partials/resources-grid.j2
+++ b/frontend/templates/views/partials/resources-grid.j2
@@ -1,0 +1,28 @@
+{% do doc.styles.addCssFile('/css/components/organisms/resources-grid.css') %}
+<section class="ap--resources-grid">
+  <h2 class="ap-o-resources-grid-text">Useful resources</h2>
+  <a href="{{g.doc('/content/amp-dev/documentation/components/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
+    <div class="ap-a-ico ap-o-resources-grid-card-icon">
+      {% do doc.icons.useIcon('/icons/code.svg') %}
+      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#code"></use></svg>
+    </div>
+    <h4 class="ap-o-resources-grid-card-headline">Components</h4>
+    <p class="ap-o-resources-grid-card-copy">The complete documented AMP library and its referencees.</p>
+  </a>
+  <a href="{{g.doc('/content/amp-dev/documentation/examples/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
+    <div class="ap-a-ico ap-o-resources-grid-card-icon">
+      {% do doc.icons.useIcon('/icons/examples-flyout.svg') %}
+      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#examples-flyout"></use></svg>
+    </div>
+    <h4 class="ap-o-resources-grid-card-headline">Examples</h4>
+    <p class="ap-o-resources-grid-card-copy">The fastest way to learn is to peak over the tangible examples.</p>
+  </a>
+  <a href="{{g.doc('/content/amp-dev/documentation/templates/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
+    <div class="ap-a-ico ap-o-resources-grid-card-icon">
+      {% do doc.icons.useIcon('/icons/templates.svg') %}
+      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#template"></use></svg>
+    </div>
+    <h4 class="ap-o-resources-grid-card-headline">Templates</h4>
+    <p class="ap-o-resources-grid-card-copy">Don't want to start from scratch? Start with a ready-made design.</p>
+  </a>
+</section>

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/index.ads.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/index.ads.html
@@ -12,8 +12,8 @@ $hidden: true
 ---
 
 <section class="ap--section">
-  <h1>Build websites with AMP!</h1>
-  <p>Here you can find everything you need to build AMP experiences. The sidebar on the left shows you all resources for building <strong>AMP websites.</strong></p>
+  <h1>Build ads with AMP!</h1>
+  <p>Here you can find everything you need to build AMP experiences. The sidebar on the left shows you all resources for building <strong>AMP ads.</strong></p>
   <p>But you can also use AMP to build one of these:</p>
 </section>
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/index.ads.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/index.ads.html
@@ -66,6 +66,8 @@ $hidden: true
   </div>
 </section>
 
+{% include '/views/partials/resources-grid.j2' %}
+
 {% do doc.styles.addCssFile('/css/components/organisms/card-grid.css') %}
 <section class="ap--card-grid">
   <h2 class="ap-o-card-grid-text">AMP's development workflow</h2>
@@ -133,35 +135,6 @@ $hidden: true
       <span class="ap-m-lnk-text">Style & layout</span>
     </a>
   </div>
-</section>
-
-{% do doc.styles.addCssFile('/css/components/organisms/resources-grid.css') %}
-<section class="ap--resources-grid">
-  <h2 class="ap-o-resources-grid-text">Useful resources</h2>
-  <a href="{{g.doc('/content/amp-dev/documentation/components/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/code.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#code"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Components</h4>
-    <p class="ap-o-resources-grid-card-copy">The complete documented AMP library and its referencees.</p>
-  </a>
-  <a href="{{g.doc('/content/amp-dev/documentation/examples/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/examples-flyout.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#examples-flyout"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Examples</h4>
-    <p class="ap-o-resources-grid-card-copy">The fastest way to learn is to peak over the tangible examples.</p>
-  </a>
-  <a href="{{g.doc('/content/amp-dev/documentation/templates/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/templates.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#template"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Templates</h4>
-    <p class="ap-o-resources-grid-card-copy">Don't want to start from scratch? Start with a ready-made design.</p>
-  </a>
 </section>
 
 {% do doc.styles.addCssFile('/css/components/organisms/video-slider.css') %}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/index.email.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/index.email.html
@@ -66,6 +66,8 @@ $hidden: true
   </div>
 </section>
 
+{% include '/views/partials/resources-grid.j2' %}
+
 {% do doc.styles.addCssFile('/css/components/organisms/card-grid.css') %}
 <section class="ap--card-grid">
   <h2 class="ap-o-card-grid-text">AMP's development workflow</h2>
@@ -133,35 +135,6 @@ $hidden: true
       <span class="ap-m-lnk-text">Style & layout</span>
     </a>
   </div>
-</section>
-
-{% do doc.styles.addCssFile('/css/components/organisms/resources-grid.css') %}
-<section class="ap--resources-grid">
-  <h2 class="ap-o-resources-grid-text">Useful resources</h2>
-  <a href="{{g.doc('/content/amp-dev/documentation/components/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/code.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#code"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Components</h4>
-    <p class="ap-o-resources-grid-card-copy">The complete documented AMP library and its referencees.</p>
-  </a>
-  <a href="{{g.doc('/content/amp-dev/documentation/examples/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/examples-flyout.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#examples-flyout"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Examples</h4>
-    <p class="ap-o-resources-grid-card-copy">The fastest way to learn is to peak over the tangible examples.</p>
-  </a>
-  <a href="{{g.doc('/content/amp-dev/documentation/templates/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/templates.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#template"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Templates</h4>
-    <p class="ap-o-resources-grid-card-copy">Don't want to start from scratch? Start with a ready-made design.</p>
-  </a>
 </section>
 
 {% do doc.styles.addCssFile('/css/components/organisms/video-slider.css') %}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/index.email.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/index.email.html
@@ -12,8 +12,8 @@ $hidden: true
 ---
 
 <section class="ap--section">
-  <h1>Build websites with AMP!</h1>
-  <p>Here you can find everything you need to build AMP experiences. The sidebar on the left shows you all resources for building <strong>AMP websites.</strong></p>
+  <h1>Build emails with AMP!</h1>
+  <p>Here you can find everything you need to build AMP experiences. The sidebar on the left shows you all resources for building <strong>AMP emails.</strong></p>
   <p>But you can also use AMP to build one of these:</p>
 </section>
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/index.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/index.html
@@ -67,6 +67,8 @@ flyout:
   </div>
 </section>
 
+{% include '/views/partials/resources-grid.j2' %}
+
 {% do doc.styles.addCssFile('/css/components/organisms/card-grid.css') %}
 <section class="ap--card-grid">
   <h2 class="ap-o-card-grid-text">AMP's development workflow</h2>
@@ -159,35 +161,6 @@ flyout:
       </div>
     </div>
   </div>
-</section>
-
-{% do doc.styles.addCssFile('/css/components/organisms/resources-grid.css') %}
-<section class="ap--resources-grid">
-  <h2 class="ap-o-resources-grid-text">Useful resources</h2>
-  <a href="{{g.doc('/content/amp-dev/documentation/components/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/code.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#code"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Components</h4>
-    <p class="ap-o-resources-grid-card-copy">The complete documented AMP library and its referencees.</p>
-  </a>
-  <a href="{{g.doc('/content/amp-dev/documentation/examples/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/examples-flyout.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#examples-flyout"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Examples</h4>
-    <p class="ap-o-resources-grid-card-copy">The fastest way to learn is to peak over the tangible examples.</p>
-  </a>
-  <a href="{{g.doc('/content/amp-dev/documentation/templates/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/templates.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#template"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Templates</h4>
-    <p class="ap-o-resources-grid-card-copy">Don't want to start from scratch? Start with a ready-made design.</p>
-  </a>
 </section>
 
 {% do doc.styles.addCssFile('/css/components/organisms/video-slider.css') %}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/index.stories.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/index.stories.html
@@ -66,6 +66,8 @@ $hidden: true
   </div>
 </section>
 
+{% include '/views/partials/resources-grid.j2' %}
+
 {% do doc.styles.addCssFile('/css/components/organisms/card-grid.css') %}
 <section class="ap--card-grid">
   <h2 class="ap-o-card-grid-text">AMP's development workflow</h2>
@@ -133,35 +135,6 @@ $hidden: true
       <span class="ap-m-lnk-text">Style & layout</span>
     </a>
   </div>
-</section>
-
-{% do doc.styles.addCssFile('/css/components/organisms/resources-grid.css') %}
-<section class="ap--resources-grid">
-  <h2 class="ap-o-resources-grid-text">Useful resources</h2>
-  <a href="{{g.doc('/content/amp-dev/documentation/components/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/code.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#code"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Components</h4>
-    <p class="ap-o-resources-grid-card-copy">The complete documented AMP library and its referencees.</p>
-  </a>
-  <a href="{{g.doc('/content/amp-dev/documentation/examples/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/examples-flyout.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#examples-flyout"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Examples</h4>
-    <p class="ap-o-resources-grid-card-copy">The fastest way to learn is to peak over the tangible examples.</p>
-  </a>
-  <a href="{{g.doc('/content/amp-dev/documentation/templates/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/templates.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#template"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Templates</h4>
-    <p class="ap-o-resources-grid-card-copy">Don't want to start from scratch? Start with a ready-made design.</p>
-  </a>
 </section>
 
 {% do doc.styles.addCssFile('/css/components/organisms/video-slider.css') %}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/index.stories.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/index.stories.html
@@ -12,8 +12,8 @@ $hidden: true
 ---
 
 <section class="ap--section">
-  <h1>Build websites with AMP!</h1>
-  <p>Here you can find everything you need to build AMP experiences. The sidebar on the left shows you all resources for building <strong>AMP websites.</strong></p>
+  <h1>Build stories with AMP!</h1>
+  <p>Here you can find everything you need to build AMP experiences. The sidebar on the left shows you all resources for building <strong>AMP stories.</strong></p>
   <p>But you can also use AMP to build one of these:</p>
 </section>
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/index.websites.html
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/index.websites.html
@@ -64,6 +64,8 @@ $hidden: true
   </div>
 </section>
 
+{% include '/views/partials/resources-grid.j2' %}
+
 {% do doc.styles.addCssFile('/css/components/organisms/card-grid.css') %}
 <section class="ap--card-grid">
   <h2 class="ap-o-card-grid-text">AMP's development workflow</h2>
@@ -156,35 +158,6 @@ $hidden: true
       </div>
     </div>
   </div>
-</section>
-
-{% do doc.styles.addCssFile('/css/components/organisms/resources-grid.css') %}
-<section class="ap--resources-grid">
-  <h2 class="ap-o-resources-grid-text">Useful resources</h2>
-  <a href="{{g.doc('/content/amp-dev/documentation/components/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/code.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#code"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Components</h4>
-    <p class="ap-o-resources-grid-card-copy">The complete documented AMP library and its referencees.</p>
-  </a>
-  <a href="{{g.doc('/content/amp-dev/documentation/examples/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/examples-flyout.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#examples-flyout"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Examples</h4>
-    <p class="ap-o-resources-grid-card-copy">The fastest way to learn is to peak over the tangible examples.</p>
-  </a>
-  <a href="{{g.doc('/content/amp-dev/documentation/templates/index.html', locale=doc.locale).url.path}}" class="ap-o-resources-grid-card">
-    <div class="ap-a-ico ap-o-resources-grid-card-icon">
-      {% do doc.icons.useIcon('/icons/templates.svg') %}
-      <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#template"></use></svg>
-    </div>
-    <h4 class="ap-o-resources-grid-card-headline">Templates</h4>
-    <p class="ap-o-resources-grid-card-copy">Don't want to start from scratch? Start with a ready-made design.</p>
-  </a>
 </section>
 
 {% do doc.styles.addCssFile('/css/components/organisms/video-slider.css') %}

--- a/platform/lib/routers/pages.js
+++ b/platform/lib/routers/pages.js
@@ -183,8 +183,16 @@ if (!config.isDevMode()) {
     }
 
     try {
+      // Check if there's a manually filtered variant ...
+      const format = getFilteredFormat(request);
+      const manualRequestPath = requestPath.replace('.html', `.${format}.html`);
+      if (fs.existsSync(utils.project.pagePath(manualRequestPath))) {
+        // ... and if there is one vend this
+        requestPath = manualRequestPath;
+      }
+
       const page = await readFileAsync(utils.project.pagePath(requestPath));
-      const filteredPage = new FilteredPage(getFilteredFormat(request), page, true);
+      const filteredPage = new FilteredPage(format, page, true);
       response.send(filteredPage.content);
       return next();
     } catch (e) {


### PR DESCRIPTION
This PR currently:

- Fixes the bug that manually filtered variants arent respected
- Puts the resources grid further up in the structure
- Fixes content errors in the introduction texts of the manually filtered pages