### PR TITLE
🐛 Reintroduce HTML extension for built files.

### DIFF
--- a/examples/source/1.components/amp-ad.html
+++ b/examples/source/1.components/amp-ad.html
@@ -1,9 +1,3 @@
-<!---
-
-draft: true
-
---->
-
 <!--
   ## Introduction
 

--- a/examples/source/news-publishing/Live_Blog/Live_Blog.html
+++ b/examples/source/news-publishing/Live_Blog/Live_Blog.html
@@ -3,7 +3,6 @@
 preview: default
 skipValidation: true
 teaserImage: '/static/samples/img/teaser/live_blog.jpg'
-draft: true
 
 --->
 

--- a/pages/content/amp-dev/about/_blueprint.yaml
+++ b/pages/content/amp-dev/about/_blueprint.yaml
@@ -1,8 +1,8 @@
 $title@: About
-$path: /about/{base}
+$path: /about/{base}.html
 $view: /views/default.j2
 $localization:
-  path: /{locale}/about/{base}
+  path: /{locale}/about/{base}.html
 $order: 1
 
 flyout:

--- a/pages/content/amp-dev/about/success-stories/_blueprint.yaml
+++ b/pages/content/amp-dev/about/success-stories/_blueprint.yaml
@@ -1,6 +1,6 @@
 $title@: Success Stories
-$path: /success-stories/{base}
 $view: /views/detail/success-story-detail.j2
+$path: /success-stories/{base}.html
 $localization:
-  path: /{locale}/success-stories/{base}
+  path: /{locale}/success-stories/{base}.html
 $order: 1

--- a/pages/content/amp-dev/community/_blueprint.yaml
+++ b/pages/content/amp-dev/community/_blueprint.yaml
@@ -1,8 +1,8 @@
 $view: /views/default.j2
 $title@: Community
-$path: /community/{base}
+$path: /community/{base}.html
 $localization:
-  path: /{locale}/community/{base}
+  path: /{locale}/community/{base}.html
 $order: 3
 
 flyout:

--- a/pages/content/amp-dev/documentation/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/_blueprint.yaml
@@ -2,7 +2,7 @@ $path: /documentation/{base}
 $view: /views/default.j2
 $title@: Documentation
 $localization:
-  path: /{locale}/documentation/{base}
+  path: /{locale}/documentation/{base}.html
 $order: 2
 
 flyout:

--- a/pages/content/amp-dev/documentation/components/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/components/_blueprint.yaml
@@ -1,6 +1,6 @@
 $title@: Components
 $view: /views/overview/components-detail.j2
-$path: /documentation/components/{base}
+$path: /documentation/components/{base}.html
 $localization:
-  path: /{locale}/documentation/components/{base}
+  path: /{locale}/documentation/components/{base}.html
 $order: 2

--- a/pages/content/amp-dev/documentation/components/reference/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/components/reference/_blueprint.yaml
@@ -1,5 +1,5 @@
 $title@: Components
-$path: /documentation/components/{base}
+$path: /documentation/components/{base}.html
 $localization:
-  path: /{locale}/documentation/components/{base}
+  path: /{locale}/documentation/components/{base}.html
 $view: /views/detail/component-detail.j2

--- a/pages/content/amp-dev/documentation/examples/documentation/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/examples/documentation/_blueprint.yaml
@@ -1,5 +1,5 @@
 $title: Examples documentation
 $view: /views/examples/documentation.j2
-$path: /documentation/examples/{base}
+$path: /documentation/examples/{base}.html
 $localization:
