### PR TITLE
🐛 fix table cells for responsive assets

### DIFF
--- a/frontend/scss/components/molecules/table.scss
+++ b/frontend/scss/components/molecules/table.scss
@@ -28,11 +28,12 @@ example markup:
 @import '../atoms/_text.scss';
 
 table {
+  table-layout: fixed;
+  width: 100%;
   position: relative;
   border-collapse: collapse;
   padding: 0 0 0 20px;
   margin: 1.5em -20px 2em -20px;
-  max-width: calc(100% + 40px);
   display: block;
   overflow-x: scroll;
   -webkit-overflow-scrolling: touch;
@@ -40,7 +41,6 @@ table {
   @include txt-2;
 
   @media (min-width: 768px){
-    max-width: 100%;
     padding: 0;
     margin: 1.5em 0 2em;
   }
@@ -74,16 +74,17 @@ tbody {
   }
 
   td {
-    padding: 20px;
+    padding: 10px 20px;
     text-align: left;
     vertical-align: top;
+    width: 50%;
 
-    @media (orientation: portrait) and (max-width: 575px) {
-      min-width: 40vw;
+    @media (min-width: 768px){
+      padding: 20px;
+    }
 
-      &:last-child {
-        min-width: 80vw;
-      }
+    @media (min-width: 1024px){
+      width: 25%;
     }
 
     code {


### PR DESCRIPTION
When assets were added to table cells, some assets were smaller or larger than intended to be due to styling across all table cells. This is now fixed with a set width for table cells and the table