### PR TITLE
Update Ja translation of AMP Conf page to show schedule and speakers

### DIFF
--- a/content/pages/amp-conf@ja.html
+++ b/content/pages/amp-conf@ja.html
@@ -44,20 +44,110 @@
   <div class="wrapper">
     <h3 id="schedule">スケジュール</h3>
 
-    <p>詳細なスケジュールはまもなく発表されます。また、CFP の受付を開始しましたので（期日：2019年2月14日）、何か AMP についてコミュニティにシェアすべきテーマがありましたらぜひともお申し込みください。登壇経験は問いません！お待ちしております！</p>
+    <p class="note">このアジェンダは現段階のもので、今後更にセッションが追加されたり、時間や内容は変更される可能性があります。</p>
 
-    <p><a href="https://goo.gl/forms/bWdzWs28nUrC6Fq13" class="button">トークプロポーザルを送信する</a></p>
+    {% macro render_session(item) -%}
+
+        {% if conf.speakers[item.speaker] %}
+        <span class="image">{% if conf.speakers[item.speaker].pic %}<amp-img src="{{ conf.speakers[item.speaker].pic }}" width="100" height="100"></amp-img>{% endif %}</span>
+        {% endif %}
+
+        {% if item.speakers %}
+            {% for speaker in item.speakers if conf.speakers[speaker]  %}
+            <span class="image multiple">{% if conf.speakers[speaker].pic %}<amp-img src="{{ conf.speakers[speaker].pic }}" width="60" height="60"></amp-img>{% endif %}</span>
+            {% endfor %}
+        {% endif %}
+
+        <time>{{ item.time }}</time>
+        <div>
+            <h5 class="{{ item.type }}">{{ item.title }}</h5>
+            {% if conf.speakers[item.speaker] %}
+            <small><a href="#{{ item.speaker }}">{{ conf.speakers[item.speaker].name }}, {{ conf.speakers[item.speaker].company }}</a></small>
+            {% endif %}
+            {% if item.speakers %}
+                {% if conf.speakers[item.moderator] %}
+                    <small><a href="#{{ item.moderator }}">{{ conf.speakers[item.moderator].name }}, {{ conf.speakers[item.moderator].company }} (Moderator)</a></small>
+                {% endif %}
+                {% for speaker in item.speakers %}
+                    {% if conf.speakers[speaker] %}
+                    <small><a href="#{{ speaker }}">{{ conf.speakers[speaker].name }}, {{ conf.speakers[speaker].company }}</a></small>
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+            {% if item.description %}
+            <p>{{ item.description }}</p>
+            {% endif %}
+            {% if item.workshops %}
+                <ul class="workshops">
+                {% for workshop in item.workshops %}
+                    <li>
+                        <h6>{{ workshop.title }}</h6>
+                    </li>
+                {% endfor %}
+                </ul>
+            {% endif %}
+        </div>
+
+    {%- endmacro %}
+
+    <amp-selector role="tablist" layout="container" class="days">
+      <div role="tab" class="tab" selected option="a">Day 1</div>
+      <div role="tabpanel" class="day">
+        <ul class="schedule">
+          {% for item in conf.agenda.day_1 %}
+          <li class="{{ item.type }}">
+            {{ render_session(item) }}
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div role="tab" class="tab" option="b">Day 2</div>
+      <div role="tabpanel" class="day">
+        <ul class="schedule">
+          {% for item in conf.agenda.day_2 %}
+          <li class="{{ item.type }}">
+            {{ render_session(item) }}
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </amp-selector>
 
   </div>
 </section>
 
 <section class="speakers amp-conf-section">
-    <div class="wrapper">
-      <h3 id="speakers">スピーカー</h3>
+  <div class="wrapper">
+    <h3 id="speakers">スピーカー</h3>
 
-      <p>講演者はまもなく発表されます。</p>
+    <ul class="speakers">
+        {% set sortedSpeakers = conf.speakers|sort %}
+        {% for speaker in sortedSpeakers if conf.speakers[speaker].pic %}
+        <li class="card" on="tap:lightbox-{{ speaker }}" role="button" tabindex="0">
+            <span class="image" data-name="{{ conf.speakers[speaker].name }}">{% if conf.speakers[speaker].pic %}<amp-img src="{{ conf.speakers[speaker].pic }}" width="400" height="400" layout="responsive"></amp-img>{% endif %}</span>
+            <div>
+                <h4 id="{{ speaker }}">{{ conf.speakers[speaker].name }}<small>{{ conf.speakers[speaker].company }}</small></h4>
+                {{ conf.speakers[speaker].bio|markdown|safe }}
+            </div>
+        </li>
+        <amp-lightbox id="lightbox-{{ speaker }}" layout="nodisplay">
+          <div class="lightbox" on="tap:lightbox-{{ speaker }}.close" role="button" tabindex="0">
+            <div class="inner-lightbox">
+              <h4 id="{{ speaker }}">{{ conf.speakers[speaker].name }}<small>{{ conf.speakers[speaker].company }}</small></h4>
+              {{ conf.speakers[speaker].bio|markdown|safe }}
+            </div>
+          </div>
+        </amp-lightbox>
+        {% endfor %}
+        <li class="card" role="button" tabindex="0">
+          <span class="image"></span>
+          <div>
+              <h4>More speakers to be announced!</h4>
+          </div>
+      </li>
+    </ul>
 
-  </div>
+</div>
 </section>
 
 <section class="location amp-conf-section">


### PR DESCRIPTION
Hi

Some Japanese developers reached out to me and said there is still no schedule and speakers on the page announcing AMP Conf 2019. 
https://www.ampproject.org/ja/amp-conf/

This change will show the schedule and speakers on the Japanese page. Even though session and speakers info is written in English, it's better than nothing. And, amp.dev doesn't have the Japanese language page so far, it's okay to change only master branch.