### PR TITLE
Typo fix in embed pin widget doc

### DIFF
--- a/examples/source/1.components/amp-pinterest.html
+++ b/examples/source/1.components/amp-pinterest.html
@@ -47,7 +47,7 @@
 
   <!-- ## Embed pin widget -->
   <!--
-    To embed the pin widget, set `data-do` to `embedPing`. The `data-url` attribute must contain the fully-qualified URL of the Pinterest resource.
+    To embed the pin widget, set `data-do` to `embedPin`. The `data-url` attribute must contain the fully-qualified URL of the Pinterest resource.
   -->
   <amp-pinterest width="236" height="326"
     data-do="embedPin"


### PR DESCRIPTION
`data-do` should be `embedPin` and not `embedPing`