### PR TITLE
🐛 fixed broken link for stories video

### DIFF
--- a/examples/source/0.introduction/Stories_in_AMP.html
+++ b/examples/source/0.introduction/Stories_in_AMP.html
@@ -72,7 +72,7 @@ skipValidation: 'true'
                 height="960"
                 poster="<% hosts.platform %>/static/samples/img/story_video_dog_cover.jpg"
                 layout="responsive">
-                <source src="<% hosts.platform %>/samples/video/story_video_dog.mp4" type="video/mp4">
+                <source src="<% hosts.platform %>/static/samples/video/story_video_dog.mp4" type="video/mp4">
           </amp-video>
         </amp-story-grid-layer>
       </amp-story-page>


### PR DESCRIPTION
mp4 video path was incorrect inside amp-video component. closes #1998