### PR TITLE
Setup runtime logging endpoint

### DIFF
--- a/pages/content/amp-dev/message.html
+++ b/pages/content/amp-dev/message.html
@@ -1,0 +1,22 @@
+---
+$title: "[[ title ]]"
+$view: /views/custom.j2
+$sitemap:
+  enabled: false
+---
+{% do doc.styles.addCssFile('css/components/templates/error.css') %}
+{% do doc.styles.addCssFile('/css/components/molecules/jumbo.css') %}
+
+<main class="ap--main">
+  <section class="ap--container">
+    <div class="ap-m-jumbo">
+      <div class="ap-a-ico">
+        {% do doc.icons.useIcon('/icons/bolt-broken-solid.svg') %}
+        <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#bolt-broken-solid"></use></svg>
+      </div>
+      <h1 class="ap-m-jumbo-headline">[[ title ]]</h1>
+      <h2 class="ap-m-jumbo-subline">[[ subTitle ]]</h2>
+      <p class="ap-m-jumbo-copy">[[{ text }]]</p>
+    </div>
+  </section>
+</main>

--- a/platform/config/environments/development.json
+++ b/platform/config/environments/development.json
@@ -34,6 +34,12 @@
       "host": "localhost",
       "port": "8086"
 		},
+    "log": {
+      "scheme": "http",
+      "subdomain": "log",
+      "host": "localhost",
+      "port": "8087"
+		},
 		"packager": {
       "scheme": "https",
       "host": "amp-dev-sxg.appspot.com",

--- a/platform/config/environments/production.json
+++ b/platform/config/environments/production.json
@@ -34,6 +34,12 @@
       "host": "amp.dev",
       "port": ""
     },
+    "log": {
+      "scheme": "https",
+      "subdomain": "log",
+      "host": "amp.dev",
+      "port": ""
+    },
     "packager": {
       "scheme": "http",
       "host": "ig-amp-dev-packager-n37h.c.amp-dev-230314.internal",

--- a/platform/config/environments/staging.json
+++ b/platform/config/environments/staging.json
@@ -34,6 +34,12 @@
       "host": "appspot.com",
       "port": ""
     },
+    "log": {
+      "scheme": "https",
+      "subdomain": "log-dot-amp-dev-staging",
+      "host": "appspot.com",
+      "port": ""
+    },
     "packager": {
       "scheme": "https",
       "host": "amp-dev-sxg.appspot.com",

--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -32,6 +32,7 @@ const routers = {
     embeds: require('@lib/routers/example/embeds.js'),
     api: require('@examples'),
   },
+  log: require('@lib/routers/runtimeLog.js'),
   go: require('@lib/routers/go.js'),
   healthCheck: require('@lib/routers/healthCheck.js').router,
   notFound: require('@lib/routers/notFound.js'),
@@ -113,6 +114,7 @@ class Platform {
   _configureSubdomains() {
     this.server.use(subdomain.map(config.hosts.playground, routers.playground));
     this.server.use(subdomain.map(config.hosts.go, routers.go));
+    this.server.use(subdomain.map(config.hosts.log, routers.log));
     // eslint-disable-next-line new-cap
     this.server.use(subdomain.map(config.hosts.preview, express.Router().use([
       routers.example.embeds,

--- a/platform/lib/routers/runtimeLog.js
+++ b/platform/lib/routers/runtimeLog.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+const express = require('express');
+const LogFormatter = require('../runtime-log/formatter');
+
+const Templates = require('@lib/templates/');
+
+// eslint-disable-next-line new-cap
+const runtimeLog = express.Router();
+const logFormatter = new LogFormatter();
+
+runtimeLog.get('/', async (request, response) => {
+  const message = {
+    version: request.query.v,
+    id: request.query.id,
+    params: request.query.s,
+  };
+  const messageTemplate = await Templates.get('message.html');
+  try {
+    const html = logFormatter.formatHtml(message);
+    response.send(messageTemplate.render({
+      title: 'Log',
+      text: html,
+    }));
+  } catch (error) {
+    response.status(400).send('Invalid request');
+  }
+});
+
+
+module.exports = runtimeLog;
+

--- a/platform/lib/runtime-log/formatter.js
+++ b/platform/lib/runtime-log/formatter.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+/**
+ * Formats a AMP runtime log requests.
+ */
+class LogFormatter {
+  /**
+   * Turns a AMP runtime log requests into an HTML string
+   * @param {Object} message The log request object.
+   * @returns {string} HTML string
+   */
+  formatHtml(message) {
+    throw new Error('not yet implemented' + message);
+  }
+}
+
+module.exports = LogFormatter;

--- a/platform/lib/templates/index.js
+++ b/platform/lib/templates/index.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const nunjucks = require('nunjucks');
+const config = require('@lib/config.js');
+const {promisify} = require('util');
+const {readFile} = require('fs');
+const readFileAsync = promisify(readFile);
+const fetch = require('node-fetch');
+const {pagePath} = require('@lib/utils/project');
+
+let templates = null;
+
+class Templates {
+  /**
+   * Loads a template from cache (if not in dev mode). Otherwise
+   * it'll load the template from the pages directory.
+   * @param (string} templatePath The relative path to the template
+   * @param {Function} [loader] Optional function providing
+   * a string for the given templatePath.
+   * @returns {Template} a Nunjucks template instance
+   */
+  static get(templatePath, loader) {
+    if (!templates) {
+      templates = new Templates();
+    }
+    if (loader) {
+      return templates.compile(templatePath, loader);
+    }
+    return templates.load(templatePath);
+  }
+
+  constructor() {
+    this.nunjucksEnv_ = new nunjucks.Environment(null, {
+      tags: {
+        blockStart: '[%',
+        blockEnd: '%]',
+        variableStart: '[[',
+        variableEnd: ']]',
+        commentStart: '[#',
+        commentEnd: '#]',
+      }});
+
+    this.cache_ = new Map();
+  }
+
+  /**
+   * Loads a template from cache (if not in dev mode). Otherwise
+   * it'll load the template from the pages directory.
+   */
+  async load(templatePath) {
+    return this.compile(templatePath, () => {
+      if (config.isDevMode()) {
+        // fetch doc from proxy
+        return this.fetchTemplate_(templatePath);
+      } else {
+        // fetch comiled doc page from filesystem
+        return readFileAsync(pagePath(templatePath), 'utf-8');
+      }
+    });
+  }
+
+  /**
+   * Loads a template from cache (if not in dev mode). If the template
+   * is not cached, it will use the provided callback to retrieve the
+   * template string.
+   */
+  async compile(key, fn) {
+    let compiledTemplate = this.cache_.get(key);
+    if (config.isDevMode() || !compiledTemplate) {
+      const template = await fn();
+      compiledTemplate = nunjucks.compile(template, this.nunjucksEnv_);
+      this.cache_.set(key, compiledTemplate);
+    }
+    return compiledTemplate;
+  }
+
+  async fetchTemplate_(templatePath) {
+    const templateUrl = new URL(templatePath, config.hosts.pages.base);
+    const fetchResponse = await fetch(templateUrl);
+    return fetchResponse.text();
+  }
+}
+
+module.exports = Templates;


### PR DESCRIPTION
* adds a new endpoint for the log.amp.dev subdomain.
* moves server-side templates into a helper class

The actual log formatting is not yet implemented. See #2051.