### PR TITLE
♻️ Make header keyboard accessible.

### DIFF
--- a/frontend/scss/components/molecules/format-toggle.scss
+++ b/frontend/scss/components/molecules/format-toggle.scss
@@ -116,6 +116,7 @@
 
     .#{molecule('format-toggle')}-selected:focus + &,
     .#{molecule('format-toggle')}-selected:hover + &,
+    &:focus-within,
     &:hover {
       pointer-events: auto;
       opacity: 1;

--- a/frontend/scss/components/molecules/language-selector.scss
+++ b/frontend/scss/components/molecules/language-selector.scss
@@ -29,7 +29,8 @@
   &-toggle {
     display: flex;
     align-items: center;
-    cursor: pointer;
+    border: none;
+    background: none;
   }
 
     &-icon {
@@ -50,7 +51,9 @@
   }
 
   /* For when the selector is active */
-  &-toggle:focus ~ &-list, &-toggle:hover ~ &-list, &-list:hover {
+  &-toggle:focus ~ &-list,
+  &-toggle:hover ~ &-list,
+  &-list:hover {
       display: block;
   }
 

--- a/frontend/scss/components/organisms/header.scss
+++ b/frontend/scss/components/organisms/header.scss
@@ -98,14 +98,14 @@
       display: flex;
       align-items: center;
       margin: 0 18px -5px;
-      padding-bottom: 14px;
     }
 
     &-link {
       display: flex;
       align-items: center;
+      padding: 0 0 14px 0;
       border: 0;
-      padding: 0;
+      background: none;
 
       &-icon {
         font-size: 8px;
@@ -118,6 +118,7 @@
 
   &-main-link:hover ~ &-flyout,
   &-main-link:focus ~ &-flyout,
+  &-flyout:hover,
   &-flyout:focus-within {
     opacity: 1;
     pointer-events: all;

--- a/frontend/scss/components/organisms/header.scss
+++ b/frontend/scss/components/organisms/header.scss
@@ -50,14 +50,6 @@
     padding-left: 30px;
   }
 
-  input {
-    display: none;
-  }
-
-  .ap-o-header-main-item-radio-btn:checked ~ .ap-o-header-flyout {
-    display: block;
-  }
-
   &-home {
     position: -webkit-sticky;
     position: sticky;
@@ -84,12 +76,12 @@
         }
       }
 
-    &-sub-title {
-      color: color('black');
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
-    }
+      &-sub-title {
+        color: color('black');
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
   }
 
   &-main {
@@ -109,48 +101,40 @@
       padding-bottom: 14px;
     }
 
-    &-item:hover {
-
-      & > .ap-o-header-flyout {
-          opacity: 1;
-          pointer-events: all;
-          transition: opacity 0.2s cubic-bezier(0.25, 0.1, 0.25, 1);
-
-          &-secondary {
-            z-index: -1;
-          }
-      }
-    }
-
     &-link {
-      border-radius: 10px;
+      display: flex;
+      align-items: center;
+      border: 0;
+      padding: 0;
 
       &-icon {
         font-size: 8px;
         margin-left: 5px;
         transform: rotate(0deg);
         transition: transform 0.2s cubic-bezier(.25,.1,.25,1);
-
-        &.right {
-          transform: rotate(-90deg);
-          margin-left: auto;
-          font-size: 10px;
-        }
       }
     }
   }
 
+  &-main-link:hover ~ &-flyout,
+  &-main-link:focus ~ &-flyout,
+  &-flyout:focus-within {
+    opacity: 1;
+    pointer-events: all;
+    transition: opacity 0.2s cubic-bezier(0.25, 0.1, 0.25, 1);
+  }
+
   &-flyout {
     @include flyout;
+    position: absolute;
+    top: 95%;
+    left: 0;
+    margin: 0;
+    padding: 0 0 10px;
     pointer-events: none;
     opacity: 0;
     list-style: none;
     background: color('white');
-    position: absolute;
-    left: 0;
-    top: 95%;
-    padding: 0 0 10px;
-    margin: 0;
     border-radius: 0 0 4px 4px;
     transition: opacity 0.2s cubic-bezier(0.25, 0.1, 0.25, 1);
 
@@ -163,18 +147,6 @@
       margin-bottom: 10px;
     }
 
-    &-label {
-      /* Expand the label over the link in case the device can't hover */
-      @media (hover: none) {
-        position: absolute;
-        display: flex;
-        width: calc(100% + 14px);
-        height: 100%;
-        justify-content: flex-end;
-        align-items: center;
-      }
-    }
-
     &-item {
 
       &-secondary {
@@ -182,7 +154,7 @@
         white-space: nowrap;
         min-width: 200px;
 
-        &:hover > a {
+        a:hover {
           color: color('blue-ribbon');
         }
       }
@@ -211,17 +183,6 @@
       }
     }
 
-    &-secondary {
-      left: 100%;
-      top: 15%;
-      padding: 5px 30px;
-      z-index: -1;
-
-      &:hover {
-        opacity: 1;
-      }
-    }
-
     &-primary-item {
       position: relative;
       width: 300px;
@@ -235,21 +196,21 @@
         }
 
         &-info-stories {
-          .ap-o-header-flyout-item-title {
+          .#{organism('header')}-flyout-item-title {
             @include color-stories;
           }
 
-          .ap-o-header-flyout-item-description {
+          .#{organism('header')}-flyout-item-description {
             @include color-stories;
           }
         }
 
         &-info-email {
-          .ap-o-header-flyout-item-title {
+          .#{organism('header')}-flyout-item-title {
             @include color-e-mails;
           }
 
-          .ap-o-header-flyout-item-description {
+          .#{organism('header')}-flyout-item-description {
             @include color-e-mails;
           }
         }
@@ -281,23 +242,6 @@
         &.email {
           @include gradient-e-mails;
         }
-      }
-
-
-      &:hover > .ap-o-header-flyout-secondary {
-        pointer-events: auto;
-        opacity: 1;
-        transition: opacity 0.2s cubic-bezier(0.25, 0.1, 0.25, 1);
-      }
-
-      &:hover .ap-o-header-main-link-icon {
-        &.right {
-          display: none;
-        }
-      }
-
-      &:hover .ap-o-header-flyout-secondary {
-        display: block;
       }
 
       &-link {

--- a/frontend/scss/components/templates/_default.scss
+++ b/frontend/scss/components/templates/_default.scss
@@ -157,8 +157,9 @@
   box-shadow: 20px 25px 40px 0 rgba(0,0,0,0.05);
 
   & ~ .#{utility('content')} {
-    box-shadow: -20px 25px 40px 0 rgba(0,0,0,0.05);
+    box-shadow: -30px -5px 30px -20px rgba(0,0,0,0.05);
   }
