### PR TITLE
Use https for photo stream, create hello endpoint

### DIFF
--- a/examples/api/hello.js
+++ b/examples/api/hello.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+const multer = require('multer');
+const upload = multer();
+const {setNoCache} = require('@lib/utils/cacheHelpers');
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+
+examples.get('/hello', (request, response) => {
+  setNoCache(response);
+  const name = request.query.name;
+  if (!name || name.length > 10) {
+    response.status(400);
+    response.json({ error: 'Invalid input' });
+    return;
+  }
+  response.json({
+    message: `Hello, ${name}`
+  });
+});
+
+examples.post('/hello', upload.none(), (request, response) => {
+  setNoCache(response);
+  const name = request.body ? request.body.name : '';
+  if (!name || name.length > 10) {
+    response.status(400);
+    response.json({ error: 'Invalid input' });
+    return;
+  }
+  response.json({
+    message: `Hello, ${name}`
+  });
+});
+
+module.exports = examples;

--- a/examples/api/hello.js
+++ b/examples/api/hello.js
@@ -32,7 +32,7 @@ examples.get('/hello', (request, response) => {
     return;
   }
   response.json({
-    message: `Hello, ${name}`
+    message: `Hello, ${name}!`
   });
 });
 
@@ -45,7 +45,7 @@ examples.post('/hello', upload.none(), (request, response) => {
     return;
   }
   response.json({
-    message: `Hello, ${name}`
+    message: `Hello, ${name}!`
   });
 });
 

--- a/examples/api/photo-stream.js
+++ b/examples/api/photo-stream.js
@@ -17,9 +17,7 @@
 
 const express = require('express');
 const {setNoCache} = require('@lib/utils/cacheHelpers');
-const {LoremIpsum} = require('lorem-ipsum');
-
-const lorem = new LoremIpsum();
+const casual = require('casual');
 
 // eslint-disable-next-line new-cap
 const examples = express.Router();
@@ -28,20 +26,23 @@ examples.get('/photo-stream', (req, res) => {
   setNoCache(res);
   const {query} = req;
   const items = [];
-  const numberOfItems = req.query.items || 10;
-  const pagesLeft = req.query.left || 1;
-  const latency = query.latency || 0;
+  const numberOfItems = Number(query.items) || 10;
+  const pagesLeft = Number(query.left) || 1;
+  const latency = Number(query.latency) || 0;
+  const width = Number(query.width) || 200;
+  const height = Number(query.height) || width;
+  const dimensions = width === height ? String(width) : `${width}/${height}`;
 
   if (pagesLeft == 0) {
     res.json({items: []});
   }
 
   for (let i = 0; i < numberOfItems; i++) {
-    const imageUrl = 'http://picsum.photos/200?' +
-        Math.floor(Math.random() * Math.floor(50));
+    const imageId = Math.floor(Math.random() * Math.floor(50));
+    const imageUrl = `https://picsum.photos/${dimensions}?${imageId}`;
     const r = {
-      'title': 'Item ' + i,
-      description: lorem.generateParagraphs(1),
+      title: casual.title,
+      description: casual.description,
       imageUrl
     };
     items.push(r);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2719,6 +2719,15 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "casual": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/casual/-/casual-1.6.0.tgz",
+      "integrity": "sha512-UmOIqc09KMrGIOKbLsb8GfPHDW8E+hdI1AjmJ8BYhQazTj8BHX3y6zEXj5lT7v7T4ZBkO180HXXF8ZACf3qANA==",
+      "requires": {
+        "mersenne-twister": "^1.0.1",
+        "moment": "^2.15.2"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -8575,14 +8584,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lorem-ipsum": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.1.tgz",
-      "integrity": "sha512-FjqfVmw4pEYOWCgzJf+ei2ohRTeuxhnPW/b+nQO+JK4z/QE9OEslnf+SeBVJJCTNRPKIupTW91evd7ezTX2xGA==",
-      "requires": {
-        "commander": "^2.17.1"
-      }
-    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -8812,6 +8813,11 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
+    "mersenne-twister": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
+      "integrity": "sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o="
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -9020,6 +9026,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.0.tgz",
       "integrity": "sha512-O4bbvlZkHj2LUQhieQWWCr486ddc8X+WwRqi3QGnFKfknaxdHTOB7+xRgeyWHc6arpjgtT5SLLMMTFwUM3/x5w=="
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mout": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
   "dependencies": {
     "amp-toolbox-cors": "0.2.4",
     "amp-toolbox-runtime-version": "0.2.6",
+    "casual": "1.6.0",
     "cheerio": "1.0.0-rc.3",
     "cors": "2.8.5",
     "express": "4.16.4",
     "js-yaml": "3.13.1",
-    "lorem-ipsum": "2.0.1",
     "module-alias": "2.2.0",
     "mri": "1.1.4",
     "multer": "1.4.1",


### PR DESCRIPTION
- Images in `api/photo-stream` now use HTTPS
- Titles in `api/photo-stream` are now generative as well
- `api/photo-stream` now supports image sizes (and other parameters are better sanitized)
- Added `api/hello` endpoint to test forms
