### PR TITLE
🐛 Fix development setup.

### DIFF
--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -143,7 +143,6 @@ class Platform {
     // handle 404s
     this.server.use(routers.notFound);
   }
-
 };
 
 module.exports = Platform;

--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -50,7 +50,6 @@ class Platform {
     return new Promise(async (resolve, reject) => {
       try {
         this._createServer();
-        await this._configureDevMode(HOST);
         const httpServer = this.server.listen(PORT, () => {
           signale.success(`server listening on ${PORT}!`);
           resolve();
@@ -76,7 +75,6 @@ class Platform {
     // pass app engine HTTPS status to express app
     this.server.set('trust proxy', true);
 
-    this._configureDevMode();
     this._configureMiddlewares();
     this._configureSubdomains();
     this._configureRouters();
@@ -146,28 +144,6 @@ class Platform {
     this.server.use(routers.notFound);
   }
 
-  _configureDevMode() {
-    if (!config.isDevMode()) {
-      return Promise.resolve();
-    }
-    return new Promise((resolve) => {
-      const HttpProxy = require('http-proxy');
-      // When in development fire up a second server as a simple proxy
-      // to simulate CORS requests for stuff like playground
-      this.proxy = express();
-      this.proxy.listen(config.hosts.api.port, () => {
-        signale.success(`Proxy available on ${config.hosts.api.base}`);
-        resolve();
-      });
-
-      const proxy = new HttpProxy();
-      this.proxy.get('/*', (request, response, next) => {
-        proxy.web(request, response, {
-          'target': HOST,
-        }, next);
-      });
-    });
-  }
 };
 
 module.exports = Platform;

--- a/platform/lib/routers/pages.js
+++ b/platform/lib/routers/pages.js
@@ -25,8 +25,6 @@ const {project} = require('@lib/utils');
 
 // eslint-disable-next-line new-cap
 const pages = express.Router();
-const growHost = `${config.hosts.pages.scheme}://${config.hosts.pages.host}:${config.hosts.pages.port}`;
-
 
 /**
  * Inspects a incoming request (either proxied or not) for its GET args
@@ -90,7 +88,7 @@ if (config.isDevMode()) {
   async function hasManualFormatVariant(request, format) {
     const path = request.url.replace('.html', `.${format}.html`);
 
-    const page = await got(`${growHost}${path}`).catch(() => {
+    const page = await got(`${config.hosts.pages.base}${path}`).catch(() => {
       return {};
     });
 
@@ -136,7 +134,7 @@ if (config.isDevMode()) {
     }
   });
 
-  pages.use('/*', async (request, response, next) => {
+  pages.get('/*', async (request, response, next) => {
     request.url = ensureFileExtension(request.path);
 
     // Check if there is a manually filtered variant of the requested page
@@ -153,8 +151,9 @@ if (config.isDevMode()) {
 
     next();
   }, (request, response, next) => {
+
     proxy.web(request, response, {
-      'target': growHost,
+      'target': config.hosts.pages.base,
     }, next);
   });
 }

--- a/platform/lib/routers/pages.js
+++ b/platform/lib/routers/pages.js
@@ -151,7 +151,6 @@ if (config.isDevMode()) {
 
     next();
   }, (request, response, next) => {
-
     proxy.web(request, response, {
       'target': config.hosts.pages.base,
     }, next);


### PR DESCRIPTION
There was a bunch of things that were a little fishy with the development setup: `_configureDevMode` was called twice, which was the reason for the port already in use message, but additionally the server that has been started by it isn't needed anymore as all things needing CORS requests now have dedicated servers. The sample previews are served from `[10:16:29] › ℹ  info      preview dev server listening on 8084` for example.

The other thing that was broken is that the actual pages router for development was implemented as a middleware while it should have been a router (`use`/`get`). With the included changes `npm run develop` now works fine for me again.