### PR TITLE
Add Kenshoo analytics service documentation

### DIFF
--- a/content/docs/analytics/analytics-vendors.md
+++ b/content/docs/analytics/analytics-vendors.md
@@ -187,6 +187,12 @@ Adds support for Keen. Additionally, the following `vars` must be defined:
 
 Use `extraUrlParams` to add more data. Configuration details can be found at [keen.io/docs/api](https://keen.io/docs/api/).
 
+### Kenshoo
+
+Type attribute value: `kenshoo`
+
+Adds support for Kenshoo. More information and configuration details can be found at [helpcenter.kenshoo.com](https://helpcenter.kenshoo.com/hc/en-us/articles/360025260592).
+
 ### Krux
 
 Type attribute value: `krux`


### PR DESCRIPTION
✨  Add [Kenshoo](https://kenshoo.com/)  documentation to the supported Analytics Vendors docs.