-  path: /{locale}/documentation/examples/{base}
+  path: /{locale}/documentation/examples/{base}.html

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
@@ -1,9 +1,9 @@
 $title@: Contribute
 $title@fr: Participer
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/contribute/{base}
+$path: /documentation/guides-and-tutorials/contribute/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/contribute/{base}
+  path: /{locale}/documentation/guides-and-tutorials/contribute/{base}.html
 
 $order: 6
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/_blueprint.yaml
@@ -1,8 +1,8 @@
 $title@: Develop
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/develop/{base}
+$path: /documentation/guides-and-tutorials/develop/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/develop/{base}
+  path: /{locale}/documentation/guides-and-tutorials/develop/{base}.html
 
 $order: 2
 formats:

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/animations/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/animations/_blueprint.yaml
@@ -1,7 +1,7 @@
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/develop/animations/{base}
+$path: /documentation/guides-and-tutorials/develop/animations/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/develop/animations/{base}
+  path: /{locale}/documentation/guides-and-tutorials/develop/animations/{base}.html
 $title@: Animate & Transition
 $order: 1
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/interactive_widget/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/interactive_widget/_blueprint.yaml
@@ -1,7 +1,7 @@
-$path: /documentation/guides-and-tutorials/develop/interactive_widget/{base}
+$path: /documentation/guides-and-tutorials/develop/interactive_widget/{base}.html
 $view: /views/detail/docs-detail.j2
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/develop/interactive_widget/{base}
+  path: /{locale}/documentation/guides-and-tutorials/develop/interactive_widget/{base}.html
 $title@: Create a custom interactive widget with amp-script
 $order: 102
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/interactivity/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/interactivity/_blueprint.yaml
@@ -1,7 +1,7 @@
-$path: /documentation/guides-and-tutorials/develop/interactivity/{base}
+$path: /documentation/guides-and-tutorials/develop/interactivity/{base}.html
 $view: /views/detail/docs-detail.j2
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/develop/interactivity/{base}
+  path: /{locale}/documentation/guides-and-tutorials/develop/interactivity/{base}.html
 $title@: Create interactive AMP pages
 $title@zh: 创建互动式 AMP 网页
 $title@pt: Criação de páginas AMP interativas

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/interactivity_data/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/interactivity_data/_blueprint.yaml
@@ -1,7 +1,7 @@
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/develop/interactivity_data/{base}
+$path: /documentation/guides-and-tutorials/develop/interactivity_data/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/develop/interactivity_data/{base}
+  path: /{locale}/documentation/guides-and-tutorials/develop/interactivity_data/{base}.html
 $title@: Add interactivity & dynamic data (TBD)
 $order: 3
 draft: true

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/_blueprint.yaml
@@ -1,7 +1,7 @@
-$path: /documentation/guides-and-tutorials/develop/login_requiring/{base}
+$path: /documentation/guides-and-tutorials/develop/login_requiring/{base}.html
 $view: /views/detail/docs-detail.j2
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/develop/login_requiring/{base}
+  path: /{locale}/documentation/guides-and-tutorials/develop/login_requiring/{base}.html
 $title@: Create a login-requiring AMP page
 $order: 101
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/_blueprint.yaml
@@ -1,7 +1,7 @@
-$path: /documentation/guides-and-tutorials/develop/{base}
+$path: /documentation/guides-and-tutorials/develop/{base}.html
 $view: /views/detail/docs-detail.j2
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/develop/{base}
+  path: /{locale}/documentation/guides-and-tutorials/develop/{base}.html
 $title@: Include media, iframes & third-party content
 $order: 2
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/monetization/_blueprint.yaml
@@ -1,7 +1,7 @@
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/develop/monetization/{base}
+$path: /documentation/guides-and-tutorials/develop/monetization/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/develop/monetization/{base}
+  path: /{locale}/documentation/guides-and-tutorials/develop/monetization/{base}.html
 $title@: Monetize your AMP page with ads
 $title@zh: 在您的 AMP 网页中利用广告获利
 $title@pt: Monetização de páginas AMP com anúncios

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/_blueprint.yaml
@@ -1,7 +1,7 @@
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/develop/style_and_layout/{base}
+$path: /documentation/guides-and-tutorials/develop/style_and_layout/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/develop/style_and_layout/{base}
+  path: /{locale}/documentation/guides-and-tutorials/develop/style_and_layout/{base}.html
 $title@: Style & Layout
 $title@ar: إنشاء صفحات AMP تفاعلية
 $title@es: Estilo y Layout

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/integrate/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/integrate/_blueprint.yaml
@@ -1,8 +1,8 @@
 $title@: Integrate
-$path: /documentation/guides-and-tutorials/integrate/{base}
+$path: /documentation/guides-and-tutorials/integrate/{base}.html
 $view: /views/detail/docs-detail.j2
 
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/integrate/{base}
+  path: /{locale}/documentation/guides-and-tutorials/integrate/{base}.html
 
 $order: 3

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/_blueprint.yaml
@@ -1,8 +1,8 @@
 $title@: Learn