+
   @media (min-width: 768px) {
     grid-column: 8 / 25;
 

--- a/frontend/templates/views/partials/header.j2
+++ b/frontend/templates/views/partials/header.j2
@@ -85,22 +85,20 @@
 
     {% do doc.styles.addCssFile('/css/components/molecules/language-selector.css') %}
     <div class="ap-m-language-selector">
-      <a class="ap-m-language-selector-toggle" href="#">
+      <button class="ap-m-language-selector-toggle" aria-label="{{ _('Select a language') }}">
         <span class="ap-m-nav-link">{{ doc.locale.language|upper }}</span>
         {% do doc.icons.useIcon('/icons/angle-down-solid.svg') %}
         <div class="ap-a-ico ap-m-language-selector-icon">
           <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
         </div>
-      </a>
-      <ul class="ap-m-language-selector-list">
+      </button>
+      <div class="ap-m-language-selector-list" role="list">
         {% for locale in doc.locales if not locale == doc.locale  %}
         {% set localized_doc = doc.localize(locale) %}
-        <li class="ap-m-language-selector-list-item">
-          {# Need to manually replace as doc.public_path is not available #}
-          <a class="ap-m-nav-link" href="{{ localized_doc.url.path.replace('/index.html', '/') }}">{{ locale.get_language_name()|capitalize }}</a>
-        </li>
+        {# Need to manually replace as doc.public_path is not available #}
+        <a class="ap-m-nav-link" href="{{ localized_doc.url.path.replace('/index.html', '/') }}" role="listitem">{{ locale.get_language_name()|capitalize }}</a>
         {% endfor %}
-      </ul>
+      </div>
     </div>
   </div>
 </header>

--- a/frontend/templates/views/partials/header.j2
+++ b/frontend/templates/views/partials/header.j2
@@ -32,11 +32,6 @@
       ] %}
 
       {% for section, section_index in sections %}
-      {% if section.flyout %}
-      {# Only render flyout-touch-inputs for sections with flyout #}
-      <input id="main-item-radio-{{ loop.index }}" type="radio" name="main-radio-btn" tabindex="0" role="button" aria-label="{{ section.title or section_index.titles('navigation') }}">
-      {% endif %}
-
       {# Special case for the blog #}
       {% if section == 'external' %}
       <div class="ap-o-header-main-item">
@@ -44,17 +39,17 @@
       </div>
       {% else %}
       <div class="ap-o-header-main-item">
-        <a class="ap-o-header-main-link ap-m-nav-link {{ active_class(section_index) }}" href="{{ section_index.public_path }}">{{ section.title or section_index.titles('navigation') }}</a>
-
-        {% if section.flyout %}
-        {# Only render flyout-touch-inputs for sections with flyout #}
-        {% do doc.icons.useIcon('/icons/angle-down-solid.svg') %}
-        <label class="ap-o-header-flyout-label" for="main-item-radio-{{ loop.index }}">
+        {% if not section.flyout %}
+        <a class="ap-o-header-main-link ap-m-nav-link" href="{{ section_index.public_path }}">{{ section.title or section_index.titles('navigation') }}</a>
+        {% else %}
+        <button class="ap-o-header-main-link ap-m-nav-link {{ active_class(section_index) }}">
+          {{ section.title or section_index.titles('navigation') }}
           <div class="ap-a-ico ap-o-header-main-link-icon">
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
           </div>
-        </label>
+        </button>
 
+        {% do doc.icons.useIcon('/icons/angle-down-solid.svg') %}
         <ul class="ap-o-header-flyout">
           {% for path in section.flyout %}
           {% set flyout_doc = g.doc(path, locale=doc.locale) %}


### PR DESCRIPTION
Handling one of the most prominent answers from the beta form: the flyout navigation and the format toggle is now fully keyboard accessible and are built without any `input` hacks.

This also leads to the discussed change that the top level navigation items that have a flyout aren't clickable on their own anymore.