### PR TITLE
♻️ Migrate favorite button API to amp.dev

### DIFF
--- a/examples/source/interactivity-dynamic-content/Favorite_Button/api.js
+++ b/examples/source/interactivity-dynamic-content/Favorite_Button/api.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const multer = require('multer');
+const upload = multer();
+const {setMaxAge} = require('@lib/utils/cacheHelpers');
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+examples.use(cookieParser());
+const AMP_FAVORITE_COOKIE = 'amp-favorite';
+const AMP_FAVORITE_COUNT_COOKIE = 'amp-favorite-with-count';
+const EXPIRATION_DATE = 365*24*60*60*1000; // 365 days in ms
+
+examples.all('/favorite', upload.none(), (request, response) => {
+  setMaxAge(response, 0);
+  const favorite = readFavoriteFromCookie(request, AMP_FAVORITE_COOKIE);
+  if (request.method === 'POST') {
+    writeFavoriteCookie(response, AMP_FAVORITE_COOKIE, !favorite);
+    response.json(!favorite);
+  } else if (request.method === 'GET') {
+    response.json(favorite);
+  }
+});
+examples.all('/favorite-with-count', upload.none(), (request, response) => {
+  setMaxAge(response, 0);
+  const favorite = readFavoriteFromCookie(request, AMP_FAVORITE_COUNT_COOKIE);
+  if (request.method === 'POST') {
+    writeFavoriteCookie(response, AMP_FAVORITE_COUNT_COOKIE, !favorite);
+    writeFavoriteWithCount(response, !favorite);
+  } else if (request.method === 'GET') {
+    writeFavoriteWithCount(response, favorite);
+  }
+});
+
+function writeFavoriteWithCount(response, value) {
+  let count;
+  if (value) {
+    count = 124;
+  } else {
+    count = 123;
+  }
+  response.json({
+    value,
+    count,
+  });
+}
+
+function readFavoriteFromCookie(request, name) {
+  const favorite = request.cookies[name];
+  if (!favorite) {
+    return false;
+  }
+  return favorite.value;
+}
+
+function writeFavoriteCookie(response, name, value) {
+  response.cookie(name, {value}, {maxAge: EXPIRATION_DATE});
+}
+
+module.exports = examples;

--- a/examples/source/interactivity-dynamic-content/Favorite_Button/index.html
+++ b/examples/source/interactivity-dynamic-content/Favorite_Button/index.html
@@ -137,7 +137,7 @@ author: sebastianbenz
     -->
     <amp-state id="favorite"
                credentials="include"
-               src="/favorite">
+               src="favorite">
     </amp-state>
 
     <!--
@@ -160,7 +160,7 @@ author: sebastianbenz
     -->
     <form class="favorite-button"
           method="post"
-          action-xhr="/favorite"
+          action-xhr="favorite"
           target="_top"
           on="submit:AMP.setState({
                         favorite: !favorite
@@ -175,7 +175,7 @@ author: sebastianbenz
                 credentials="include"
                 items="."
                 single-item
-                src="/favorite">
+                src="favorite">
         <template type="amp-mustache">
           <input type="submit"
                  class="{{#.}}heart-fill{{/.}}{{^.}}heart-border{{/.}}"
@@ -203,7 +203,7 @@ author: sebastianbenz
     -->
     <amp-state id="favoriteWithCount"
                credentials="include"
-               src="/favorite-with-count">
+               src="favorite-with-count">
     </amp-state>
     <!--
     The implementation is similar to the previous sample, but also updates the count when the button is clicked
@@ -220,7 +220,7 @@ author: sebastianbenz
     -->
     <form class="favorite-button"
           method="post"
-          action-xhr="/favorite-with-count"
+          action-xhr="favorite-with-count"
           target="_top"
           on="submit:AMP.setState({
                    previousFavoriteWithCount: favoriteWithCount,
@@ -241,7 +241,7 @@ author: sebastianbenz
                 items="."
                 single-item
                 noloading
-                src="/favorite-with-count">
+                src="favorite-with-count">
         <template type="amp-mustache">
           <div class="favorite-container">
             <input type="submit"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4273,6 +4273,22 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
+    "cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -12637,8 +12653,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "amp-toolbox-cors": "0.2.5",
     "casual": "1.6.0",
     "cheerio": "1.0.0-rc.3",
-    "cookie-parser": "^1.4.4",
+    "cookie-parser": "1.4.4",
     "cors": "2.8.5",
     "express": "4.17.0",
     "http-proxy": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "amp-toolbox-cors": "0.2.5",
     "casual": "1.6.0",
     "cheerio": "1.0.0-rc.3",
+    "cookie-parser": "^1.4.4",
     "cors": "2.8.5",
     "express": "4.17.0",
     "http-proxy": "1.17.0",


### PR DESCRIPTION
Migrated the backend/favorite.go from ampbyexample.com to amp.dev.
This fixes the example on https://amp.dev/documentation/examples/interactivity-dynamic-content/favorite_button/.

Part of the migration/improvements in #2054.