### PR TITLE
⚡️ Use box-shadow instead of drop-shadow for tip

### DIFF
--- a/frontend/scss/components/molecules/tip.scss
+++ b/frontend/scss/components/molecules/tip.scss
@@ -50,7 +50,7 @@ $borderSize: 5px;
   padding: $cornerSize/2 ($cornerSize - 10px);
   margin-bottom: 50px;
   background-color: color('white');
-  filter: drop-shadow(0 2px 25px rgba(0, 0, 0, 0.1));
+  box-shadow: 0 2px 25px rgba(0, 0, 0, 0.1);
 
   code {
     white-space: normal;


### PR DESCRIPTION
Safari has performance issues with rendering `filter: drop-shadow` in certain cases. Replaced it with `box-shadow` which doesn't respect the tip's special shapes but at least renders smoothly.