### PR TITLE
♻️ Migrate autosuggest API to amp.dev

### DIFF
--- a/examples/api/autosuggest.js
+++ b/examples/api/autosuggest.js
@@ -81,29 +81,24 @@ examples.post('/autosuggest/address', upload.none(), handleAddressRequest);
 function handleSearchRequest(request, response) {
   const query = request.query ? request.query.q : '';
 
-  const results = US_CAPITAL_CITIES.filter((key) => {
+  let results = US_CAPITAL_CITIES.filter((key) => {
     return key.toUpperCase().includes(query.toUpperCase());
   });
 
-  if (results.length > 0) {
-    const visibleResults = Math.min(results.length, MAX_RESULT_SIZE);
-    response.json({
-      'items': [
-        {
-          query,
-          'results': results.slice(0, visibleResults),
-        },
-      ],
-    });
-  } else {
-    response.json({
-      'items': [
-        {
-          query,
-        },
-      ],
-    });
+  if (results.length > MAX_RESULT_SIZE) {
+    results = results.slice(0, MAX_RESULT_SIZE);
   }
+
+  const items = ({
+    items: [
+      {
+        query,
+        results,
+      },
+    ],
+  });
+
+  response.json(items);
 };
 
 function handleAddressRequest(request, response) {

--- a/examples/api/autosuggest.js
+++ b/examples/api/autosuggest.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+const multer = require('multer');
+const upload = multer();
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+const US_CAPITAL_CITIES = [
+  'Montgomery, Alabama',
+  'Juneau, Alaska',
+  'Phoenix, Arizona',
+  'Little Rock, Arkansas',
+  'Sacramento, California',
+  'Denver, Colorado',
+  'Hartford, Connecticut',
+  'Dover, Delaware',
+  'Tallahassee, Florida',
+  'Atlanta, Georgia',
+  'Honolulu, Hawaii',
+  'Boise, Idaho',
+  'Springfield, Illinois',
+  'Indianapolis, Indiana',
+  'Des Moines, Iowa',
+  'Topeka, Kansas',
+  'Frankfort, Kentucky',
+  'Baton Rouge, Louisiana',
+  'Augusta, Maine',
+  'Annapolis, Maryland',
+  'Boston, Massachusetts',
+  'Lansing, Michigan',
+  'Saint Paul, Minnesota',
+  'Jackson, Mississippi',
+  'Jefferson City, Missouri',
+  'Helena, Montana',
+  'Lincoln, Nebraska',
+  'Carson City, Nevada',
+  'Concord, New Hampshire',
+  'Trenton, New Jersey',
+  'Santa Fe, New Mexico',
+  'Albany, New York',
+  'Raleigh, North Carolina',
+  'Bismarck, North Dakota',
+  'Columbus, Ohio',
+  'Oklahoma City, Oklahoma',
+  'Salem, Oregon',
+  'Harrisburg, Pennsylvania',
+  'Providence, Rhode Island',
+  'Columbia, South Carolina',
+  'Pierre, South Dakota',
+  'Nashville, Tennessee',
+  'Austin, Texas',
+  'Salt Lake City, Utah',
+  'Montpelier, Vermont',
+  'Richmond, Virginia',
+  'Olympia, Washington',
+  'Charleston, West Virginia',
+  'Madison, Wisconsin',
+  'Cheyenne, Wyoming',
+];
+
+examples.get('/autosuggest/search_list', upload.none(), handleSearchRequest);
+examples.post('/autosuggest/address', upload.none(), handleAddressRequest);
+
+function handleSearchRequest(request, response) {
+  const query = request.query ? request.query.q : '';
+
+  const results = US_CAPITAL_CITIES.filter((key) => {
+    return key.toUpperCase().includes(query.toUpperCase());
+  });
+
+  if (results.length > 0) {
+    const visibleResults = min(results.length, 4);
+    response.json({
+      'items': [
+        {
+          query,
+          'results': results.slice(0, visibleResults),
+        },
+      ],
+    });
+  } else {
+    response.json({
+      'items': [
+        {
+          query,
+        },
+      ],
+    });
+  }
+};
+
+function handleAddressRequest(request, response) {
+  const city = request.body ? request.body.city : '';
+
+  if (US_CAPITAL_CITIES.includes(city)) {
+    response.json({
+      'result': `Success! Your package is on it's way to ${city}.`,
+    });
+  } else {
+    response.json({
+      'result': `Sorry! We don't ship to ${city}.`,
+    });
+  }
+};
+
+function min(x, y) {
+  if (x < y) {
+    return x;
+  } else {
+    return y;
+  }
+}
+
+module.exports = examples;

--- a/examples/api/autosuggest.js
+++ b/examples/api/autosuggest.js
@@ -85,7 +85,7 @@ function handleSearchRequest(request, response) {
   });
 
   if (results.length > 0) {
-    const visibleResults = min(results.length, 4);
+    const visibleResults = Math.min(results.length, 4);
     response.json({
       'items': [
         {
@@ -118,13 +118,5 @@ function handleAddressRequest(request, response) {
     });
   }
 };
-
-function min(x, y) {
-  if (x < y) {
-    return x;
-  } else {
-    return y;
-  }
-}
 
 module.exports = examples;

--- a/examples/api/autosuggest.js
+++ b/examples/api/autosuggest.js
@@ -21,6 +21,7 @@ const upload = multer();
 
 // eslint-disable-next-line new-cap
 const examples = express.Router();
+const MAX_RESULT_SIZE = 4;
 const US_CAPITAL_CITIES = [
   'Montgomery, Alabama',
   'Juneau, Alaska',
@@ -85,7 +86,7 @@ function handleSearchRequest(request, response) {
   });
 
   if (results.length > 0) {
-    const visibleResults = Math.min(results.length, 4);
+    const visibleResults = Math.min(results.length, MAX_RESULT_SIZE);
     response.json({
       'items': [
         {

--- a/examples/api/autosuggest.js
+++ b/examples/api/autosuggest.js
@@ -108,16 +108,17 @@ function handleSearchRequest(request, response) {
 
 function handleAddressRequest(request, response) {
   const city = request.body ? request.body.city : '';
+  let result;
 
   if (US_CAPITAL_CITIES.includes(city)) {
-    response.json({
-      'result': `Success! Your package is on it's way to ${city}.`,
-    });
+    result = `Success! Your package is on it's way to ${city}.`;
   } else {
-    response.json({
-      'result': `Sorry! We don't ship to ${city}.`,
-    });
+    result = `Sorry! We don't ship to ${city}.`;
   }
+
+  response.json({
+    result,
+  });
 };
 
 module.exports = examples;

--- a/examples/source/interactivity-dynamic-content/Autosuggest_form.html
+++ b/examples/source/interactivity-dynamic-content/Autosuggest_form.html
@@ -198,7 +198,7 @@ The remaining rules set the style and layout of the form fields.
   >
     <form
       method="post"
-      action-xhr="<% hosts.backend %>/advanced/autosuggest/address"
+      action-xhr="/documentation/examples/api/autosuggest/address"
       target="_blank"
       id="search-form"
       on="
@@ -258,7 +258,7 @@ The remaining rules set the style and layout of the form fields.
               class="autosuggest-box"
               layout="fixed-height"
               height="120"
-              src="/advanced/autosuggest/search_list"
+              src="/documentation/examples/api/autosuggest/search_list"
               [src]="query ?
                 autosuggest.endpoint + query :
                 autosuggest.emptyAndInitialTemplateJson"
@@ -321,7 +321,7 @@ The remaining rules set the style and layout of the form fields.
   <amp-state id="autosuggest">
     <script type="application/json">
     {
-      "endpoint": "/advanced/autosuggest/search_list?q=",
+      "endpoint": "/documentation/examples/api/autosuggest/search_list?q=",
       "emptyAndInitialTemplateJson": [{
         "query": "",
         "results": []


### PR DESCRIPTION
Migrated the backend/autosuggest.go from ampbyexample.com to amp.dev.
This fixes the example on https://amp.dev/documentation/examples/interactivity-dynamic-content/autosuggest_form/.

Part of the migration/improvements in #2054.