### PR TITLE
🙈 Unignore files in /examples/source/.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,7 +18,6 @@ packager/
 /frontend/
 pages/
 !platform/pages
-/examples/source/**/*.html
 
 # playground: ignore everything except the dist folder
 /playground/*

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -29,7 +29,6 @@ packager/
 /frontend/
 pages/
 !platform/pages
-/examples/source/**/*.html
 
 # playground: ignore everything except the dist folder
 /playground/*


### PR DESCRIPTION
Fixes #1865.

We could possibly handcraft better ignore rules but I fear that they then don't match all upcoming cases and produce similar errors again. Therefore I went for unignoring the `/example/source` at all.