### PR TITLE
🐛 Do not use doc.public_path in language selector.

### DIFF
--- a/frontend/templates/views/partials/header.j2
+++ b/frontend/templates/views/partials/header.j2
@@ -101,7 +101,8 @@
         {% for locale in doc.locales if not locale == doc.locale  %}
         {% set localized_doc = doc.localize(locale) %}
         <li class="ap-m-language-selector-list-item">
-          <a class="ap-m-nav-link" href="{{ localized_doc.public_path }}">{{ locale.get_language_name()|capitalize }}</a>
+          {# Need to manually replace as doc.public_path is not available #}
+          <a class="ap-m-nav-link" href="{{ localized_doc.url.path.replace('/index.html', '/') }}">{{ locale.get_language_name()|capitalize }}</a>
         </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
Grow's API is not consistent, therefore the monkey-patch didn't affect that edge case.