### PR TITLE
Don't call next() after serving a page

### DIFF
--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -136,8 +136,10 @@ class Platform {
 
     // handle errors
     this.server.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
-      console.error(err.stack);
-      res.status(500).sendFile('500.html', {root: pagePath()});
+      if (err) {
+        console.error(err.stack);
+        res.status(500).sendFile('500.html', {root: pagePath()});
+      }
     });
     // handle 404s
     this.server.use((req, res, next) => { // eslint-disable-line no-unused-vars

--- a/platform/lib/routers/pages.js
+++ b/platform/lib/routers/pages.js
@@ -194,7 +194,6 @@ if (!config.isDevMode()) {
       const page = await readFileAsync(utils.project.pagePath(requestPath));
       const filteredPage = new FilteredPage(format, page, true);
       response.send(filteredPage.content);
-      return next();
     } catch (e) {
       return next(e);
     }


### PR DESCRIPTION
This fixes the 404 handler being called after serving a page.