### PR TITLE
♻️ Move Grow URL rewrite to dedicated extension

### DIFF
--- a/pages/extensions/amp_dev/extension.py
+++ b/pages/extensions/amp_dev/extension.py
@@ -1,20 +1,5 @@
 # -*- coding: utf-8 -*-
 from grow import extensions
-
-# Monkey patch grow.url before doing anything else
-from grow.common import urls
-
-urls._Url = urls.Url
-
-class AmpDevUrl(urls._Url):
-
-    def __init__(self, path, host=None, port=None, scheme=None):
-        super(AmpDevUrl, self).__init__(path, host=host, port=port, scheme=scheme)
-        self.path = self.path.replace('/index.html', '/').replace('.html', '')
-
-urls.Url = AmpDevUrl
-
-from grow import extensions
 from grow.documents import document, document_format, static_document
 from grow.extensions import hooks
 

--- a/pages/extensions/url_beautifier/__init__.py
+++ b/pages/extensions/url_beautifier/__init__.py
@@ -1,0 +1,1 @@
+from url_beautifier import *

--- a/pages/extensions/url_beautifier/url_beautifier.py
+++ b/pages/extensions/url_beautifier/url_beautifier.py
@@ -1,0 +1,15 @@
+from grow import extensions
+from grow.common import urls
+
+urls._Url = urls.Url
+
+class BeautifiedUrl(urls._Url):
+
+    def __init__(self, path, host=None, port=None, scheme=None):
+        super(BeautifiedUrl, self).__init__(path, host=host, port=port, scheme=scheme)
+        self.path = self.path.replace('/index.html', '/').replace('.html', '')
+
+urls.Url = BeautifiedUrl
+
+class UrlBeautifierExtension(extensions.BaseExtension):
+    pass

--- a/platform/config/podspec.yaml
+++ b/platform/config/podspec.yaml
@@ -41,3 +41,4 @@ ext:
           method: 'useIcon'
 - extensions.amp_dev.AmpDevExtension
 - extensions.amp_dependency_injector.AmpDependencyInjectorExtension
+- extensions.url_beautifier.UrlBeautifierExtension


### PR DESCRIPTION
This change should render the tips usable again in your local setup, @CrystalOnScript and @pbakaus, without installing Grow via `pip`.

Remembering the debugging information I've got from Sebastian code execution just stopped for your environments when we tried to apply the URL monkey patch - but went fine otherwise. No exception whatsoever.

By moving the URL rewrite to a dedicated extension it can (and most probably still will) fail silently while the `AmpDevExtension` responsible for rendering the tips runs flawlessly.

But I'll also try to propose a canonical way of configuring paths to the Grow team again, making this extension obsolete.