### PR TITLE
Make "Multiple Image" story ad template zip downloadable

### DIFF
--- a/pages/content/amp-dev/documentation/templates/multi_image_ads.yaml
+++ b/pages/content/amp-dev/documentation/templates/multi_image_ads.yaml
@@ -16,4 +16,4 @@ teaser:
     width: 9
     height: 16
 
-download_url: '/static/files/templates/multi-image-ads.zip'
+  download_url: '/static/files/templates/multi-image-ads.zip'


### PR DESCRIPTION
The "Multiple Image" Story Ads template at https://amp.dev/documentation/templates/ can't actually be downloaded, because there's no `href` property on the `<a>`. This is probably why…

<img width="1269" alt="Screenshot 2019-04-30 at 15 08 03" src="https://user-images.githubusercontent.com/51244/56967875-01076000-6b5a-11e9-85b4-4d2f8b68a942.png">