### PR TITLE
🐛 Add redirect rules for language independent requests

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1631,8 +1631,653 @@
         "type": 301
       },
       {
+        "source": "/static/:path*",
+        "destination": "https://amp.dev/static/:path",
+        "type": 301
+      },
+      {
+        "source": "/",
+        "destination": "https://amp.dev/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
         "source": "/:lang",
         "destination": "https://amp.dev/:lang/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/about/benefits",
+        "destination": "https://amp.dev/?referrer=ampproject.org#benefits",
+        "type": 301
+      },
+      {
+        "source": "/about/mission",
+        "destination": "https://amp.dev/about/mission-and-vision?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/amp-conf",
+        "destination": "https://amp.dev/events/amp-conf-2019?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/amp-conf/accessibility/",
+        "destination": "https://amp.dev/events/accessibility?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/amp-conf/code-of-conduct/",
+        "destination": "https://amp.dev/events/code-of-conduct?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/amp-roadshow",
+        "destination": "https://amp.dev/events/amp-roadshow?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/case-studies",
+        "destination": "https://amp.dev/success-stories/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/case-studies/:name",
+        "destination": "https://amp.dev/success-stories/:name?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/contribute",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/contribute?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/?format=ads&referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/adnetwork_integration",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/contribute/adnetwork_integration?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/ads_vendors",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/monetization/ads_vendors?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/advertise_amp_stories",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/advertise_amp_stories?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/amphtml_ads",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/intro-to-amphtml-ads?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/amphtml_ads/create_shell",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create_amphtml_ad/create_shell?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/amphtml_ads/image_ad",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create_amphtml_ad/image_ad?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/amphtml_ads/summary",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create_amphtml_ad/summary?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/amphtml_ads/track_views",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create_amphtml_ad/track_views?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/amphtml_ads/validate",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create_amphtml_ad/validate?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/create_amphtml_ad",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/?format=ads&referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/introduction_ads",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/intro-to-amphtml-ads.html?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/monetization",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/monetization/monetization?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/ads/story_ads_best_practices",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/story_ads_best_practices?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/analytics/",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/analytics/analytics-vendors",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics-vendors?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/analytics/analytics_amp",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/analytics/analytics_basics",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics_basics?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/analytics/deep_dive_analytics",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/deep_dive_analytics?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/analytics/use_cases",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/use_cases?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/contribute/",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/contribute/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/design/",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/design/amp-html-layout/layouts_demonstrated",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/amp-html-layout/layouts_demonstrated?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/design/responsive/art_direction",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/art_direction?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/design/responsive/control_layout",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/design/responsive/custom_fonts",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/custom_fonts?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/design/responsive/placeholders",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/placeholders?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/design/responsive/responsive_design",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/responsive_design?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/design/responsive/style_pages",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/design/responsive_amp",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/add_advanced",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/add_advanced?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/add_advanced/adding_carousels",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/adding_carousels?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/add_advanced/adding_components",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/adding_components?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/add_advanced/congratulations",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/congratulations?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/add_advanced/fonts",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/fonts?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/add_advanced/navigating",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/navigating?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/add_advanced/review_code",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/review_code?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/add_advanced/setting_up",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/setting_up?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/add_advanced/tracking_data",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/tracking_data?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/amp_story_best_practices",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/amp_story_best_practices?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/converting",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/converting?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/converting/building-page",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/building-page?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/converting/congratulations",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/congratulations?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/converting/discoverable",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/discoverable?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/converting/resolving-errors",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/resolving-errors?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/converting/setting-up",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/setting-up?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/discovery",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/discovery?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/engagement",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/engagement?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/how_cached",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how-cached?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/optimize_amp",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/third_party_components",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/third_party_components?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/fundamentals/validate",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validate-amp?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/create",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/create/basic_markup",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/basic_markup?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/create/include_image",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/include_image?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/create/prepare_for_discovery",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/prepare_for_discovery?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/create/presentation_layout",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/presentation_layout?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/create/preview_and_validate",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/preview_and_validate?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/create/publish",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/publish?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/quickstart",
+        "destination": " https://amp.dev/documentation/guides-and-tutorials/start/create.html?format=websites",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/visual_story",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/first-story?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/visual_story/add_more_pages",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/add_more_pages?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/visual_story/animating_elements",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/animating_elements?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/visual_story/congratulations",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/congratulations?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/visual_story/create_bookend",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/create_bookend?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/visual_story/create_cover_page",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/create_cover_page?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/visual_story/parts_of_story",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/parts_of_story?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/visual_story/setting_up",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/setting_up?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/visual_story/start_story",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/start_story?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/getting_started/visual_story/validation",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/validation?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/integration/",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/integration/integrate-amphtml-email",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/contribute/integrate-amphtml-email?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/integration/integrate-with-apps",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/integrate/integrate-with-apps?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/integration/integrate-your-tech",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/contribute/integrate-your-tech?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/integration/pwa-amp",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/combine-amp-pwa",
+        "type": 301
+      },
+      {
+        "source": "/docs/integration/pwa-amp/amp-as-pwa",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-as-pwa?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/integration/pwa-amp/amp-in-pwa",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/integrate/amp-in-pwa?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/integration/pwa-amp/amp-to-pwa",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/integrate/amp-to-pwa?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/integration/supported_integrations",
+        "destination": "https://amp.dev/community/platform-and-vendor-partners.html?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/interactivity",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/create-interactive.html?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/interactivity/advanced-interactivity",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/advanced-interactivity?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/interactivity/get-familiar",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/get-familiar?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/interactivity/prereqs-setup",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/prereqs-setup?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/interactivity/remote-data",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/remote-data?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/interactivity/wrapping-up",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/wrapping-up?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/live_blog",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/live_blog?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/login_requiring",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/login_requiring/create-login.html?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/login_requiring/add_comment",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/login_requiring/add_comment?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/login_requiring/login",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/login_requiring/login?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/login_requiring/logout",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/login_requiring/logout?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/interaction_dynamic/login_requiring/summary",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/login_requiring/summary?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/media",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/media",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/media_iframes_3p",
+        "type": 301
+      },
+      {
+        "source": "/docs/media/amp_replacements",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/media_iframes_3p/amp_replacements?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/media/iframes",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/iframes?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/media/iframes",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/iframes?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/reference/common_attributes",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/reference/components",
+        "destination": "https://amp.dev/documentation/components/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/reference/components/:component",
+        "destination": "https://amp.dev/documentation/components/:component?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/reference/experimental",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/experimental?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/docs/troubleshooting",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how_amp_pages_are_cached",
+        "type": 301
+      },
+      {
+        "source": "/docs/troubleshooting/validation_errors",
+        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/latest",
+        "destination": "https://blog.amp.dev?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/latest/blog/:path*",
+        "destination": "https://blog.amp.dev/:path?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/latest/event",
+        "destination": "https://amp.dev/events/amp-conf-2019?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/learn/about-how/",
+        "destination": "https://amp.dev/about/how-amp-works?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/learn/showcases/",
+        "destination": "https://amp.dev/about/use-cases?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/learn/who-uses-amp{,/**}",
+        "destination": "https://amp.dev/community/platform-and-vendor-partners?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/reference",
+        "destination": "https://amp.dev/documentation/components?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/roadmap{,/**}",
+        "destination": "https://amp.dev/community/roadmap?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/showcases{,/**}",
+        "destination": "https://amp.dev/about/use-cases?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/stories",
+        "destination": "https://amp.dev/about/stories/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/support",
+        "destination": "https://amp.dev/support/?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/support/faqs/supported-platforms",
+        "destination": "https://amp.dev/community/platform-and-vendor-partners?referrer=ampproject.org",
         "type": 301
       },
       {
@@ -2253,11 +2898,6 @@
       {
         "source": "/:lang/showcases{,/**}",
         "destination": "https://amp.dev/:lang/about/use-cases?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/static/:path*",
-        "destination": "https://amp.dev/static/:path?referrer=ampproject.org",
         "type": 301
       },
       {

--- a/firebase.json
+++ b/firebase.json
@@ -1636,1283 +1636,648 @@
         "type": 301
       },
       {
-        "source": "/",
-        "destination": "https://amp.dev/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
         "source": "/:lang",
         "destination": "https://amp.dev/:lang/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/about/benefits",
-        "destination": "https://amp.dev/?referrer=ampproject.org#benefits",
-        "type": 301
-      },
-      {
-        "source": "/about/mission",
-        "destination": "https://amp.dev/about/mission-and-vision?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/amp-conf",
-        "destination": "https://amp.dev/events/amp-conf-2019?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/amp-conf/accessibility/",
-        "destination": "https://amp.dev/events/accessibility?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/amp-conf/code-of-conduct/",
-        "destination": "https://amp.dev/events/code-of-conduct?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/amp-roadshow",
-        "destination": "https://amp.dev/events/amp-roadshow?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/case-studies",
-        "destination": "https://amp.dev/success-stories/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/case-studies/:name",
-        "destination": "https://amp.dev/success-stories/:name?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/contribute",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/contribute?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/?format=ads&referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/adnetwork_integration",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/contribute/adnetwork_integration?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/ads_vendors",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/monetization/ads_vendors?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/advertise_amp_stories",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/advertise_amp_stories?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/amphtml_ads",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/intro-to-amphtml-ads?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/amphtml_ads/create_shell",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create_amphtml_ad/create_shell?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/amphtml_ads/image_ad",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create_amphtml_ad/image_ad?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/amphtml_ads/summary",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create_amphtml_ad/summary?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/amphtml_ads/track_views",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create_amphtml_ad/track_views?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/amphtml_ads/validate",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create_amphtml_ad/validate?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/create_amphtml_ad",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/?format=ads&referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/introduction_ads",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/intro-to-amphtml-ads.html?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/monetization",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/monetization/monetization?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/ads/story_ads_best_practices",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/story_ads_best_practices?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/analytics/",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/analytics/analytics-vendors",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics-vendors?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/analytics/analytics_amp",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/analytics/analytics_basics",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics_basics?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/analytics/deep_dive_analytics",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/deep_dive_analytics?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/analytics/use_cases",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/use_cases?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/contribute/",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/contribute/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/design/",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/design/amp-html-layout/layouts_demonstrated",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/amp-html-layout/layouts_demonstrated?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/design/responsive/art_direction",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/art_direction?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/design/responsive/control_layout",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/design/responsive/custom_fonts",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/custom_fonts?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/design/responsive/placeholders",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/placeholders?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/design/responsive/responsive_design",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/responsive_design?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/design/responsive/style_pages",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/design/responsive_amp",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/add_advanced",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/add_advanced?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/add_advanced/adding_carousels",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/adding_carousels?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/add_advanced/adding_components",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/adding_components?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/add_advanced/congratulations",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/congratulations?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/add_advanced/fonts",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/fonts?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/add_advanced/navigating",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/navigating?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/add_advanced/review_code",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/review_code?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/add_advanced/setting_up",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/setting_up?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/add_advanced/tracking_data",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/add_advanced/tracking_data?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/amp_story_best_practices",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/amp_story_best_practices?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/converting",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/converting?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/converting/building-page",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/building-page?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/converting/congratulations",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/congratulations?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/converting/discoverable",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/discoverable?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/converting/resolving-errors",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/resolving-errors?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/converting/setting-up",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/converting/setting-up?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/discovery",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/discovery?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/engagement",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/engagement?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/how_cached",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how-cached?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/optimize_amp",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/third_party_components",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/third_party_components?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/fundamentals/validate",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validate-amp?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/create",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/create/basic_markup",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/basic_markup?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/create/include_image",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/include_image?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/create/prepare_for_discovery",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/prepare_for_discovery?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/create/presentation_layout",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/presentation_layout?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/create/preview_and_validate",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/preview_and_validate?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/create/publish",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/create/publish?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/quickstart",
-        "destination": " https://amp.dev/documentation/guides-and-tutorials/start/create.html?format=websites",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/visual_story",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/first-story?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/visual_story/add_more_pages",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/add_more_pages?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/visual_story/animating_elements",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/animating_elements?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/visual_story/congratulations",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/congratulations?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/visual_story/create_bookend",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/create_bookend?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/visual_story/create_cover_page",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/create_cover_page?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/visual_story/parts_of_story",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/parts_of_story?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/visual_story/setting_up",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/setting_up?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/visual_story/start_story",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/start_story?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/getting_started/visual_story/validation",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/start/visual_story/validation?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/integration/",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/integration/integrate-amphtml-email",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/contribute/integrate-amphtml-email?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/integration/integrate-with-apps",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/integrate/integrate-with-apps?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/integration/integrate-your-tech",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/contribute/integrate-your-tech?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/integration/pwa-amp",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/combine-amp-pwa",
-        "type": 301
-      },
-      {
-        "source": "/docs/integration/pwa-amp/amp-as-pwa",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/amp-as-pwa?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/integration/pwa-amp/amp-in-pwa",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/integrate/amp-in-pwa?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/integration/pwa-amp/amp-to-pwa",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/integrate/amp-to-pwa?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/integration/supported_integrations",
-        "destination": "https://amp.dev/community/platform-and-vendor-partners.html?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/interactivity",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/create-interactive.html?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/interactivity/advanced-interactivity",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/advanced-interactivity?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/interactivity/get-familiar",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/get-familiar?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/interactivity/prereqs-setup",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/prereqs-setup?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/interactivity/remote-data",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/remote-data?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/interactivity/wrapping-up",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/interactivity/wrapping-up?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/live_blog",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/live_blog?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/login_requiring",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/login_requiring/create-login.html?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/login_requiring/add_comment",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/login_requiring/add_comment?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/login_requiring/login",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/login_requiring/login?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/login_requiring/logout",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/login_requiring/logout?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/interaction_dynamic/login_requiring/summary",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/login_requiring/summary?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/media",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/media",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/media_iframes_3p",
-        "type": 301
-      },
-      {
-        "source": "/docs/media/amp_replacements",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/media_iframes_3p/amp_replacements?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/media/iframes",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/iframes?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/media/iframes",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/develop/iframes?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/reference/common_attributes",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/reference/components",
-        "destination": "https://amp.dev/documentation/components/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/reference/components/:component",
-        "destination": "https://amp.dev/documentation/components/:component?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/reference/experimental",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/experimental?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/docs/troubleshooting",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how_amp_pages_are_cached",
-        "type": 301
-      },
-      {
-        "source": "/docs/troubleshooting/validation_errors",
-        "destination": "https://amp.dev/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/latest",
-        "destination": "https://blog.amp.dev?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/latest/blog/:path*",
-        "destination": "https://blog.amp.dev/:path?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/latest/event",
-        "destination": "https://amp.dev/events/amp-conf-2019?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/learn/about-how/",
-        "destination": "https://amp.dev/about/how-amp-works?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/learn/showcases/",
-        "destination": "https://amp.dev/about/use-cases?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/learn/who-uses-amp{,/**}",
-        "destination": "https://amp.dev/community/platform-and-vendor-partners?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/reference",
-        "destination": "https://amp.dev/documentation/components?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/roadmap{,/**}",
-        "destination": "https://amp.dev/community/roadmap?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/showcases{,/**}",
-        "destination": "https://amp.dev/about/use-cases?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/stories",
-        "destination": "https://amp.dev/about/stories/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/support",
-        "destination": "https://amp.dev/support/?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/support/faqs/supported-platforms",
-        "destination": "https://amp.dev/community/platform-and-vendor-partners?referrer=ampproject.org",
-        "type": 301
-      },
-      {
-        "source": "/:lang/about/benefits",
+        "source": "/{,:lang/}about/benefits",
         "destination": "https://amp.dev/:lang/?referrer=ampproject.org#benefits",
         "type": 301
       },
       {
-        "source": "/:lang/about/mission",
+        "source": "/{,:lang/}about/mission",
         "destination": "https://amp.dev/:lang/about/mission-and-vision?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/amp-conf",
+        "source": "/{,:lang/}amp-conf",
         "destination": "https://amp.dev/:lang/events/amp-conf-2019?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/amp-conf/accessibility/",
+        "source": "/{,:lang/}amp-conf/accessibility/",
         "destination": "https://amp.dev/:lang/events/accessibility?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/amp-conf/code-of-conduct/",
+        "source": "/{,:lang/}amp-conf/code-of-conduct/",
         "destination": "https://amp.dev/:lang/events/code-of-conduct?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/amp-roadshow",
+        "source": "/{,:lang/}amp-roadshow",
         "destination": "https://amp.dev/:lang/events/amp-roadshow?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/case-studies",
+        "source": "/{,:lang/}case-studies",
         "destination": "https://amp.dev/:lang/success-stories/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/case-studies/:name",
+        "source": "/{,:lang/}case-studies/:name",
         "destination": "https://amp.dev/:lang/success-stories/:name?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/contribute",
+        "source": "/{,:lang/}contribute",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/contribute?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs",
+        "source": "/{,:lang/}docs",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads",
+        "source": "/{,:lang/}docs/ads",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/?format=ads&referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/adnetwork_integration",
+        "source": "/{,:lang/}docs/ads/adnetwork_integration",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/contribute/adnetwork_integration?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/ads_vendors",
+        "source": "/{,:lang/}docs/ads/ads_vendors",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/monetization/ads_vendors?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/advertise_amp_stories",
+        "source": "/{,:lang/}docs/ads/advertise_amp_stories",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/advertise_amp_stories?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/amphtml_ads",
+        "source": "/{,:lang/}docs/ads/amphtml_ads",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/learn/intro-to-amphtml-ads?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/amphtml_ads/create_shell",
+        "source": "/{,:lang/}docs/ads/amphtml_ads/create_shell",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create_amphtml_ad/create_shell?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/amphtml_ads/image_ad",
+        "source": "/{,:lang/}docs/ads/amphtml_ads/image_ad",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create_amphtml_ad/image_ad?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/amphtml_ads/summary",
+        "source": "/{,:lang/}docs/ads/amphtml_ads/summary",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create_amphtml_ad/summary?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/amphtml_ads/track_views",
+        "source": "/{,:lang/}docs/ads/amphtml_ads/track_views",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create_amphtml_ad/track_views?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/amphtml_ads/validate",
+        "source": "/{,:lang/}docs/ads/amphtml_ads/validate",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create_amphtml_ad/validate?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/create_amphtml_ad",
+        "source": "/{,:lang/}docs/ads/create_amphtml_ad",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/?format=ads&referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/introduction_ads",
+        "source": "/{,:lang/}docs/ads/introduction_ads",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/learn/intro-to-amphtml-ads.html?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/monetization",
+        "source": "/{,:lang/}docs/ads/monetization",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/monetization/monetization?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/ads/story_ads_best_practices",
+        "source": "/{,:lang/}docs/ads/story_ads_best_practices",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/story_ads_best_practices?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/analytics/",
+        "source": "/{,:lang/}docs/analytics/",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/analytics/analytics-vendors",
+        "source": "/{,:lang/}docs/analytics/analytics-vendors",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics-vendors?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/analytics/analytics_amp",
+        "source": "/{,:lang/}docs/analytics/analytics_amp",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/optimize-measure/configure-analytics/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/analytics/analytics_basics",
+        "source": "/{,:lang/}docs/analytics/analytics_basics",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics_basics?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/analytics/deep_dive_analytics",
+        "source": "/{,:lang/}docs/analytics/deep_dive_analytics",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/optimize-measure/configure-analytics/deep_dive_analytics?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/analytics/use_cases",
+        "source": "/{,:lang/}docs/analytics/use_cases",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/optimize-measure/configure-analytics/use_cases?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/contribute/",
+        "source": "/{,:lang/}docs/contribute/",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/contribute/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/design/",
+        "source": "/{,:lang/}docs/design/",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/design/amp-html-layout/layouts_demonstrated",
+        "source": "/{,:lang/}docs/design/amp-html-layout/layouts_demonstrated",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/learn/amp-html-layout/layouts_demonstrated?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/design/responsive/art_direction",
+        "source": "/{,:lang/}docs/design/responsive/art_direction",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/style_and_layout/art_direction?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/design/responsive/control_layout",
+        "source": "/{,:lang/}docs/design/responsive/control_layout",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/style_and_layout/control_layout?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/design/responsive/custom_fonts",
+        "source": "/{,:lang/}docs/design/responsive/custom_fonts",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/style_and_layout/custom_fonts?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/design/responsive/placeholders",
+        "source": "/{,:lang/}docs/design/responsive/placeholders",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/style_and_layout/placeholders?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/design/responsive/responsive_design",
+        "source": "/{,:lang/}docs/design/responsive/responsive_design",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/style_and_layout/responsive_design?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/design/responsive/style_pages",
+        "source": "/{,:lang/}docs/design/responsive/style_pages",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/style_and_layout/style_pages?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/design/responsive_amp",
+        "source": "/{,:lang/}docs/design/responsive_amp",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/style_and_layout/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/",
+        "source": "/{,:lang/}docs/fundamentals/",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/add_advanced",
+        "source": "/{,:lang/}docs/fundamentals/add_advanced",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/add_advanced/add_advanced?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/add_advanced/adding_carousels",
+        "source": "/{,:lang/}docs/fundamentals/add_advanced/adding_carousels",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/add_advanced/adding_carousels?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/add_advanced/adding_components",
+        "source": "/{,:lang/}docs/fundamentals/add_advanced/adding_components",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/add_advanced/adding_components?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/add_advanced/congratulations",
+        "source": "/{,:lang/}docs/fundamentals/add_advanced/congratulations",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/add_advanced/congratulations?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/add_advanced/fonts",
+        "source": "/{,:lang/}docs/fundamentals/add_advanced/fonts",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/add_advanced/fonts?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/add_advanced/navigating",
+        "source": "/{,:lang/}docs/fundamentals/add_advanced/navigating",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/add_advanced/navigating?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/add_advanced/review_code",
+        "source": "/{,:lang/}docs/fundamentals/add_advanced/review_code",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/add_advanced/review_code?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/add_advanced/setting_up",
+        "source": "/{,:lang/}docs/fundamentals/add_advanced/setting_up",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/add_advanced/setting_up?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/add_advanced/tracking_data",
+        "source": "/{,:lang/}docs/fundamentals/add_advanced/tracking_data",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/add_advanced/tracking_data?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/amp_story_best_practices",
+        "source": "/{,:lang/}docs/fundamentals/amp_story_best_practices",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/amp_story_best_practices?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/converting",
+        "source": "/{,:lang/}docs/fundamentals/converting",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/converting/converting?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/converting/building-page",
+        "source": "/{,:lang/}docs/fundamentals/converting/building-page",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/converting/building-page?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/converting/congratulations",
+        "source": "/{,:lang/}docs/fundamentals/converting/congratulations",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/converting/congratulations?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/converting/discoverable",
+        "source": "/{,:lang/}docs/fundamentals/converting/discoverable",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/converting/discoverable?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/converting/resolving-errors",
+        "source": "/{,:lang/}docs/fundamentals/converting/resolving-errors",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/converting/resolving-errors?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/converting/setting-up",
+        "source": "/{,:lang/}docs/fundamentals/converting/setting-up",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/converting/setting-up?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/discovery",
+        "source": "/{,:lang/}docs/fundamentals/discovery",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/optimize-and-measure/discovery?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/engagement",
+        "source": "/{,:lang/}docs/fundamentals/engagement",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/optimize-and-measure/engagement?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/how_cached",
+        "source": "/{,:lang/}docs/fundamentals/how_cached",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how-cached?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/optimize_amp",
+        "source": "/{,:lang/}docs/fundamentals/optimize_amp",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/third_party_components",
+        "source": "/{,:lang/}docs/fundamentals/third_party_components",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/third_party_components?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/fundamentals/validate",
+        "source": "/{,:lang/}docs/fundamentals/validate",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/learn/validation-workflow/validate-amp?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/",
+        "source": "/{,:lang/}docs/getting_started/",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/create",
+        "source": "/{,:lang/}docs/getting_started/create",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/create/basic_markup",
+        "source": "/{,:lang/}docs/getting_started/create/basic_markup",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create/basic_markup?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/create/include_image",
+        "source": "/{,:lang/}docs/getting_started/create/include_image",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create/include_image?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/create/prepare_for_discovery",
+        "source": "/{,:lang/}docs/getting_started/create/prepare_for_discovery",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create/prepare_for_discovery?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/create/presentation_layout",
+        "source": "/{,:lang/}docs/getting_started/create/presentation_layout",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create/presentation_layout?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/create/preview_and_validate",
+        "source": "/{,:lang/}docs/getting_started/create/preview_and_validate",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create/preview_and_validate?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/create/publish",
+        "source": "/{,:lang/}docs/getting_started/create/publish",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/create/publish?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/quickstart",
+        "source": "/{,:lang/}docs/getting_started/quickstart",
         "destination": " https://amp.dev/:lang/documentation/guides-and-tutorials/start/create.html?format=websites",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/visual_story",
+        "source": "/{,:lang/}docs/getting_started/visual_story",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/first-story?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/visual_story/add_more_pages",
+        "source": "/{,:lang/}docs/getting_started/visual_story/add_more_pages",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/visual_story/add_more_pages?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/visual_story/animating_elements",
+        "source": "/{,:lang/}docs/getting_started/visual_story/animating_elements",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/visual_story/animating_elements?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/visual_story/congratulations",
+        "source": "/{,:lang/}docs/getting_started/visual_story/congratulations",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/visual_story/congratulations?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/visual_story/create_bookend",
+        "source": "/{,:lang/}docs/getting_started/visual_story/create_bookend",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/visual_story/create_bookend?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/visual_story/create_cover_page",
+        "source": "/{,:lang/}docs/getting_started/visual_story/create_cover_page",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/visual_story/create_cover_page?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/visual_story/parts_of_story",
+        "source": "/{,:lang/}docs/getting_started/visual_story/parts_of_story",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/visual_story/parts_of_story?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/visual_story/setting_up",
+        "source": "/{,:lang/}docs/getting_started/visual_story/setting_up",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/visual_story/setting_up?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/visual_story/start_story",
+        "source": "/{,:lang/}docs/getting_started/visual_story/start_story",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/visual_story/start_story?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/getting_started/visual_story/validation",
+        "source": "/{,:lang/}docs/getting_started/visual_story/validation",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/start/visual_story/validation?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/integration/",
+        "source": "/{,:lang/}docs/integration/",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/integration/integrate-amphtml-email",
+        "source": "/{,:lang/}docs/integration/integrate-amphtml-email",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/contribute/integrate-amphtml-email?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/integration/integrate-with-apps",
+        "source": "/{,:lang/}docs/integration/integrate-with-apps",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/integrate/integrate-with-apps?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/integration/integrate-your-tech",
+        "source": "/{,:lang/}docs/integration/integrate-your-tech",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/contribute/integrate-your-tech?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/integration/pwa-amp",
+        "source": "/{,:lang/}docs/integration/pwa-amp",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/learn/combine-amp-pwa",
         "type": 301
       },
       {
-        "source": "/:lang/docs/integration/pwa-amp/amp-as-pwa",
+        "source": "/{,:lang/}docs/integration/pwa-amp/amp-as-pwa",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/optimize-and-measure/amp-as-pwa?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/integration/pwa-amp/amp-in-pwa",
+        "source": "/{,:lang/}docs/integration/pwa-amp/amp-in-pwa",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/integrate/amp-in-pwa?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/integration/pwa-amp/amp-to-pwa",
+        "source": "/{,:lang/}docs/integration/pwa-amp/amp-to-pwa",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/integrate/amp-to-pwa?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/integration/supported_integrations",
+        "source": "/{,:lang/}docs/integration/supported_integrations",
         "destination": "https://amp.dev/:lang/community/platform-and-vendor-partners.html?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/",
+        "source": "/{,:lang/}docs/interaction_dynamic/",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/interactivity",
+        "source": "/{,:lang/}docs/interaction_dynamic/interactivity",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/interactivity/create-interactive.html?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/interactivity/advanced-interactivity",
+        "source": "/{,:lang/}docs/interaction_dynamic/interactivity/advanced-interactivity",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/interactivity/advanced-interactivity?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/interactivity/get-familiar",
+        "source": "/{,:lang/}docs/interaction_dynamic/interactivity/get-familiar",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/interactivity/get-familiar?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/interactivity/prereqs-setup",
+        "source": "/{,:lang/}docs/interaction_dynamic/interactivity/prereqs-setup",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/interactivity/prereqs-setup?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/interactivity/remote-data",
+        "source": "/{,:lang/}docs/interaction_dynamic/interactivity/remote-data",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/interactivity/remote-data?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/interactivity/wrapping-up",
+        "source": "/{,:lang/}docs/interaction_dynamic/interactivity/wrapping-up",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/interactivity/wrapping-up?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/live_blog",
+        "source": "/{,:lang/}docs/interaction_dynamic/live_blog",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/live_blog?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/login_requiring",
+        "source": "/{,:lang/}docs/interaction_dynamic/login_requiring",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/login_requiring/create-login.html?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/login_requiring/add_comment",
+        "source": "/{,:lang/}docs/interaction_dynamic/login_requiring/add_comment",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/login_requiring/add_comment?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/login_requiring/login",
+        "source": "/{,:lang/}docs/interaction_dynamic/login_requiring/login",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/login_requiring/login?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/login_requiring/logout",
+        "source": "/{,:lang/}docs/interaction_dynamic/login_requiring/logout",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/login_requiring/logout?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/interaction_dynamic/login_requiring/summary",
+        "source": "/{,:lang/}docs/interaction_dynamic/login_requiring/summary",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/login_requiring/summary?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/media",
+        "source": "/{,:lang/}docs/media",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/media",
+        "source": "/{,:lang/}docs/media",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/media_iframes_3p",
         "type": 301
       },
       {
-        "source": "/:lang/docs/media/amp_replacements",
+        "source": "/{,:lang/}docs/media/amp_replacements",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/media_iframes_3p/amp_replacements?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/media/iframes",
+        "source": "/{,:lang/}docs/media/iframes",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/iframes?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/media/iframes",
+        "source": "/{,:lang/}docs/media/iframes",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/develop/iframes?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/reference/common_attributes",
+        "source": "/{,:lang/}docs/reference/common_attributes",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/learn/common_attributes?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/reference/components",
+        "source": "/{,:lang/}docs/reference/components",
         "destination": "https://amp.dev/:lang/documentation/components/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/reference/components/:component",
+        "source": "/{,:lang/}docs/reference/components/:component",
         "destination": "https://amp.dev/:lang/documentation/components/:component?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/reference/experimental",
+        "source": "/{,:lang/}docs/reference/experimental",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/learn/experimental?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/docs/troubleshooting",
+        "source": "/{,:lang/}docs/troubleshooting",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how_amp_pages_are_cached",
         "type": 301
       },
       {
-        "source": "/:lang/docs/troubleshooting/validation_errors",
+        "source": "/{,:lang/}docs/troubleshooting/validation_errors",
         "destination": "https://amp.dev/:lang/documentation/guides-and-tutorials/learn/validation-workflow/validation_errors?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/latest",
+        "source": "/{,:lang/}latest",
         "destination": "https://blog.amp.dev?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/latest/blog/:path*",
+        "source": "/{,:lang/}latest/blog/:path*",
         "destination": "https://blog.amp.dev/:path?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/latest/event",
+        "source": "/{,:lang/}latest/event",
         "destination": "https://amp.dev/:lang/events/amp-conf-2019?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/learn/about-how/",
+        "source": "/{,:lang/}learn/about-how/",
         "destination": "https://amp.dev/:lang/about/how-amp-works?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/learn/showcases/",
+        "source": "/{,:lang/}learn/showcases/",
         "destination": "https://amp.dev/:lang/about/use-cases?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/learn/who-uses-amp{,/**}",
+        "source": "/{,:lang/}learn/who-uses-amp{,/**}",
         "destination": "https://amp.dev/:lang/community/platform-and-vendor-partners?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/reference",
+        "source": "/{,:lang/}reference",
         "destination": "https://amp.dev/:lang/documentation/components?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/roadmap{,/**}",
+        "source": "/{,:lang/}roadmap{,/**}",
         "destination": "https://amp.dev/:lang/community/roadmap?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/showcases{,/**}",
+        "source": "/{,:lang/}showcases{,/**}",
         "destination": "https://amp.dev/:lang/about/use-cases?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/stories",
+        "source": "/{,:lang/}stories",
         "destination": "https://amp.dev/:lang/about/stories/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/support",
+        "source": "/{,:lang/}support",
         "destination": "https://amp.dev/:lang/support/?referrer=ampproject.org",
         "type": 301
       },
       {
-        "source": "/:lang/support/faqs/supported-platforms",
+        "source": "/{,:lang/}support/faqs/supported-platforms",
         "destination": "https://amp.dev/:lang/community/platform-and-vendor-partners?referrer=ampproject.org",
+        "type": 301
+      },
+      {
+        "source": "/{,:lang/}support/faqs/supported-browsers",
+        "destination": "https://amp.dev/:lang/support/faq/supported-browsers",
         "type": 301
       }
     ],


### PR DESCRIPTION
Copied the rules for requests without a language, though can't see why https://www.ampproject.org/amp-conf/ has gone to https://amp.dev/events/amp-conf instead of https://amp.dev/events/amp-conf-2019.

Can you spot the error?