### PR TITLE
🐛 Fix various glitches around component overview.

### DIFF
--- a/frontend/scss/components/molecules/teaser-component.scss
+++ b/frontend/scss/components/molecules/teaser-component.scss
@@ -22,7 +22,7 @@
 		& > a {
 			@include teaser-linking;
 			height: 100%;
-			
+
 			&:hover {
 				@include teaser-linking-hover;
 
@@ -54,6 +54,7 @@
 
 			&-title {
 				@include teaser-header-title;
+        font-weight: bold;
 			}
 		}
 

--- a/pages/translations/en/LC_MESSAGES/messages.po
+++ b/pages/translations/en/LC_MESSAGES/messages.po
@@ -10,14 +10,26 @@ msgstr "Guides"
 msgid "advertising-analytics"
 msgstr "Advertising & Analytics"
 
+msgid "ads-analytics"
+msgstr "Advertising & Analytics"
+
 msgid "e-commerce"
 msgstr "E-Commerce"
 
 msgid "interactivity-dynamic-content"
 msgstr "Interactivity & Dynamic Content"
 
+msgid "dynamic-content"
+msgstr "Dynamic Content"
+
 msgid "multimedia-animations"
 msgstr "Multimedia & Animations"
+
+msgid "media"
+msgstr "Multimedia"
+
+msgid "presentation"
+msgstr "Presentation"
 
 msgid "news-publishing"
 msgstr "News & Publishing"
@@ -28,8 +40,17 @@ msgstr "Personalization"
 msgid "style-layout"
 msgstr "Style & Layout"
 
+msgid "layout"
+msgstr "Layout"
+
 msgid "user-consent"
 msgstr "User Consent"
 
+msgid "social"
+msgstr "Social & Sharing"
+
 msgid "visual-effects"
 msgstr "Visual & Effects"
+
+msgid "misc"
+msgstr "Misc"

--- a/platform/lib/build/pageMinifier.js
+++ b/platform/lib/build/pageMinifier.js
@@ -56,7 +56,10 @@ const SELECTOR_REWRITE_SAFE = [
   'ap-o-teaser-grid',
 ];
 
-const SELECTOR_REWRITE_EXCLUDED_PATHS = /\/documentation\/examples.*/;
+// Do not rewrite all example pages as users might need correct source code
+// for reference, ignore componets overview specifically as it relies on the
+// ap-m-teaser selector for filtering.
+const SELECTOR_REWRITE_EXCLUDED_PATHS = /\/documentation\/examples.*|\/documentation\/components\.html/;
 
 class PageMinifier {
   constructor() {

--- a/platform/lib/common/filteredPage.js
+++ b/platform/lib/common/filteredPage.js
@@ -204,7 +204,7 @@ class FilteredPage {
     this._dom('.ap-m-filter-bubble').each((index, filterBubble) => {
       filterBubble = this._dom(filterBubble);
       const category = filterBubble.data('category');
-      if (!this._dom(`.ap-m-teaser[data-category="${category}"]`).length) {
+      if (!this._dom(`.ap-m-teaser[data-category="${category}"]`).length && category) {
         filterBubble.remove();
       }
     });


### PR DESCRIPTION
- Skips component overview from selector rewriting
- Leaves "All" filter intact
- Correctly removes non-format-matching teasers
- "Translates" category names for components