### PR TITLE
✨ Add shortcode for format filtering.

### DIFF
--- a/frontend/templates/layouts/default.j2
+++ b/frontend/templates/layouts/default.j2
@@ -1,3 +1,14 @@
+{% macro filter(formats='websites, ads, stories, email') -%}
+{% if not formats.strip() %}
+{{ caller() }}
+{% else %}
+{% set formats = formats.split(',') %}
+<p class="{% for format in formats %}ap--{{ format.strip() }} {% endfor %}">
+{{ caller() }}
+</p>
+{% endif %}
+{%- endmacro %}
+
 {% macro tip(title, type='note') -%}
 {% with %}
 {% set text = caller() %}

--- a/frontend/templates/layouts/default.j2
+++ b/frontend/templates/layouts/default.j2
@@ -3,9 +3,9 @@
 {{ caller() }}
 {% else %}
 {% set formats = formats.split(',') %}
-<p class="{% for format in formats %}ap--{{ format.strip() }} {% endfor %}">
+<div class="{% for format in formats %}ap--{{ format.strip() }} {% endfor %}">
 {{ caller() }}
-</p>
+</div>
 {% endif %}
 {%- endmacro %}
 

--- a/pages/extensions/amp_dev/extension.py
+++ b/pages/extensions/amp_dev/extension.py
@@ -8,6 +8,7 @@ from grow import extensions
 from grow.documents import document, document_format, static_document
 from grow.extensions import hooks
 
+from .markdown_extras import block_filter as BlockFilter
 from .markdown_extras import block_tip as BlockTip
 from .markdown_extras import block_video as BlockVideo
 from .markdown_extras import inline_tip as InlineTip
@@ -55,6 +56,7 @@ class AmpDevExtension(extensions.BaseExtension):
         content = InlineTip.trigger(original_body, content)
         content = BlockTip.trigger(original_body, content)
         content = BlockVideo.trigger(original_body, content)
+        content = BlockFilter.trigger(original_body, content)
         return content
 
     @property

--- a/pages/extensions/amp_dev/markdown_extras/block_filter.py
+++ b/pages/extensions/amp_dev/markdown_extras/block_filter.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import re
+
+FILTER_TRIGGER = '[filter'
+FILTER_START_TAG_PATTERN = re.compile(r'(\[filter( formats=(?:\"|\')(.*?)(?:\"|\'))?\])',
+                                   re.MULTILINE)
+FILTER_END_TAG_PATTERN = '[/filter]'
+
+DEFAULT_FORMATS = ['websites', 'ads', 'stories', 'email']
+
+def trigger(original_body, content):
+  if FILTER_TRIGGER in original_body:
+    return _transform(content)
+  return content
+
+
+def _transform(content):
+  print content.encode('utf-8')
+  for match in FILTER_START_TAG_PATTERN.findall(content):
+    formats = match[2] or DEFAULT_FORMATS
+    content = content.replace(match[0], '{% call filter(formats=\'' + match[2] + '\') %}')
+  # Then also replace end tags
+  content = content.replace(FILTER_END_TAG_PATTERN, '{% endcall %}')
+  print content.encode('utf-8')
+  return content

--- a/pages/extensions/amp_dev/markdown_extras/block_filter.py
+++ b/pages/extensions/amp_dev/markdown_extras/block_filter.py
@@ -19,7 +19,7 @@ def trigger(original_body, content):
 def _transform(content):
   for match in FILTER_START_TAG_PATTERN.findall(content):
     formats = match[2] or DEFAULT_FORMATS
-    content = content.replace(match[0], '{% call filter(formats=\'' + match[2] + '\') %}')
+    content = content.replace(match[0], '{% call filter(formats=\'' + match[2] + '\') %}\n')
   # Then also replace end tags
-  content = content.replace(FILTER_END_TAG_PATTERN, '{% endcall %}')
+  content = content.replace(FILTER_END_TAG_PATTERN, '\n{% endcall %}')
   return content

--- a/pages/extensions/amp_dev/markdown_extras/block_filter.py
+++ b/pages/extensions/amp_dev/markdown_extras/block_filter.py
@@ -17,11 +17,9 @@ def trigger(original_body, content):
 
 
 def _transform(content):
-  print content.encode('utf-8')
   for match in FILTER_START_TAG_PATTERN.findall(content):
     formats = match[2] or DEFAULT_FORMATS
     content = content.replace(match[0], '{% call filter(formats=\'' + match[2] + '\') %}')
   # Then also replace end tags
   content = content.replace(FILTER_END_TAG_PATTERN, '{% endcall %}')
-  print content.encode('utf-8')
   return content


### PR DESCRIPTION
Fixes #1748.

```markdown
[filter formats="websites"]
This is only visible for [websites](?format=websites).
[/filter]

[filter formats='websites, email']
This is visible for [websites](?format=websites) & [email](?format=email).
[/filter]

[filter formats="stories"]
This is visible for [stories](?format=stories).
[/filter]
```