### PR TITLE
🐛 Correctly handle multiple sample builds

### DIFF
--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -69,6 +69,8 @@ function clean() {
     project.absolute('pages/.depcache.json'),
     project.absolute('pages/podspec.yaml'),
 
+    project.absolute('examples/static/samples/samples.json'),
+
     project.paths.GROW_BUILD_DEST,
     project.paths.STATICS_DEST,
     project.absolute('platform/static'),
@@ -233,7 +235,7 @@ async function fetchArtifacts() {
  * @return {Promise}
  */
 async function buildPages(done) {
-  gulp.series(fetchArtifacts, gulp.parallel(buildSamples, buildFrontend),
+  gulp.series(fetchArtifacts, buildFrontend,
       // eslint-disable-next-line prefer-arrow-callback
       async function buildGrow() {
         config.configureGrow();
@@ -405,7 +407,8 @@ exports.buildPrepare = buildPrepare;
 exports.transformPages = transformPages;
 exports.fetchArtifacts = fetchArtifacts;
 exports.collectStatics = collectStatics;
-exports.buildFinalize = gulp.parallel(fetchArtifacts, collectStatics, persistBuildInfo);
+exports.buildFinalize = gulp.series(fetchArtifacts,
+    gulp.parallel(collectStatics, persistBuildInfo));
 
 exports.build = gulp.series(clean, buildPrepare, buildPages,
     gulp.parallel(collectStatics, persistBuildInfo));

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -314,8 +314,15 @@ class SamplesBuilder {
       }
     }
 
-    return writeFileAsync(SITEMAP_DEST, JSON.stringify(this._sitemap)).then(() => {
+    return writeFileAsync(SITEMAP_DEST, JSON.stringify(this._sitemap), {
+      flag: 'wx+',
+    }).then(() => {
       this._log.success('Wrote sample sitemap.');
+    }).catch(() => {
+      // An existing sitemap is okay as it is assumed that every other write
+      // results from a watch-build and would not contain all samples
+      this._log.info('Samples sitemap already exists');
+      return;
     });
   }
 


### PR DESCRIPTION
- The reason while the sample sitemap isn't existing on staging is that `finalizeBuild` collected the static files before the build artifacts had been extracted
- Additionally subsequent calls of `gulp buildSamples` only did write partial sample sitemaps - therefore an existing sample sitemap is not overwritten anymore