### PR TITLE
✨ Make header and footer available standalone.

### DIFF
--- a/pages/content/shared/footer.html
+++ b/pages/content/shared/footer.html
@@ -1,0 +1,20 @@
+$view: /layouts/blank.j2
+---
+<style amp-custom>
+  {% do doc.styles.addCssFile('css/base.css', -5) %}
+  {% do doc.styles.addCssFile('css/components/atoms/text.css', -3) %}
+  {% do doc.styles.addCssFile('css/components/atoms/anchor.css', -2) %}
+  {% do doc.styles.addCssFile('css/components/atoms/icon.css', -1) %}
+
+  {{ doc.styles.emit() }}
+</style>
+
+{% block icons %}
+<svg style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    {{ doc.icons.emit() }}
+  </defs>
+</svg>
+{% endblock %}
+
+{% include 'views/partials/footer.j2' %}

--- a/pages/content/shared/footer.html
+++ b/pages/content/shared/footer.html
@@ -1,20 +1,3 @@
 $view: /layouts/blank.j2
 ---
-<style amp-custom>
-  {% do doc.styles.addCssFile('css/base.css', -5) %}
-  {% do doc.styles.addCssFile('css/components/atoms/text.css', -3) %}
-  {% do doc.styles.addCssFile('css/components/atoms/anchor.css', -2) %}
-  {% do doc.styles.addCssFile('css/components/atoms/icon.css', -1) %}
-
-  {{ doc.styles.emit() }}
-</style>
-
-{% block icons %}
-<svg style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <defs>
-    {{ doc.icons.emit() }}
-  </defs>
-</svg>
-{% endblock %}
-
 {% include 'views/partials/footer.j2' %}

--- a/pages/content/shared/header.html
+++ b/pages/content/shared/header.html
@@ -1,0 +1,21 @@
+$view: /layouts/blank.j2
+---
+<style amp-custom>
+  {% do doc.styles.addCssFile('css/base.css', -5) %}
+  {% do doc.styles.addCssFile('css/components/atoms/text.css', -3) %}
+  {% do doc.styles.addCssFile('css/components/atoms/anchor.css', -2) %}
+  {% do doc.styles.addCssFile('css/components/atoms/icon.css', -1) %}
+
+  {{ doc.styles.emit() }}
+</style>
+
+{% block icons %}
+<svg style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    {{ doc.icons.emit() }}
+  </defs>
+</svg>
+{% endblock %}
+
+{% include 'views/partials/header.j2' %}
+{% include 'views/partials/burger-menu.j2' %}

--- a/pages/content/shared/header.html
+++ b/pages/content/shared/header.html
@@ -1,4 +1,10 @@
 $view: /layouts/blank.j2
 ---
+<svg style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    {{ doc.icons.emit() }}
+  </defs>
+</svg>
+
 {% include 'views/partials/header.j2' %}
 {% include 'views/partials/burger-menu.j2' %}

--- a/pages/content/shared/header.html
+++ b/pages/content/shared/header.html
@@ -1,21 +1,4 @@
 $view: /layouts/blank.j2
 ---
-<style amp-custom>
-  {% do doc.styles.addCssFile('css/base.css', -5) %}
-  {% do doc.styles.addCssFile('css/components/atoms/text.css', -3) %}
-  {% do doc.styles.addCssFile('css/components/atoms/anchor.css', -2) %}
-  {% do doc.styles.addCssFile('css/components/atoms/icon.css', -1) %}
-
-  {{ doc.styles.emit() }}
-</style>
-
-{% block icons %}
-<svg style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <defs>
-    {{ doc.icons.emit() }}
-  </defs>
-</svg>
-{% endblock %}
-
 {% include 'views/partials/header.j2' %}
 {% include 'views/partials/burger-menu.j2' %}


### PR DESCRIPTION
This would make header and footer accessible via http://amp.dev/shared/header.html and http://amp.dev/shared/footer.html.

See the attached documents for reference, the final endpoints would be minified though.

Including [`base.scss`](https://github.com/ampproject/docs/blob/future/frontend/scss/base.scss) can possibly be omitted as you might have similar stylings for the blog in place already

[sample.zip](https://github.com/ampproject/docs/files/3061245/sample.zip)

.