### PR TITLE
Remove gplus from amp-social-share

### DIFF
--- a/examples/source/1.components/amp-social-share.html
+++ b/examples/source/1.components/amp-social-share.html
@@ -59,7 +59,6 @@
   <div>
     <amp-social-share type="email"></amp-social-share>
     <amp-social-share type="facebook" data-param-app_id="254325784911610"></amp-social-share>
-    <amp-social-share type="gplus"></amp-social-share>
     <amp-social-share type="linkedin"></amp-social-share>
     <amp-social-share type="pinterest" data-param-media="https://amp.dev/static/samples/img/amp.jpg"></amp-social-share>
     <amp-social-share type="tumblr"></amp-social-share>
@@ -107,7 +106,6 @@
   <div>
     <amp-social-share class="rounded" type="email" width="48" height="48"></amp-social-share>
     <amp-social-share class="rounded" type="facebook" data-param-app_id="254325784911610" width="48" height="48"></amp-social-share>
-    <amp-social-share class="rounded" type="gplus" width="48" height="48"></amp-social-share>
     <amp-social-share class="rounded" type="linkedin" width="48" height="48"></amp-social-share>
     <amp-social-share class="rounded" type="pinterest" data-param-media="https://amp.dev/static/samples/img/amp.jpg" width="48" height="48"></amp-social-share>
     <amp-social-share class="rounded" type="tumblr" width="48" height="48"></amp-social-share>


### PR DESCRIPTION
Remove references in docs to gplus in amp-social-share. #1894 