### PR TITLE
🐛 added title to email samples

### DIFF
--- a/examples/source/0.introduction/Hello_World_Email.html
+++ b/examples/source/0.introduction/Hello_World_Email.html
@@ -21,6 +21,7 @@ Learn how to create your first AMP email. This sample covers the basic structure
 <head>
   <!-- The charset definition must be the first child of the `<head>` tag. -->
   <meta charset="utf-8">
+  <title>Hello World Emails</title>
   <!-- The AMP runtime.-->
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <!-- The AMP for Email boilerplate.  -->

--- a/examples/source/interactivity-dynamic-content/Conference_Survey_Email.html
+++ b/examples/source/interactivity-dynamic-content/Conference_Survey_Email.html
@@ -19,6 +19,7 @@ This sample demonstrates how to build an AMP-powered email that contains a simpl
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
   <style amp4email-boilerplate>body{visibility:hidden}</style>
+  <title>Conference Survey Email</title>
   <style amp-custom>
     .container {
       max-width: 500px;


### PR DESCRIPTION
Without a title in the samples files, the amp playground will render 'untitled' in the header which is undesired. closes  #2059