### PR TITLE
⏪ Remove Grow URL monkey patch

### DIFF
--- a/frontend/templates/layouts/default.j2
+++ b/frontend/templates/layouts/default.j2
@@ -43,13 +43,13 @@
 
     <meta name="theme-color" content="#005af0"/>
 
-    <link rel="canonical" href="{{ doc.pod.podspec.base_urls.platform }}{{ doc.url.path }}"/>
-    <link rel="alternate" hreflang="x-default" href="{{ doc.pod.podspec.base_urls.platform }}{{ doc.localize(podspec.default_locale).url.path }}"/>
+    <link rel="canonical" href="{{ doc.pod.podspec.base_urls.platform }}{{ doc.url.path.replace('/index.html', '/').replace('.html', '') }}"/>
+    <link rel="alternate" hreflang="x-default" href="{{ doc.pod.podspec.base_urls.platform }}{{ doc.localize(podspec.default_locale).url.path.replace('/index.html', '/').replace('.html', '') }}"/>
     {% for locale in doc.locales if not locale == doc.locale  %}
     {% set localized_doc = doc.localize(locale) %}
     {# If the document really is localized cross-reference it #}
     {% if '@' in localized_doc.pod_path %}
-    <link rel="alternate" hreflang="{{ locale }}" href="{{ doc.pod.podspec.base_urls.platform }}{{ localized_doc.url.path }}"/>
+    <link rel="alternate" hreflang="{{ locale }}" href="{{ doc.pod.podspec.base_urls.platform }}{{ localized_doc.url.path.replace('/index.html', '/').replace('.html', '') }}"/>
     {% endif %}
     {% endfor %}
 

--- a/frontend/templates/layouts/sitemap.xml
+++ b/frontend/templates/layouts/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% for doc in docs|sort(attribute='url') if not doc.sitemap.enabled is sameas false %}
   <url>
-    <loc>{{ doc.pod.podspec.base_urls.platform }}{{ doc.url.path }}</loc>
+    <loc>{{ doc.pod.podspec.base_urls.platform }}{{ doc.url.path.replace('/index.html', '/').replace('.html', '') }}</loc>
     {% if doc.modified %}
     <lastmod>{{ doc.modified|date("%Y-%M-%D") }}</lastmod>
     {% endif %}

--- a/pages/extensions/amp_dev/extension.py
+++ b/pages/extensions/amp_dev/extension.py
@@ -1,21 +1,7 @@
 # -*- coding: utf-8 -*-
 from grow import extensions
 
-# Monkey patch grow.url before doing anything else
-from grow.common import urls
-
-urls._Url = urls.Url
-
-class AmpDevUrl(urls._Url):
-
-    def __init__(self, path, host=None, port=None, scheme=None):
-        super(AmpDevUrl, self).__init__(path, host=None, port=None, scheme=None)
-        self.path = self.path.replace('/index.html', '/').replace('.html', '')
-
-urls.Url = AmpDevUrl
-
-from grow import extensions
-from grow.documents import document, document_format, static_document
+from grow.documents import document_format
 from grow.extensions import hooks
 
 from .markdown_extras import block_filter as BlockFilter


### PR DESCRIPTION
... as the old way of patching isn't compatible with the new Grow version we only tidy the URL for the two crucial places: sitemap.xml and canonicals.