### PR TITLE
🐛 Stop injecting unused deps into home.

### DIFF
--- a/frontend/templates/views/partials/format-visuals/ads.j2
+++ b/frontend/templates/views/partials/format-visuals/ads.j2
@@ -6,7 +6,7 @@
   <div class="ap-m-format-visual-image ap-m-format-visual-bottom-image">
     <amp-img class="ap--media" src="/static/img/amp-ads-bottom.jpg" layout="responsive" width="750" height="1334"></amp-img>
   </div>
-  <div class="ap-m-format-visual-image ap-m-format-visual-top-image" title="<amp-ad>">
+  <div class="ap-m-format-visual-image ap-m-format-visual-top-image" title="&lt;amp-ad&gt;">
     <amp-img src="/static/img/amp-ads-top.jpg" layout="responsive" width="750" height="656"></amp-img>
   </div>
   <div class="ap-m-format-visual-code-snippet">

--- a/frontend/templates/views/partials/format-visuals/email.j2
+++ b/frontend/templates/views/partials/format-visuals/email.j2
@@ -6,7 +6,7 @@
   <div class="ap-m-format-visual-image ap-m-format-visual-bottom-image">
     <amp-img class="ap--media" src="/static/img/amp-email-base.jpg" layout="responsive" width="1060" height="1670"></amp-img>
   </div>
-  <div class="ap-m-format-visual-image ap-m-format-visual-top-image" title="<amp-state>">
+  <div class="ap-m-format-visual-image ap-m-format-visual-top-image" title="&lt;amp-state&gt;">
     <amp-img src="/static/img/amp-email-top.jpg" layout="responsive" width="883" height="600"></amp-img>
   </div>
   <div class="ap-m-format-visual-code-snippet">

--- a/frontend/templates/views/partials/format-visuals/stories.j2
+++ b/frontend/templates/views/partials/format-visuals/stories.j2
@@ -6,7 +6,7 @@
   <div class="ap-m-format-visual-image ap-m-format-visual-bottom-image">
     <amp-img class="ap--media" src="/static/img/amp-stories-base.png" layout="responsive" width="750" height="1050"></amp-img>
   </div>
-  <div class="ap-m-format-visual-image ap-m-format-visual-top-image" title="<amp-story-grid-layer>">
+  <div class="ap-m-format-visual-image ap-m-format-visual-top-image" title="&lt;amp-story-grid-layer&gt;">
     <amp-img src="/static/img/amp-stories-monde.png" layout="responsive" width="800" height="800"></amp-img>
   </div>
   <div class="ap-m-format-visual-code-snippet">

--- a/frontend/templates/views/partials/format-visuals/websites.j2
+++ b/frontend/templates/views/partials/format-visuals/websites.j2
@@ -6,7 +6,7 @@
   <div class="ap-m-format-visual-image ap-m-format-visual-bottom-image">
     <amp-img class="ap--media" src="/static/img/component-visual-site.jpg" layout="responsive" width="750" height="1334" alt="{{ _('A website screenshot.') }}"></amp-img>
   </div>
-  <div class="ap-m-format-visual-image ap-m-format-visual-top-image" title="<amp-sidebar>">
+  <div class="ap-m-format-visual-image ap-m-format-visual-top-image" title="&lt;amp-sidebar&gt;">
     <amp-img class="ap--media" src="/static/img/component-visual-nav.jpg" layout="responsive" width="520" height="1334" alt="{{ _('A screenshot showing amp-sidebar.') }}"></amp-img>
   </div>
   <div class="ap-m-format-visual-code-snippet">


### PR DESCRIPTION
While doing the live quickcheck I just noticed that the dependency injector adds the unused extensions `amp-ad`, `amp-sidebar` to the homepage.

This strangely isn't picked up by the validator.