-$path: /documentation/guides-and-tutorials/learn/{base}
+$path: /documentation/guides-and-tutorials/learn/{base}.html
 $view: /views/detail/docs-detail.j2
 
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/learn/{base}
+  path: /{locale}/documentation/guides-and-tutorials/learn/{base}.html
 
 $order: 1

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/_blueprint.yaml
@@ -1,7 +1,7 @@
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/learn/amp-caches-and-cors/{base}
+$path: /documentation/guides-and-tutorials/learn/amp-caches-and-cors/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/learn/amp-caches-and-cors/{base}
+  path: /{locale}/documentation/guides-and-tutorials/learn/amp-caches-and-cors/{base}.html
 $title@: AMP Caches & CORS
 $title@zh: AMP 网页是如何缓存的
 $title@pt: Como as páginas AMP são armazenadas em cache

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/amp-html-layout/_blueprint.yaml
@@ -1,7 +1,7 @@
-$path: /documentation/guides-and-tutorials/learn/amp-html-layout/{base}
+$path: /documentation/guides-and-tutorials/learn/amp-html-layout/{base}.html
 $view: /views/detail/docs-detail.j2
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/learn/amp-html-layout/{base}
+  path: /{locale}/documentation/guides-and-tutorials/learn/amp-html-layout/{base}.html
 $title@: AMP's Layout System
 $order: 7
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/spec/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/spec/_blueprint.yaml
@@ -1,7 +1,7 @@
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/learn/spec/{base}
+$path: /documentation/guides-and-tutorials/learn/spec/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/learn/spec/{base}
+  path: /{locale}/documentation/guides-and-tutorials/learn/spec/{base}.html
 $title@: AMP HTML Specification
 $order: 3
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/_blueprint.yaml
@@ -11,9 +11,9 @@ $title@fr: Valider les pages AMP
 $title@es: Validar páginas AMP
 $title@ar: التحقق من صحة صفحات AMP
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/learn/validation-workflow/{base}
+$path: /documentation/guides-and-tutorials/learn/validation-workflow/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/learn/validation-workflow/{base}
+  path: /{locale}/documentation/guides-and-tutorials/learn/validation-workflow/{base}.html
 $order: 4
 
 formats:

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/_blueprint.yaml
@@ -1,9 +1,9 @@
 $title@: Optimize & Measure
-$path: /documentation/guides-and-tutorials/optimize-and-measure/{base}
+$path: /documentation/guides-and-tutorials/optimize-and-measure/{base}.html
 $view: /views/detail/docs-detail.j2
 
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/optimize-and-measure/{base}
+  path: /{locale}/documentation/guides-and-tutorials/optimize-and-measure/{base}.html
 
 $order: 4
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/_blueprint.yaml
@@ -1,7 +1,7 @@
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/optimize-measure/configure-analytics/{base}
+$path: /documentation/guides-and-tutorials/optimize-measure/configure-analytics/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/optimize-measure/configure-analytics/{base}
+  path: /{locale}/documentation/guides-and-tutorials/optimize-measure/configure-analytics/{base}.html
 $title@: Track engagement with analytics
 $title@zh: 配置分析工具
 $title@tr: Analytics›i Yapılandırın

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/_blueprint.yaml
@@ -1,8 +1,8 @@
-$path: /documentation/guides-and-tutorials/start/add_advanced/{base}
+$path: /documentation/guides-and-tutorials/start/add_advanced/{base}.html
 $view: /views/detail/docs-detail.j2
 $order: 5
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/start/add_advanced/{base}
+  path: /{locale}/documentation/guides-and-tutorials/start/add_advanced/{base}.html
 $title@: Add advanced AMP features
 $title@es: Añadir funciones avanzadas de AMP
 $title@id: Menambahkan fitur AMP lanjutan

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/converting/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/converting/_blueprint.yaml
@@ -1,8 +1,8 @@
-$path: /documentation/guides-and-tutorials/start/converting/{base}
+$path: /documentation/guides-and-tutorials/start/converting/{base}.html
 $view: /views/detail/docs-detail.j2
 $order: 4
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/start/converting/{base}
+  path: /{locale}/documentation/guides-and-tutorials/start/converting/{base}.html
 $title@: Convert HTML to AMP
 $title@es: Convertir HTML en AMP
 $title@id: Mengonversi HTML menjadi AMPHTML

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/create/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/create/_blueprint.yaml
@@ -1,8 +1,8 @@
-$path: /documentation/guides-and-tutorials/start/create/{base}
+$path: /documentation/guides-and-tutorials/start/create/{base}.html
 $view: /views/detail/docs-detail.j2
 $order: 0
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/start/create/{base}
+  path: /{locale}/documentation/guides-and-tutorials/start/create/{base}.html
 $title@: Create your first AMP Page
 $title@fr: Créer votre page AMP HTML
 $title@ar: إنشاء صفحتك الأولى في AMP

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/create_amphtml_ad/_blueprint.yaml
@@ -1,8 +1,8 @@
 $view: /views/detail/docs-detail.j2
 $order: 3
-$path: /documentation/guides-and-tutorials/start/create_amphtml_ad/{base}
+$path: /documentation/guides-and-tutorials/start/create_amphtml_ad/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/start/create_amphtml_ad/{base}
+  path: /{locale}/documentation/guides-and-tutorials/start/create_amphtml_ad/{base}.html
 $title@: Create your first AMPHTML ad
 formats:
   - ads

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/visual_story/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/visual_story/_blueprint.yaml
@@ -1,8 +1,8 @@
 $view: /views/detail/docs-detail.j2
 $order: 1
