### PR TITLE
♻️ Migrate amp_inputmask backend API

### DIFF
--- a/examples/api/amp-inputmask.js
+++ b/examples/api/amp-inputmask.js
@@ -22,9 +22,7 @@ const upload = multer();
 // eslint-disable-next-line new-cap
 const examples = express.Router();
 
-examples.post('/default', upload.none(), handleRequest);
-examples.post('/postal', upload.none(), handleRequest);
-examples.post('/phone', upload.none(), handleRequest);
+examples.post(['/default', '/postal', '/phone'], upload.none(), handleRequest);
 
 function handleRequest(request, response) {
   const code = request.body ? request.body['code'] : '';

--- a/examples/api/amp-inputmask.js
+++ b/examples/api/amp-inputmask.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+const multer = require('multer');
+const upload = multer();
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+
+examples.all('/default', upload.none(), (request, response) => {
+  if (request.method !== 'POST') {
+    response.send('post only');
+    return;
+  }
+  const code = request.body ? request.body.code : '';
+  const codeUnmasked = request.body ? request.body.codeUnmasked : '';
+  response.json({
+    code,
+    'code-unmasked': codeUnmasked,
+  });
+});
+
+examples.all('/postal', upload.none(), (request, response) => {
+  if (request.method !== 'POST') {
+    response.send('post only');
+    return;
+  }
+  const code = request.body ? request.body['code'] : '';
+  const codeUnmasked = request.body ? request.body['code-unmasked'] : '';
+  response.json({
+    'code': code,
+    'code-unmasked': codeUnmasked,
+  });
+});
+
+examples.all('/phone', upload.none(), (request, response) => {
+  if (request.method !== 'POST') {
+    response.send('post only');
+    return;
+  }
+  const phone = request.body ? request.body['code'] : '';
+  const phoneUnmasked = request.body ? request.body['code-unmasked'] : '';
+  response.json({
+    'code': phone,
+    'code-unmasked': phoneUnmasked,
+  });
+});
+
+module.exports = examples;

--- a/examples/api/amp-inputmask.js
+++ b/examples/api/amp-inputmask.js
@@ -22,43 +22,17 @@ const upload = multer();
 // eslint-disable-next-line new-cap
 const examples = express.Router();
 
-examples.all('/default', upload.none(), (request, response) => {
-  if (request.method !== 'POST') {
-    response.send('post only');
-    return;
-  }
-  const code = request.body ? request.body.code : '';
-  const codeUnmasked = request.body ? request.body.codeUnmasked : '';
+examples.post('/default', upload.none(), handleRequest);
+examples.post('/postal', upload.none(), handleRequest);
+examples.post('/phone', upload.none(), handleRequest);
+
+function handleRequest(request, response) {
+  const code = request.body ? request.body['code'] : '';
+  const codeUnmasked = request.body ? request.body['code-unmasked'] : '';
   response.json({
     code,
     'code-unmasked': codeUnmasked,
   });
-});
-
-examples.all('/postal', upload.none(), (request, response) => {
-  if (request.method !== 'POST') {
-    response.send('post only');
-    return;
-  }
-  const code = request.body ? request.body['code'] : '';
-  const codeUnmasked = request.body ? request.body['code-unmasked'] : '';
-  response.json({
-    'code': code,
-    'code-unmasked': codeUnmasked,
-  });
-});
-
-examples.all('/phone', upload.none(), (request, response) => {
-  if (request.method !== 'POST') {
-    response.send('post only');
-    return;
-  }
-  const phone = request.body ? request.body['code'] : '';
-  const phoneUnmasked = request.body ? request.body['code-unmasked'] : '';
-  response.json({
-    'code': phone,
-    'code-unmasked': phoneUnmasked,
-  });
-});
+}
 
 module.exports = examples;

--- a/examples/source/1.components/amp-inputmask.html
+++ b/examples/source/1.components/amp-inputmask.html
@@ -44,7 +44,7 @@ The [`amp-inputmask` component](https://github.com/ampproject/amphtml/blob/maste
 
      In the mask, `L` allows the user to enter an alphabetic character. `0` denotes a numeric character. `_` is a literal space character. See the full mask specification at [the `amp-inputmask` documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-inputmask/README.md)
    -->
-  <form class="sample-form" method="post" action-xhr="<% hosts.platform %>/documentation/examples/api/postal" target="_top">
+  <form class="sample-form" method="post" action-xhr="/documentation/examples/api/postal" target="_top">
     <label>Postal code: <input name="code" mask="L0L_0L0" placeholder="A1A 1A1"></label>
     <input type="submit">
     <div submit-success>
@@ -58,7 +58,7 @@ The [`amp-inputmask` component](https://github.com/ampproject/amphtml/blob/maste
    <!--
     If the `mask-output` attribute is set to `"alphanumeric"`, `amp-inputmask` will add a hidden input with only the alphanumeric characters from the original input. The default value is `"raw"`
    -->
-  <form class="sample-form" method="post" action-xhr="<% hosts.platform %>/documentation/examples/api/phone" target="_top">
+  <form class="sample-form" method="post" action-xhr="/documentation/examples/api/phone" target="_top">
     <label>Phone: <input name="code" mask="+\1_(000)_000-0000" placeholder="+1 (555) 555-5555" mask-output="alphanumeric"></label>
     <input type="submit">
     <div submit-success>

--- a/examples/source/1.components/amp-inputmask.html
+++ b/examples/source/1.components/amp-inputmask.html
@@ -44,7 +44,7 @@ The [`amp-inputmask` component](https://github.com/ampproject/amphtml/blob/maste
 
      In the mask, `L` allows the user to enter an alphabetic character. `0` denotes a numeric character. `_` is a literal space character. See the full mask specification at [the `amp-inputmask` documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-inputmask/README.md)
    -->
-  <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-inputmask/postal" target="_top">
+  <form class="sample-form" method="post" action-xhr="/documentation/examples/api/postal" target="_top">
     <label>Postal code: <input name="code" mask="L0L_0L0" placeholder="A1A 1A1"></label>
     <input type="submit">
     <div submit-success>
@@ -58,7 +58,7 @@ The [`amp-inputmask` component](https://github.com/ampproject/amphtml/blob/maste
    <!--
     If the `mask-output` attribute is set to `"alphanumeric"`, `amp-inputmask` will add a hidden input with only the alphanumeric characters from the original input. The default value is `"raw"`
    -->
-  <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-inputmask/postal" target="_top">
+  <form class="sample-form" method="post" action-xhr="/documentation/examples/api/phone" target="_top">
     <label>Postal code: <input name="code" mask="L0L_0L0" placeholder="A1A 1A1" mask-output="alphanumeric"></label>
     <input type="submit">
     <div submit-success>

--- a/examples/source/1.components/amp-inputmask.html
+++ b/examples/source/1.components/amp-inputmask.html
@@ -59,7 +59,7 @@ The [`amp-inputmask` component](https://github.com/ampproject/amphtml/blob/maste
     If the `mask-output` attribute is set to `"alphanumeric"`, `amp-inputmask` will add a hidden input with only the alphanumeric characters from the original input. The default value is `"raw"`
    -->
   <form class="sample-form" method="post" action-xhr="/documentation/examples/api/phone" target="_top">
-    <label>Postal code: <input name="code" mask="L0L_0L0" placeholder="A1A 1A1" mask-output="alphanumeric"></label>
+    <label>Phone: <input name="code" mask="+\1_(000)_000-0000" placeholder="+1 (555) 555-5555" mask-output="alphanumeric"></label>
     <input type="submit">
     <div submit-success>
       <template type="amp-mustache">

--- a/examples/source/1.components/amp-inputmask.html
+++ b/examples/source/1.components/amp-inputmask.html
@@ -44,7 +44,7 @@ The [`amp-inputmask` component](https://github.com/ampproject/amphtml/blob/maste
 
      In the mask, `L` allows the user to enter an alphabetic character. `0` denotes a numeric character. `_` is a literal space character. See the full mask specification at [the `amp-inputmask` documentation](https://github.com/ampproject/amphtml/blob/master/extensions/amp-inputmask/README.md)
    -->
-  <form class="sample-form" method="post" action-xhr="/documentation/examples/api/postal" target="_top">
+  <form class="sample-form" method="post" action-xhr="<% hosts.platform %>/documentation/examples/api/postal" target="_top">
     <label>Postal code: <input name="code" mask="L0L_0L0" placeholder="A1A 1A1"></label>
     <input type="submit">
     <div submit-success>
@@ -58,7 +58,7 @@ The [`amp-inputmask` component](https://github.com/ampproject/amphtml/blob/maste
    <!--
     If the `mask-output` attribute is set to `"alphanumeric"`, `amp-inputmask` will add a hidden input with only the alphanumeric characters from the original input. The default value is `"raw"`
    -->
-  <form class="sample-form" method="post" action-xhr="/documentation/examples/api/phone" target="_top">
+  <form class="sample-form" method="post" action-xhr="<% hosts.platform %>/documentation/examples/api/phone" target="_top">
     <label>Phone: <input name="code" mask="+\1_(000)_000-0000" placeholder="+1 (555) 555-5555" mask-output="alphanumeric"></label>
     <input type="submit">
     <div submit-success>

--- a/examples/source/interactivity-dynamic-content/Paged_List.html
+++ b/examples/source/interactivity-dynamic-content/Paged_List.html
@@ -118,7 +118,7 @@ teaserImage: '/static/samples/img/teaser/paged_list.jpg'
       padding: var(--space-1) var(--space-2);
       cursor: pointer;
     }
-    .nav {
+    .navigation {
       display: flex;
     }
     .prev,
@@ -168,7 +168,7 @@ teaserImage: '/static/samples/img/teaser/paged_list.jpg'
               <button>Show more</button>
             </div>
   </amp-list>
-  <div class="nav">
+  <div class="navigation">
     <button class="prev"
             hidden
             [hidden]="pageNumber < 2"


### PR DESCRIPTION
Migrated the backend/amp-inputmask.go from ampbyexample.com to amp.dev.
I fixed the examples and updated the second example to match its headline.

Part of the migration/improvements in #2054.