### PR TITLE
🐛 Dissolve differences between i18n paths and globals

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/index.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/login_requiring/index.md
@@ -1,6 +1,5 @@
 ---
 $title: Create a login-requiring AMP page
-$path: /documentation/guides-and-tutorials/develop/login_requiring/create-login.html
 $order: 0
 description: 'Some user interactions with a page, such as leaving a comment, could be conditioned by a login flow. You can implement a login flow ...'
 numbered: 1

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/index.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/media_iframes_3p/index.md
@@ -2,7 +2,6 @@
 $title: Include images & video
 $order: 8
 description: "Like on a normal HTML page, AMP allows you to embed images, video and audio content. Learn what's different about the AMP equivalents and learn how to..."
-$path: /documentation/guides-and-tutorials/develop/media_iframes_3p/amp_replacements.html
 formats:
   - websites
   - stories

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/monetization/index.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/monetization/index.md
@@ -2,7 +2,6 @@
 $title: Monetizing your AMP page with ads
 $order: 0
 description: 'This guide provides instructions and best practices for displaying ads on your AMP pages. So, to display ads in AMP, you need to add the custom amp-ad component...'
-$path: /documentation/guides-and-tutorials/develop/monetization/monetization.html
 formats:
   - websites
 ---

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validate_amp.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validate_amp.md
@@ -2,7 +2,6 @@
 $title: Validate AMP pages
 $order: 0
 description: 'Watch our video about the various validation options. The key strength of AMP isn’t just that it makes your pages fast, but that it makes your pages ...'
-$path: /documentation/guides-and-tutorials/learn/validation-workflow/validate-amp.html
 formats:
   - websites
   - email


### PR DESCRIPTION
There have been differences between the i18n documents and the default ones which broke redirects.