### PR TITLE
🔧 Make docs having a TOC default.

### DIFF
--- a/frontend/templates/views/partials/toc.j2
+++ b/frontend/templates/views/partials/toc.j2
@@ -1,5 +1,7 @@
 {% set empty_toc = doc.format.toc == '<div class="toc">\n<ul></ul>\n</div>\n' or not doc.format.toc %}
-{% if not empty_toc and (doc.toc or doc.content.find('[TOC]')) != -1 %}
+{% set hide_toc = (doc.toc == False or doc.collection.toc == False) %}
+
+{% if not empty_toc and not hide_toc %}
 {% do doc.icons.useIcon('icons/contentmenu.svg') %}
 <section class="ap--toc">
   {% do doc.styles.addCssFile('/css/components/atoms/sidebar-toggle.css') %}


### PR DESCRIPTION
Note to @morsssss: this makes docs have a TOC by default per team vote. Can either be switch off by setting `toc: false` in the document's frontmatter or its closest collection/`_blueprint.yaml`.