### PR TITLE
🐛 Add missing extension to Start collection.

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/_blueprint.yaml
@@ -1,7 +1,7 @@
 $title@: Start
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/start/{base}
+$path: /documentation/guides-and-tutorials/start/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/start/{base}
+  path: /{locale}/documentation/guides-and-tutorials/start/{base}.html
 
 $order: 0


### PR DESCRIPTION
Fixes #1807 and #1808.