### PR TITLE
✨ Small UX improvements.

### DIFF
--- a/frontend/templates/layouts/default.j2
+++ b/frontend/templates/layouts/default.j2
@@ -35,7 +35,6 @@
     {% block head %}
     <meta charset="utf-8"/>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
-    <title>{{ doc.title }}</title>
     {% if podspec.env.name == 'development' %}
     <link rel="shortcut icon" href="/static/img/favicon-local.png"/>
     {% else %}

--- a/frontend/templates/views/partials/breadcrumbs.j2
+++ b/frontend/templates/views/partials/breadcrumbs.j2
@@ -13,6 +13,14 @@ and the current page title #}
   </span>
 
   <a class="ap-m-breadcrumbs-crumb" href="{{ guides_and_tutorials.url.path }}">{{ guides_and_tutorials.titles('navigation') }}</a>
+
+  {% if not doc.collection.bucket %}
+  <span class="ap-m-breadcrumbs-divider">
+    <svg class="ap-a-ico ap-m-breadcrumbs-angle"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#angle-down-solid"></use></svg>
+  </span>
+
+  <div class="ap-m-breadcrumbs-crumb">{{ doc.collection.title }}</div>
+  {% endif %}
 </nav>
 {% elif doc.pod_path.startswith('/content/amp-dev/documentation/examples') %}
 <nav class="ap-m-breadcrumbs">

--- a/frontend/templates/views/partials/structured-data.j2
+++ b/frontend/templates/views/partials/structured-data.j2
@@ -1,13 +1,10 @@
-{# Structured data can't be printed without a description #}
-{% if doc.description or (doc.teaser and doc.teaser.text) %}
-
 {# Set needed data for all meta tags #}
-{% set description = doc.description or doc.teaser.text %}
+{% set description = doc.description or (doc.teaser.text if doc.teaser else None) %}
 {% set title = doc.title %}
 {% set base_url = doc.pod.podspec.base_urls.platform %}
 {% set canonical = doc.pod.podspec.base_urls.platform + doc.url.path %}
 
-{# Alter sharing image based on template and/or maintained data #}
+{# Alter sharing image and title prefix based on template and/or maintained data #}
 {% if doc.sharing_images %}
 {% set sharing_images = doc.sharing_images %}
 {% elif '/components/' in doc.pod_path %}
@@ -32,7 +29,24 @@
 } %}
 {% endif %}
 
+{# Prefix title with section #}
+{% set title_prefix = '' %}
+{% if doc.pod_path.startswith('/content/amp-dev/documentation/examples/documentation/') %}
+{% set title_prefix = _('Example: ') %}
+{% elif doc.pod_path.startswith('/content/amp-dev/documentation/examples/previews/') %}
+{% set title_prefix = _('Example preview: ') %}
+{% elif doc.pod_path.startswith('/content/amp-dev/documentation/components/reference/') %}
+{% set title_prefix = _('Component: ') %}
+{% elif doc.pod_path.startswith('/content/amp-dev/about/success-stories/') and not 'index.html' in doc.pod_path %}
+{% set title_prefix = _('Success Story: ') %}
+{% endif %}
+
+<title>{{ title_prefix }}{{ doc.title }} - amp.dev</title>
+
+{% if description %}
 <meta name="description" content="{{ description }}">
+{% endif %}
+
 <script type="application/ld+json">
 {
   "@context": "http://schema.org",
@@ -40,7 +54,9 @@
   "url": "{{ canonical}} ",
   "name": "amp.dev",
   "headline":"{{ title }}",
+  {% if description %}
   "description":"{{ description }}",
+  {% endif %}
   "mainEntityOfPage": {
     "@type": "WebPage",
     "@id": "{{ base_url }}"
@@ -65,7 +81,9 @@
 </script>
 
 <meta name="twitter:card" content="summary_large_image">
+{% if description %}
 <meta name="twitter:description" content="{{ description }}">
+{% endif %}
 <meta name="twitter:title" content="{{ title }}">
 <meta name="twitter:creator" content="@ampproject">
 <meta name="twitter:site" content="@ampproject">
@@ -76,5 +94,3 @@
 <meta property="og:image" content="{{ base_url }}{{ sharing_images.wide }}">
 <meta property="og:image:width" content="600">
 <meta property="og:image:height" content="314">
-
-{% endif %}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/contribute/_blueprint.yaml
@@ -7,6 +7,7 @@ $localization:
 
 $order: 6
 
+bucket: true
 formats:
   - websites
   - stories

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/_blueprint.yaml
@@ -3,8 +3,9 @@ $view: /views/detail/docs-detail.j2
 $path: /documentation/guides-and-tutorials/develop/{base}.html
 $localization:
   path: /{locale}/documentation/guides-and-tutorials/develop/{base}.html
-
 $order: 2
+
+bucket: true
 formats:
   - websites
   - stories

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/integrate/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/integrate/_blueprint.yaml
@@ -1,8 +1,8 @@
 $title@: Integrate
-$path: /documentation/guides-and-tutorials/integrate/{base}.html
 $view: /views/detail/docs-detail.j2
-
+$path: /documentation/guides-and-tutorials/integrate/{base}.html
 $localization:
   path: /{locale}/documentation/guides-and-tutorials/integrate/{base}.html
-
 $order: 3
+
+bucket: true

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/_blueprint.yaml
@@ -1,8 +1,8 @@
 $title@: Learn
-$path: /documentation/guides-and-tutorials/learn/{base}.html
 $view: /views/detail/docs-detail.j2
-
+$path: /documentation/guides-and-tutorials/learn/{base}.html
 $localization:
   path: /{locale}/documentation/guides-and-tutorials/learn/{base}.html
-
 $order: 1
+
+bucket: true

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/_blueprint.yaml
@@ -1,12 +1,11 @@
 $title@: Optimize & Measure
 $path: /documentation/guides-and-tutorials/optimize-and-measure/{base}.html
 $view: /views/detail/docs-detail.j2
-
 $localization:
   path: /{locale}/documentation/guides-and-tutorials/optimize-and-measure/{base}.html
-
 $order: 4
 
+bucket: true
 formats:
   - websites
   - email

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/_blueprint.yaml
@@ -3,5 +3,6 @@ $view: /views/detail/docs-detail.j2
 $path: /documentation/guides-and-tutorials/start/{base}.html
 $localization:
   path: /{locale}/documentation/guides-and-tutorials/start/{base}.html
-
 $order: 0
+
+bucket: true


### PR DESCRIPTION
Scopes title tag to make it more easy to identify tabs and prevent double titles in regards to SEO. 

### Before 
![Bildschirmfoto 2019-04-14 um 13 09 24](https://user-images.githubusercontent.com/12857772/56092176-d9a56780-5eb8-11e9-91ce-c701d0b79d7a.png)
### After
![Bildschirmfoto 2019-04-14 um 13 10 08](https://user-images.githubusercontent.com/12857772/56092183-e6c25680-5eb8-11e9-973e-898911a6d8b0.png)

And adds the parent collection's title to the Guides breadcrumbs

### Before
![Bildschirmfoto 2019-04-14 um 13 23 17](https://user-images.githubusercontent.com/12857772/56092187-f5107280-5eb8-11e9-9d11-bbd21f9120f2.png)

### After
![Bildschirmfoto 2019-04-14 um 13 23 02](https://user-images.githubusercontent.com/12857772/56092189-f8a3f980-5eb8-11e9-8010-90e8fe8b71d7.png)
