### PR TITLE
🐛 Correctly check if document should have a TOC.

### DIFF
--- a/frontend/templates/views/partials/toc.j2
+++ b/frontend/templates/views/partials/toc.j2
@@ -1,6 +1,5 @@
 {% set empty_toc = doc.format.toc == '<div class="toc">\n<ul></ul>\n</div>\n' or not doc.format.toc %}
-
-{% if not empty_toc and (doc.toc or doc.content.find('[TOC]')) %}
+{% if not empty_toc and (doc.toc or doc.content.find('[TOC]')) != -1 %}
 {% do doc.icons.useIcon('icons/contentmenu.svg') %}
 <section class="ap--toc">
   {% do doc.styles.addCssFile('/css/components/atoms/sidebar-toggle.css') %}


### PR DESCRIPTION
Fixes #1686.