-$path: /documentation/guides-and-tutorials/start/visual_story/{base}
+$path: /documentation/guides-and-tutorials/start/visual_story/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/start/visual_story/{base}
+  path: /{locale}/documentation/guides-and-tutorials/start/visual_story/{base}.html
 $title@: Create your first AMP Story
 $title@es: Crear una historia AMP visual
 $title@id: Membuat artikel AMP visual

--- a/pages/content/amp-dev/documentation/templates/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/templates/_blueprint.yaml
@@ -1,5 +1,5 @@
-$path: /documentation/templates/{base}
+$path: /documentation/templates/{base}.html
 $view: /views/default.j2
 $title: Templates
 $localization:
-  path: /{locale}/documentation/templates/{base}
+  path: /{locale}/documentation/templates/{base}.html

--- a/pages/content/amp-dev/events/_blueprint.yaml
+++ b/pages/content/amp-dev/events/_blueprint.yaml
@@ -1,8 +1,8 @@
 $view: /views/default.j2
 $title@: Events
-$path: /events/{base}
+$path: /events/{base}.html
 $localization:
-  path: /{locale}/events/{base}
+  path: /{locale}/events/{base}.html
 $order: 4
 
 index: /content/amp-dev/events/amp-conf-2019.html

--- a/pages/content/amp-dev/support/_blueprint.yaml
+++ b/pages/content/amp-dev/support/_blueprint.yaml
@@ -1,6 +1,6 @@
 $title@: Support
 $view: /views/meta.j2
-$path: /support/{base}
+$path: /support/{base}.html
 $localization:
-  path: /{locale}/support/{base}
+  path: /{locale}/support/{base}.html
 $order: 999

--- a/pages/content/amp-dev/support/faq/_blueprint.yaml
+++ b/pages/content/amp-dev/support/faq/_blueprint.yaml
@@ -1,6 +1,6 @@
 $title@: FAQ
-$path: /support/faq/{base}
+$path: /support/faq/{base}.html
 $view: /views/meta.j2
 $localization:
-  path: /{locale}/support/faq/{base}
+  path: /{locale}/support/faq/{base}.html
 $order: 999

--- a/pages/extensions/amp_dev/extension.py
+++ b/pages/extensions/amp_dev/extension.py
@@ -68,5 +68,6 @@ def get_doc(self, pod_path, locale=None):
     doc = self.amp_dev_get_doc(pod_path, locale=locale)
     # Monkey patch doc and add property public_path, do not do this during
     # development as otherwise Grows dev routing will fail
-    setattr(doc, 'public_path', doc.url.path.replace('/index.html', '/'))
+    public_path = doc.url.path.replace('/index.html', '/').replace('.html', '')
+    setattr(doc, 'public_path', public_path)
     return doc

--- a/platform/lib/build/pageMinifier.js
+++ b/platform/lib/build/pageMinifier.js
@@ -99,7 +99,7 @@ class PageMinifier {
   start(path) {
     // Ugly but needed to keep scope for .pipe
     const scope = this;
-    return gulp.src(`${path}/**/*.html`, {'base': './'})
+    return gulp.src(`${path}/**/*`, {'base': './'})
         .pipe(through.obj(async function(canonicalPage, encoding, callback) {
           let html = canonicalPage.contents.toString();
           html = scope.minifyPage(html, canonicalPage.path);

--- a/platform/lib/routers/pages.js
+++ b/platform/lib/routers/pages.js
@@ -151,7 +151,9 @@ if (config.isDevMode()) {
 
 if (!config.isDevMode()) {
   const STATIC_PAGES_PATH = utils.project.absolute('platform/pages');
-  const staticMiddleware = express.static(STATIC_PAGES_PATH);
+  const staticMiddleware = express.static(STATIC_PAGES_PATH, {
+    'extensions': ['html']
+  });
 
   /**
    * Checks preconditions that need to be met to filter the ongoing request

--- a/platform/lib/routers/pages.js
+++ b/platform/lib/routers/pages.js
@@ -152,7 +152,7 @@ if (config.isDevMode()) {
 if (!config.isDevMode()) {
   const STATIC_PAGES_PATH = utils.project.absolute('platform/pages');
   const staticMiddleware = express.static(STATIC_PAGES_PATH, {
-    'extensions': ['html']
+    'extensions': ['html'],
   });
 
   /**


### PR DESCRIPTION
HTML extension is needed for gulp to properly get the files in pageMinifier.js and express to determine the mime type.

Lint errors are also fixed 😉 