### PR TITLE
🍎 Set default state for rolling formats animation.

### DIFF
--- a/frontend/scss/components/molecules/rolling-formats.scss
+++ b/frontend/scss/components/molecules/rolling-formats.scss
@@ -24,12 +24,7 @@
     grid-column: 1 / -1;
     grid-row: 1 / -1;
     margin-right: auto;
-    animation-name: roll;
-    animation-duration: 8s;
-    animation-delay: 1s;
-    animation-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1);
-    animation-iteration-count: infinite;
-    animation-fill-mode: backwards;
+    animation: roll 8s cubic-bezier(0.25, 0.1, 0.25, 1) 1s infinite backwards;
 
     @media (min-width: 768px) {
       margin-left: auto;
@@ -39,9 +34,9 @@
       margin-left: 0;
     }
 
-    &:nth-child(2) { animation-delay: 3s; }
-    &:nth-child(3) { animation-delay: 5s; }
-    &:nth-child(4) { animation-delay: 7s; }
+    &:nth-child(2) { animation-delay: 3s; opacity: 0; }
+    &:nth-child(3) { animation-delay: 5s; opacity: 0; }
+    &:nth-child(4) { animation-delay: 7s; opacity: 0; }
   }
 }
 


### PR DESCRIPTION
Resolves #1898. As the error isn't deterministic at all this change just sets the default animation state for the rolling animation. This way even if the animation doesn't start it won't look broken on Safari.