### PR TITLE
🐛 Add missing getter for formats to MarkdownDocument

### DIFF
--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -67,6 +67,10 @@ class MarkdownDocument {
     this._frontmatter['$category@'] = category;
   }
 
+  get formats() {
+    return this._frontmatter['formats'] || [];
+  }
+
   set formats(formats) {
     this._frontmatter['formats'] = formats;
   }


### PR DESCRIPTION
Fixes #2071.

https://github.com/ampproject/docs/blob/67a6ee7fe13caafa373866d9e3f3a6f2d8903bdd/platform/lib/pipeline/componentReferenceImporter.js#L112-L114

`document.formats` has always been `undefined` before.