### PR TITLE
💬 Update amp.dev for AMP Conf Day 2.

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/custom-javascript.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/custom-javascript.md
@@ -6,15 +6,16 @@ formats:
 author: CrystalOnScript
 contributors:
   - fstanis
+description: For web experiences requiring a high amount of customization AMP has created amp-script, a component that allows the use of arbitrary JavaScript on your AMP page without affecting the page's overall performance.
 ---
 
-AMP strives to provide a consistently good experience to all users across the web by encouraging the use of high-functioning and seamless components that are ready to go out of the box. 
+AMP strives to provide a consistently good experience to all users across the web by encouraging the use of high-functioning and seamless components that are ready to go out of the box.
 
 Some web experiences require a high amount of customization that go beyond the state binding capabilities of [`amp-bind`](https://amp.dev/documentation/components/reference/amp-bind.html?format=websites) and the dynamic data retrieval and templating functionality of [`amp-list`](https://amp.dev/documentation/components/reference/amp-list.html?format=websites) and [`amp-mustache`](https://amp.dev/documentation/components/reference/amp-mustache.html?format=websites). For those one-off cases, AMP has created [`<amp-script>`](https://amp.dev/documentation/components/reference/amp-script.html?format=websites), a component that allows the use of arbitrary JavaScript on your AMP page without affecting the page's overall performance.
 
-# Inserting custom JavaScript 
+# Inserting custom JavaScript
 
-AMP pages support custom JavaScript through the `<amp-script>` component. 
+AMP pages support custom JavaScript through the `<amp-script>` component.
 
 ```html
 <!doctype html>
@@ -32,7 +33,7 @@ AMP pages support custom JavaScript through the `<amp-script>` component.
 </html>
 ```
 
-The `<amp-script>` component registers a [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) to run on a separate thread than the main page. The Web Worker is given its own copy of the DOM through `amp-script` use of [Worker DOM](https://github.com/ampproject/worker-dom). This allows the Web Worker to use JavaScript libraries, such as [React](https://reactjs.org/) and [jQuery](https://jquery.com/), without modification. 
+The `<amp-script>` component registers a [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) to run on a separate thread than the main page. The Web Worker is given its own copy of the DOM through `amp-script` use of [Worker DOM](https://github.com/ampproject/worker-dom). This allows the Web Worker to use JavaScript libraries, such as [React](https://reactjs.org/) and [jQuery](https://jquery.com/), without modification.
 
 The `amp-script` component sends messages between the Web Worker thread and the main thread, causing any changes the user makes on the main DOM to be echoed on the Web Worker's false DOM. In turn, the Web Worker can then update the false DOM, which is reflected on the main DOM.
 
@@ -40,15 +41,15 @@ The `amp-script` component sends messages between the Web Worker thread and the 
  `<amp-script>` is in experimental mode and may break in unpredictable ways.
 [/tip]
 
-## Custom scripts caching 
+## Custom scripts caching
 
-The [AMP cache](https://www.ampproject.org/docs/fundamentals/how_cached) serves custom JavaScript files inserted with `<amp-script>` same as AMP component scripts. This ensures that any custom JavaScript will not slow the speed of an AMP document. 
+The [AMP cache](https://www.ampproject.org/docs/fundamentals/how_cached) serves custom JavaScript files inserted with `<amp-script>` same as AMP component scripts. This ensures that any custom JavaScript will not slow the speed of an AMP document.
 
-The AMP cache proxies the JavaScript files and then delivers them. Users can expect the same performance experience from a page using `<amp-script>` as a page that doesn't include it. 
+The AMP cache proxies the JavaScript files and then delivers them. Users can expect the same performance experience from a page using `<amp-script>` as a page that doesn't include it.
 
 # Using `<amp-script>`
 
-To keep experiences on AMP pages consistent, limitations exist on `<amp-script>` to guarantee a fast loading time and smooth UI. 
+To keep experiences on AMP pages consistent, limitations exist on `<amp-script>` to guarantee a fast loading time and smooth UI.
 
 ## Initialization
 
@@ -57,43 +58,43 @@ JavaScript inside the Web Worker allows minimal change to the DOM on load. Chang
 *   Registering event handlers.
 *   Splitting a TextNode into multiple TextNodes, to allow for frameworks that require it.
 
-The DOM inside `<amp-script>` tags should be almost identical before and after initialization. 
+The DOM inside `<amp-script>` tags should be almost identical before and after initialization.
 
 For example, if starting with the code below:
 ```html
 <text> Hello world </text>
 ```
-Worker DOM permits minor changes in structure but not content: 
+Worker DOM permits minor changes in structure but not content:
 
 ```html
  <text>Hello </text><text>world</text>
 ```
 
-## DOM manipulation 
+## DOM manipulation
 
-For user experience and security reasons, `amp-script` enforced DOM manipulation restrictions. 
+For user experience and security reasons, `amp-script` enforced DOM manipulation restrictions.
 
-### User interaction 
+### User interaction
 
 When a user interacts with elements wrapped inside an `<amp-script>` components, DOM manipulations must respond quickly. If running a `fetch` function, DOM manipulations must be completed within a **five second** window. If your `amp-script` logic is not preforming a fetch, the DOM has **less than one second** to update the DOM.  If a script mutates the DOM outside of the permitted window, it will result in a fatal error and the `amp-script` component will terminate the Web Worker. A terminated `<amp-script>` component will not run again.
 
-### Unprompted changes 
+### Unprompted changes
 
-If your `<amp-script>` component uses a fixed layout, other than `layout=container`, and is sufficiently small, there is no interaction requirement to manipulate the DOM. 
+If your `<amp-script>` component uses a fixed layout, other than `layout=container`, and is sufficiently small, there is no interaction requirement to manipulate the DOM.
 
 [tip type="note"]
 As of April 2019, your `<amp-script>` component must be at a fixed hight of `300 px` or less to meet the unprompted change requirement.
 [/tip]
 
-## Script size 
+## Script size
 
-AMP enforces a limit of 150 kilobytes of custom JavaScript on each page. This limit is shared  among all `<amp-script>` component on that page. If using a library, it must be imported to each individual `<amp-script>` component. 
+AMP enforces a limit of 150 kilobytes of custom JavaScript on each page. This limit is shared  among all `<amp-script>` component on that page. If using a library, it must be imported to each individual `<amp-script>` component.
 
 ## Scope
 
 Any DOM elements the custom JavaScript files wishes to interact with must be wrapped inside the `<amp-script>` component tags, this includes other AMP components. The `<amp-script>` component considers `document.body` to be the `amp-script` element and not the document's `<body>` element.
 
-If you were to call `document.body.appendChild(document.createElement('span'))` within the `<amp-script>`file in the following document: 
+If you were to call `document.body.appendChild(document.createElement('span'))` within the `<amp-script>`file in the following document:
 
 ```html
 <body>  
@@ -118,11 +119,11 @@ It will result in this:
 </body>
 ```
 
-## Event triggers 
+## Event triggers
 
-As of April 2019, all event triggers are allowed. This may change in the future as `<amp-script>` is still an experimental component. 
+As of April 2019, all event triggers are allowed. This may change in the future as `<amp-script>` is still an experimental component.
 
-## API restrictions 
+## API restrictions
 
  Some synchronous methods are disallowed in `<amp-script>` and replaced with alternatives, such as [`Element.getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)). Because `Element.getBoundingClientRect()` could not be implemented in a Web Worker, an async alternative to it, `getBoundingClientRectAsync()`, is provided. `getBoundingClientRectAsync()` returns a [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) instead of returning the result directly.
 

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/interactivity_data/using_javascript.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/interactivity_data/using_javascript.md
@@ -1,8 +1,0 @@
----
-$title: Using JavaScript to create custom experiences (TBD)
-$order: 3
-formats:
-  - websites
----
-
-TBD

--- a/pages/content/amp-dev/events/amp-conf-2019.html
+++ b/pages/content/amp-dev/events/amp-conf-2019.html
@@ -36,7 +36,7 @@ section_links:
     {% do doc.styles.addCssFile('css/components/molecules/roadshow-video.css') %}
     <div class="ap-m-roadshow-video">
       <div class="ap-m-roadshow-video-block">
-        <amp-youtube data-videoid="Yx7z0rzAKqY" layout="responsive" height="9" width="16"></amp-youtube>
+        <amp-youtube data-videoid="3j540p3GxvE" layout="responsive" height="9" width="16"></amp-youtube>
       </div>
       <div class="ap-m-roadshow-video-notice">
         <a href="https://youtu.be/W7T5tMgrrFs" target="_blank">Recap Day 1</a>

--- a/pages/content/amp-dev/events/amp-conf-2019.html
+++ b/pages/content/amp-dev/events/amp-conf-2019.html
@@ -36,9 +36,10 @@ section_links:
     {% do doc.styles.addCssFile('css/components/molecules/roadshow-video.css') %}
     <div class="ap-m-roadshow-video">
       <div class="ap-m-roadshow-video-block">
-        <amp-youtube data-videoid="W7T5tMgrrFs" layout="responsive" height="9" width="16"></amp-youtube>
+        <amp-youtube data-videoid="Yx7z0rzAKqY" layout="responsive" height="9" width="16"></amp-youtube>
       </div>
       <div class="ap-m-roadshow-video-notice">
+        <a href="https://youtu.be/W7T5tMgrrFs" target="_blank">Recap Day 1</a>
         <a href="/ja/events/amp-conf-2019">日本語に切り替える</a>
       </div>
     </div>
@@ -75,7 +76,11 @@ section_links:
     <div class="ap--content-default">
       <h1>Join the conversation!</h1>
       <p>Take part in the discussion and get your questions answered by the people on stage.</p>
-      <p><a href="https://app2.sli.do/event/nulvdxp3" class="ap--slido-code">Ask a question</a></p>
+
+      {% do doc.styles.addCssFile('/css/components/atoms/button.css') %}
+      <a href="https://app2.sli.do/event/nulvdxp3" class="ap-o-stage-content-button ap-a-btn">
+        Ask a question
+      </a>
     </div>
   </div>
 </section>

--- a/pages/content/amp-dev/events/amp-conf-2019@ja.html
+++ b/pages/content/amp-dev/events/amp-conf-2019@ja.html
@@ -33,9 +33,10 @@ section_links:
     {% do doc.styles.addCssFile('css/components/molecules/roadshow-video.css') %}
     <div class="ap-m-roadshow-video">
       <div class="ap-m-roadshow-video-block">
-        <amp-youtube data-videoid="ZNmdl31cMpk" layout="responsive" height="9" width="16"></amp-youtube>
+        <amp-youtube data-videoid="DpEPnOkiVLs" layout="responsive" height="9" width="16"></amp-youtube>
       </div>
       <div class="ap-m-roadshow-video-notice">
+        <a href="https://www.youtube.com/watch?v=ZNmdl31cMpk" target="_blank">1日目を見る</a>
         <a href="/events/amp-conf-2019">Switch to English</a>
       </div>
     </div>
@@ -129,7 +130,7 @@ section_links:
                   {% elif agenda_item.speakers %}
                     {% if agenda_item.moderator %}
                     <a href="#{{ agenda_item.moderator }}" class="ap-m-agenda-item-description-speaker">{{ doc.ampconf.speakers[agenda_item.moderator].name }}, {{ doc.ampconf.speakers[agenda_item.moderator].company }}</a> (モデレータ)
-                    <br>                     
+                    <br>
                     {% endif %}
                     {% for speaker in agenda_item.speakers %}
                       <a href="#{{ speaker }}" class="ap-m-agenda-item-description-speaker">{{ doc.ampconf.speakers[speaker].name }}, {{ doc.ampconf.speakers[speaker].company }}</a>


### PR DESCRIPTION
Just that we are not facing similar trouble as this morning tomorrow 🙂 

This updates the AMP Conf page to show the livestream for Day 2 and adds a CTA to watch the recording of Day 1. (There possibly is a better term than "Recap")

Video-IDs used for the Day 2 Streams: `3j540p3GxvE` (EN) and `DpEPnOkiVLs` (JA).

<img width="670" alt="Bildschirmfoto 2019-04-17 um 13 52 48" src="https://user-images.githubusercontent.com/12857772/56262083-508c6b80-6118-11e9-97b0-32a195889712.png">

Additionally this adds a description to the newly added `amp-script` guide for better sharability and SEO.

Feel free to comment further changes that are needed for tomorrow.