### PR TITLE
🎨 Verify release tag prior build.

### DIFF
--- a/gulpfile.js/deploy.js
+++ b/gulpfile.js/deploy.js
@@ -28,7 +28,7 @@ const argv = mri(process.argv.slice(2));
 // We tag docker images by the current git commit SHA,
 // this makes it easy to identify and reproduce builds.
 // Pass a specific tag via commandline using `gulp updateStart --tag ABCDE...`
-const TAG = argv.tag || require('@lib/build/repo.js').version;
+const TAG = argv.tag || `${require('@lib/build/repo.js').version}-${Date.now()}`;
 
 // The Google Cloud project id, pass via commandline
 // using `gulp deploy --project my-gcloud-project
@@ -147,4 +147,3 @@ exports.imageBuild = imageBuild;
 exports.updateStop = updateStop;
 exports.updateStatus = updateStatus;
 exports.updateStart = updateStart;
-

--- a/gulpfile.js/deploy.js
+++ b/gulpfile.js/deploy.js
@@ -60,14 +60,14 @@ const config = {
 };
 
 /**
- * Verifies the commit SHA1 (TAG) hasn't already been built
+ * Verifies the commit SHA1 (config.tag) hasn't already been deployed
  */
 async function verifyTag() {
   const tags = await sh(`gcloud container images list-tags ${config.image.name}`, {quiet: true});
   console.log('Verifying build tag', config.tag);
   if (tags.includes(config.tag)) {
     throw new Error(`The commit ${config.tag} you are trying to build has ` +
-              'already been built!');
+              'already been deployed!');
   }
 }
 

--- a/platform/lib/utils/sh.js
+++ b/platform/lib/utils/sh.js
@@ -22,6 +22,7 @@ const {ROOT} = require('@lib/utils/project').paths;
 
 const DEFAULT_OPTIONS = {
   workingDir: ROOT,
+  quiet: false,
 };
 
 /**
@@ -30,8 +31,7 @@ const DEFAULT_OPTIONS = {
  * @param {string} the command string
  * @param {string=''} an optional message being displayed after the command has
  * terminated succesfully.
- * @param {Object=DEFAULT_OPTIONS} an optional message being displayed after the command has
- * terminated succesfully.
+ * @param {Object=DEFAULT_OPTIONS} an optional object extending the default options
  */
 function sh(string, ...params) {
   let message = '';
@@ -48,13 +48,18 @@ function sh(string, ...params) {
   console.log(`$ ${command} ${args.join(' ')}`);
   return new Promise((resolve, reject) => {
     const process = spawn(command, args, {cwd: opts.workingDir});
+    let result = '';
 
     process.stdout.on('data', (data) => {
-      console.log(`${data.toString()}`);
+      data = data.toString();
+      result += data;
+      if (!opts.quiet) {
+        console.log(data);
+      }
     });
 
     process.stderr.on('data', (data) => {
-      console.log(`${data}`);
+      console.log(`${data.toSting()}`);
     });
 
     process.on('close', (code) => {
@@ -62,19 +67,20 @@ function sh(string, ...params) {
         reject(new Error(`${command} process exited with code ${code}`));
         return;
       }
-      resolve();
+      resolve(result);
     });
-  }).then(() => console.log(message));
+  }).then((result) => {
+    console.log(message);
+    return result;
+  });
 }
 
 function extractOptions(params) {
   if (isString(params[0])) {
-    return params[1] || DEFAULT_OPTIONS;
+    return Object.assign(DEFAULT_OPTIONS, params[1] || {});
   }
-  if (params.length === 0) {
-    return DEFAULT_OPTIONS;
-  }
-  return params[0];
+
+  return Object.assign(DEFAULT_OPTIONS, params[0] || {});
 }
 
 function isString(obj) {

--- a/platform/lib/utils/sh.js
+++ b/platform/lib/utils/sh.js
@@ -59,7 +59,7 @@ function sh(string, ...params) {
     });
 
     process.stderr.on('data', (data) => {
-      console.log(`${data.toSting()}`);
+      console.log(`${data.toString()}`);
     });
 
     process.on('close', (code) => {


### PR DESCRIPTION
Not to sure if this makes sense: to prevent something similar as this morning happening we could append the current timestamp to build tags. Otherwise creating a new build based on the same commit without giving an explicit tag wouldn't be possible.