### PR TITLE
Don't put text in lists in a smaller font size.

### DIFF
--- a/frontend/scss/components/atoms/text.scss
+++ b/frontend/scss/components/atoms/text.scss
@@ -47,7 +47,6 @@
   ol {
     @include txt;
     @include txt-p;
-    @include txt-2;
     padding-left: 2em;
     margin: 1.5em 0 2.5em;
 


### PR DESCRIPTION
Remove the rule that gives `<ul>` and `<ol>` `font-size:0.875rem;`

This would close #1684 