### PR TITLE
♻️ Use req.url instead of req.path for cache and log

### DIFF
--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -104,7 +104,7 @@ class Platform {
         let seconds = (timeElapsed[0] * 1000 + timeElapsed[1] / 1e6) / 1000;
         seconds = seconds.toFixed(3);
         const prefix = seconds > 1 ? 'CRITICAL TIMING' : 'TIMING';
-        console.log(`[${prefix}]: ${req.path}: ${seconds}s`);
+        console.log(`[${prefix}]: ${req.url}: ${seconds}s`);
       });
 
       next();

--- a/platform/lib/routers/pages.js
+++ b/platform/lib/routers/pages.js
@@ -222,13 +222,13 @@ if (!config.isDevMode()) {
     if (!hasFormatFilter && !hasReferrerNotification) {
       return staticMiddleware(request, response, next);
     }
-    const page = cache.get(requestPath);
+    const page = cache.get(request.url);
     if (page) {
-      console.log('[CACHE] hit', requestPath);
+      console.log('[CACHE] hit', request.url);
       response.send(page);
       return;
     }
-    console.log('[CACHE] miss', requestPath);
+    console.log('[CACHE] miss', request.url);
 
     // Apply format and referrer transformations
     try {


### PR DESCRIPTION
```
[CACHE] miss /documentation/components/?format=stories
cache count 1
[TIMING]: /documentation/components/?format=stories: 0.114s
```