### PR TITLE
Support configured redirect links at amp.dev

### DIFF
--- a/platform/config/amp-dev-redirects.yaml
+++ b/platform/config/amp-dev-redirects.yaml
@@ -1,0 +1,23 @@
+# Redirects for amp.dev
+# External targets are possible
+#
+# The first section contains basic shortcuts
+# (For shortened deep links please use go.amp.dev/shortcut and the file 'go-links.yaml')
+#
+# The second part contains other redirects (e.g. moved pages)
+
+### Shortcuts
+# These shortcuts are intended for basic pages (not deeplinks)
+# Ensure you do not use shortcuts that would shadow real contents
+# Add new entries in alphabetical order
+/ads: /about/ads
+/docs: /documentation/guides-and-tutorials/
+/email: /about/email
+/learn: /documentation/courses/
+/samples: /documentation/examples/
+/stories: /about/stories
+/websites: /about/websites
+
+### Other redirects
+# Put here redirects for pages that have been moved, etc
+# Add new entries in alphabetical order

--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -3,7 +3,7 @@
 /ads: /about/ads
 /camp-code: https://github.com/ampproject/samples/tree/master/amp-camp
 /cors: /documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests
-/docs: /documentation/
+/docs: /documentation/guides-and-tutorials/
 /email: /about/email
 /governance: /community/governance
 /io-email: /documentation/examples/interactivity-dynamic-content/conference_survey_email/


### PR DESCRIPTION
https://github.com/ampproject/docs/issues/2008

Initial shortcuts:
/ads: /about/ads
/docs: /documentation/guides-and-tutorials/
/email: /about/email
/learn: /documentation/courses/
/samples: /documentation/examples/
/stories: /about/stories
/websites: /about/websites


Also correct an invalid go.amp.dev link