### PR TITLE
Create spacing between paragraphs inside notes

### DIFF
--- a/frontend/scss/components/molecules/tip.scss
+++ b/frontend/scss/components/molecules/tip.scss
@@ -63,8 +63,11 @@ $borderSize: 5px;
     }
 
     p {
-      margin-bottom: 0;
       @include txt-2;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
 
     ul {


### PR DESCRIPTION
I took out the `margin-bottom:0`. But then I added that for the last paragraph, so that the spacing only exists _between_ paragraphs.

The only thing that may be undesirable is that sometimes content in notes on amp.dev is surrounded by a blank `<p>` or two. With my change, each `<p>` now has a margin. So the whitespace in the note grows.

Fixes #1685 .