### PR TITLE
Update importing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,6 @@ $ export AMP_DOC_TOKEN="c59f6..."
 $ npm run develop -- --import
 ```
 
-If you have checked out a local copy of the `amphtml` repository you can also import from there by running the following command. An exported GitHub token is required nevertheless.
-
-```sh
-$ npm run develop -- --import --local-amphtml-repository='</Users/...>'
-```
-
 ### Maintenance
 
 #### Documents

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "develop": "cd platform && node build.js",
     "lint": "npm-run-all lint:* --aggregate-output --parallel",
     "lint-disabled:grow": "cd platform && node lib/pipeline/growReferenceChecker.js",
-    "lint:node": "eslint \"**/*.js\" --ignore-path ./.gitignore",
+    "lint:node": "eslint \"**/*.js\" --ignore-path ./.gitignore --ignore-pattern \"examples/**/static\"",
     "fix:node": "eslint \"**/*.js\" --fix --ignore-path ./.gitignore",
     "build:boilerplate": "cd boilerplate && node build.js",
     "build:local": "NODE_ENV=local npm run build:site",

--- a/pages/content/amp-dev/community/governance.md
+++ b/pages/content/amp-dev/community/governance.md
@@ -10,4 +10,94 @@ formats:
 
 
 
-[This document moved into the meta repository](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md).
+## Glossary
+
+* **Advisory Committee (AC).**  A group of people with representation from a variety of AMP's constituencies including Users, End-users and Collaborators who provide advice to the Technical Steering Committee.
+
+* <strong id=facilitator>Facilitator.</strong>  A member of a governance body who is responsible for facilitating the consensus-based decision making process and acting as a representative to other governance bodies.
+
+* <strong id=governance-body>Governance body</strong> Any of the Advisory Committee, Technical Steering Committee, and Workings Groups.
+
+* <strong id=user>Users.</strong> Developers who use AMP but haven’t contributed to it (yet).
+
+* <strong id=end-user>End-users</strong>. People who consume content distributed using the AMP format.
+
+* **Technical Steering Committee (TSC).**  A group of people who set AMP's technical & product direction.
+
+* <strong id=wg>Working Groups (WG)</strong>.  A group of people who have a familiarity and interest in a given area; may be cross-cutting (e.g. "Documentation") or focused on a given area (e.g. "Ads & Analytics" or "Runtime").  These are formally recognized by the TSC, but may form informally.
+
+## Governance Structures
+
+### Advisory Committee (AC)
+
+#### Role
+
+The Advisory Committee provides perspective and advice to the Technical Steering Committee.
+
+#### Membership
+* Membership on the Advisory Committee shall include representatives from major AMP constituencies (Collaborators, Contributors, Users and End-Users) who are committed to fulfilling [AMP's vision and mission](https://www.ampproject.org/about/mission/).
+* Membership on the Advisory Committee is not time limited.
+* The target size of the Advisory Committee is 6-12 members, but there is no fixed size.
+* Once established the Advisory Committee sets its own membership through the consensus-based process.
+* No more than ⅓ of the Advisory Committee should be from one employer.
+* The Advisory Committee will designate a Facilitator from among its members for the purposes of facilitating the consensus-based decision-making process.
+
+### Technical Steering Committee (TSC)
+
+#### Role
+
+* The TSC's primary role is setting AMP's technical & product direction based on the [project guidelines](https://www.ampproject.org/about/amp-design-principles/).
+* Creates a product roadmap in consultation with the Working Groups.
+* Creates Working Groups and sets the initial membership & Facilitator of the Working Groups.  The TSC may initiate the creation of Working Groups or a group of people with a common interest may request recognition as a Working Group.
+* Approves new Collaborators.
+* Sets and maintains the project guidelines.
+* Sets and maintains the project’s feature and bug fix process.
+* Enforces the Code of Conduct.
+* The TSC may designate entities to perform legal, security and privacy reviews of AMP code/features.
+* Decisions within the TSC follow the decision-making policy, and are facilitated by the Facilitator or their designate.
+
+#### Membership
+
+* The TSC shall be composed of members with significant experience contributing to AMP on a technical and product level.
+* Membership on the TSC is not time-limited.
+* The target size of the TSC is 6-12 members, but there is no fixed size.
+* Once established the TSC sets its own membership through the consensus-based process.
+* The TSC shall have a goal of having no more than ⅓ of the TSC from one employer.  Given the requirement that membership in the TSC requires recognized technical and/or product experience with AMP this may not be feasible at the time the TSC is formed, but the TSC should actively work towards this goal.
+* Entities (such as a company) may be granted seats on the TSC.  In these cases certain conditions may be placed on the seat (such as maintaining committed resources to the project). The entity may designate the individual representing the entity at the TSC and may change this individual at their discretion.
+* The TSC will designate a Facilitator from among its members for the purposes of facilitating the consensus-based decision-making process.
+
+### Working Groups
+
+#### Role
+* A Working Group is a segment of the community with knowledge/interest in specific areas of AMP (e.g. UI, Runtime, Infrastructure, documentation) recognized by the TSC.
+* The TSC defines each Working Group's mandate, which may include responsibility for certain AMP features, systems and/or code.  A Working Group generally operates independently on the area(s) in which it has a mandate while adhering to AMP's [project guidelines](https://github.com/ampproject/amphtml/tree/master/contributing), [vision/mission](https://www.ampproject.org/about/mission/) and [technical/product roadmaps](https://github.com/ampproject/amphtml/projects/43).
+* Each Working Group is made up of a set of Collaborators with knowledge/interest in that particular area + other interested parties.
+* Each Working Group may have a Facilitator as designated by the Technical Steering Committee.  The Facilitator is responsible for:
+  * Facilitating consensus-based decisions within the Working Group.
+  * Representing the Working Group to the TSC.
+  * Choosing designate(s) from within the Working Group for these responsibilities as needed.
+* Decisions within Working Groups follow the decision-making policy, and are facilitated by the Facilitator or their designate.
+
+#### Membership
+* The TSC creates Working Groups and assigns initial members.  Membership should include some Committers but may include other interested parties.
+* A Working Group may add or remove members by using the consensus-based approach.
+* It is acceptable & expected that groups of people with a common interest will work together without requiring a formal Working Group.  These groups may choose to be officially recognized as a Working Group by making a proposal (including its purpose and proposed membership) to the TSC.
+* The TSC may disband/reorganize Working Groups as needed.
+
+## Decision making policy
+
+* Decisions in AMP's Advisory Committee, TSC and Working Groups should be made using a [consensus-based approach](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making) (similar to the [approach used by Node.js](https://nodejs.org/en/about/governance/#consensus-seeking-process) and [JS Foundation](https://github.com/JSFoundation/TAC/blob/master/TAC-Charter.md#section-8-decision-making)).
+  * When discussions have appeared to reach a consensus, the Facilitator will ask if there are any objections to the apparent consensus.  A member may call a vote to finalize a decision, but this should only happen as a last resort.  With the agreement of two other members of the group the vote will be held, otherwise the consensus-seeking process will continue.
+  * When votes are called:
+    * The vote should be set at a time that allows a reasonable amount of time for those in the group to attend.  This time should be announced publicly.
+    * Anyone who is unable to attend at the time of the vote can register their vote early.
+    * They will be simple majority votes except for changes to Advisory Committee or TSC membership which requires a ⅔ vote.
+  * For decisions made within a Working Group every effort should be made to resolve issues within the Working Group itself; issues that cannot be resolved within the Working Group may be escalated to the TSC.
+
+* Decisions made by the Advisory Committee, TSC and Working Groups must be publicly documented (unless they cannot be for legal or security reasons).
+
+* Decisions should be made through asynchronous communication channels. In the case where they are not—such as over video conference or during face to face meetings—a reasonable period of time should be allowed for objections to be made before the decision is ratified.
+
+* A decision may be revisited if new technical information becomes available.
+
+* The Advisory Committee, TSC and Working Groups may hold calls, video conferences, and face to face meetings. These meetings shall be announced sufficiently in advance with a published agenda. A mechanism by which the community can propose items for the agenda shall be provided.

--- a/platform/config/imports/spec.json
+++ b/platform/config/imports/spec.json
@@ -2,49 +2,56 @@
   {
     "title": "Governance",
     "order": 2,
-    "from": "GOVERNANCE.md",
+		"repo": "ampproject/meta",
+		"from": "GOVERNANCE.md",
     "to": "community/governance.md",
     "formats": ["websites","email","stories", "ads"]
   },
   {
     "title": "AMP HTML Specification",
     "order": 3,
-    "from": "spec/amp-html-format.md",
+		"repo": "ampproject/amphtml",
+		"from": "spec/amp-html-format.md",
     "to": "documentation/guides-and-tutorials/learn/spec/amphtml.md",
     "formats": ["websites"]
   },
   {
     "title": "AMP Boilerplate Code",
     "order": 3,
-    "from": "spec/amp-boilerplate.md",
+		"repo": "ampproject/amphtml",
+		"from": "spec/amp-boilerplate.md",
     "to": "documentation/guides-and-tutorials/learn/spec/amp-boilerplate.md",
     "formats": ["websites", "stories"]
   },
   {
     "title": "AMPHTML Layout System",
     "order": 1,
-    "from": "spec/amp-html-layout.md",
+		"repo": "ampproject/amphtml",
+		"from": "spec/amp-html-layout.md",
     "to": "documentation/guides-and-tutorials/learn/amp-html-layout/index.md",
     "formats": ["websites","email","stories", "ads"]
   },
   {
     "title": "Actions and events",
     "order": 7,
-    "from": "spec/amp-actions-and-events.md",
+		"repo": "ampproject/amphtml",
+		"from": "spec/amp-actions-and-events.md",
     "to": "documentation/guides-and-tutorials/learn/amp-actions-and-events.md",
     "formats": ["websites","email","stories", "ads"]
   },
   {
     "title": "Debug AMP Cache issues",
     "order": 8,
-    "from": "spec/amp-cache-debugging.md",
+		"repo": "ampproject/amphtml",
+		"from": "spec/amp-cache-debugging.md",
     "to": "documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cache-debugging.md",
     "formats": ["websites", "stories", "ads"]
   },
   {
     "title": "CORS in AMP",
     "order": 12,
-    "from": "spec/amp-cors-requests.md",
+		"repo": "ampproject/amphtml",
+		"from": "spec/amp-cors-requests.md",
     "to": "documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests.md",
     "toc": true,
     "formats": ["websites","email","stories", "ads"]
@@ -52,7 +59,8 @@
   {
     "title": "Support",
     "order": 1,
-    "from": "SUPPORT.md",
+		"repo": "ampproject/amphtml",
+		"from": "SUPPORT.md",
     "to": "support/index.md",
     "group": 1,
     "formats": ["websites","email","stories", "ads"]
@@ -60,7 +68,8 @@
   {
     "title": "Integrate your ad technologies into AMP",
     "order": 3,
-    "from": "ads/_integration-guide.md",
+		"repo": "ampproject/amphtml",
+		"from": "ads/_integration-guide.md",
     "to": "documentation/guides-and-tutorials/contribute/ad-integration-guide.md",
     "toc": true,
     "formats": ["ads"]
@@ -68,7 +77,8 @@
   {
     "title": "AMP for Ads specification",
     "order": 3,
-    "from": "extensions/amp-a4a/amp-a4a-format.md",
+		"repo": "ampproject/amphtml",
+		"from": "extensions/amp-a4a/amp-a4a-format.md",
     "to": "documentation/guides-and-tutorials/learn/a4a_spec.md",
     "toc": true,
     "formats": ["ads"]
@@ -76,7 +86,8 @@
   {
     "title": "Integrate your analytics tool with AMP",
     "order": 1,
-    "from": "extensions/amp-analytics/integrating-analytics.md",
+		"repo": "ampproject/amphtml",
+		"from": "extensions/amp-analytics/integrating-analytics.md",
     "to": "documentation/guides-and-tutorials/contribute/integrate-your-analytics-tools.md",
     "toc": true,
     "formats": ["websites", "stories"]
@@ -84,14 +95,16 @@
   {
     "title": "Manage non-authenticated user state with AMP",
     "order": 2,
-    "from": "spec/amp-managing-user-state.md",
+		"repo": "ampproject/amphtml",
+		"from": "spec/amp-managing-user-state.md",
     "to": "documentation/guides-and-tutorials/optimize-measure/amp-managing-user-state.md",
     "formats": ["websites"]
   },
   {
     "title": "AMP for Email specification",
     "order": 3,
-    "from": "spec/amp-email-format.md",
+		"repo": "ampproject/amphtml",
+		"from": "spec/amp-email-format.md",
     "to": "documentation/guides-and-tutorials/learn/amp-email-format.md",
     "toc": true,
     "formats": ["email"]

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -119,7 +119,7 @@ class SamplesBuilder {
 
     return new Promise((resolve, reject) => {
       let stream = gulp.src([
-          `${SAMPLE_SRC}/*/*.html`, `${SAMPLE_SRC}/*/*/*.html`], {'read': true});
+        `${SAMPLE_SRC}/*/*.html`, `${SAMPLE_SRC}/*/*/*.html`], {'read': true});
 
       // Only build samples changed since last run and if it's not a fresh build
       if ((config.options['clean-samples'] && watch) || !config.options['clean-samples']) {

--- a/platform/lib/pipeline/gitHubImporter.js
+++ b/platform/lib/pipeline/gitHubImporter.js
@@ -15,8 +15,6 @@
  */
 
 const octonode = require('octonode');
-const {promisify} = require('util');
-const fs = require('fs');
 const {Signale} = require('signale');
 
 const Document = require('./markdownDocument');

--- a/platform/lib/pipeline/roadmapImporter.js
+++ b/platform/lib/pipeline/roadmapImporter.js
@@ -117,7 +117,6 @@ async function importRoadmap() {
       .reduce((acc, val) => acc.concat(val), [])
       .filter((value, index, self) => self.indexOf(value) === index);
 
-  console.log(labels);
   // Write finalized JSON to config file that gets imported by the roadmap template
   fs.writeFileSync(
       DESTINATION_JSON,

--- a/platform/lib/pipeline/specImporter.js
+++ b/platform/lib/pipeline/specImporter.js
@@ -48,7 +48,7 @@ class SpecImporter {
     const importedDocs = [];
     for (const importDoc of importDocs) {
       try {
-        const doc = await this.githubImporter_.fetchDocument(importDoc.from, /* master */ true);
+        const doc = await this.githubImporter_.fetchDocument(importDoc.from, importDoc.repo, true);
         doc.path = path.join(DESTINATION_BASE_PATH, importDoc.to);
         doc.title = importDoc.title;
         doc.order = importDoc.order;


### PR DESCRIPTION
Enables importing from different repositories than `ampproject/amphtml` for spec importer and removes support for importing from a local clone of it - which was not really reliable anyway.

This fixes #1773, as GOVERNANCE.md can now be imported from ampproject/meta