### PR TITLE
Add ~/bin to path for grow exec

### DIFF
--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -18,6 +18,7 @@
 
 const gulp = require('gulp');
 const {sh} = require('@lib/utils/sh');
+const grow = require('@lib/utils/grow');
 const config = require('@lib/config');
 const signale = require('signale');
 const del = require('del');
@@ -239,9 +240,7 @@ async function buildPages(done) {
       // eslint-disable-next-line prefer-arrow-callback
       async function buildGrow() {
         config.configureGrow();
-        await sh('grow deploy --noconfirm --threaded', {
-          workingDir: project.paths.GROW_POD,
-        });
+        await grow('deploy --noconfirm --threaded');
       }, transformPages,
       // eslint-disable-next-line prefer-arrow-callback
       async function storeArtifacts() {

--- a/gulpfile.js/develop.js
+++ b/gulpfile.js/develop.js
@@ -18,7 +18,7 @@
 
 const gulp = require('gulp');
 const {project} = require('@lib/utils');
-const {sh} = require('@lib/utils/sh');
+const grow = require('@lib/utils/grow');
 const config = require('@lib/config');
 const Platform = require('@lib/platform');
 const signale = require('signale');
@@ -42,9 +42,8 @@ function _run() {
   gulp.watch(`${project.paths.SCSS}/**/*`, build.sass);
 
   config.configureGrow();
-  sh(`grow run --port ${config.hosts.pages.port}`, {
-    workingDir: project.paths.GROW_POD,
-  });
+
+  grow(`run --port ${config.hosts.pages.port}`);
 
   new Platform().start();
 }

--- a/platform/lib/utils/grow.js
+++ b/platform/lib/utils/grow.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const {sh} = require('@lib/utils/sh');
+const {project} = require('@lib/utils');
+
+/**
+ * Will execute grow in the configured pod path "project.paths.GROW_POD"
+ * @param args the arguments for grow in a string
+ */
+function exec(args) {
+  return sh(
+      // to support local execution where grow is often not in the path, we add the default install path ~/bin
+      ['sh', '-c', `PATH=$PATH:~/bin && grow ${args}`],
+      {
+        workingDir: project.paths.GROW_POD,
+      });
+}
+
+module.exports = exec;

--- a/platform/lib/utils/sh.js
+++ b/platform/lib/utils/sh.js
@@ -85,7 +85,7 @@ function extractOptions(params) {
 
 function extractCommandFragments(command) {
   if (typeof command === 'string') {
-    return command.replace(/\\(\r?\n)+/gm, ' ')
+    return command.replace(/\s+/gm, ' ')
         .trim()
         .split(' ');
   }

--- a/platform/lib/utils/sh.js
+++ b/platform/lib/utils/sh.js
@@ -25,26 +25,26 @@ const DEFAULT_OPTIONS = {
   quiet: false,
 };
 
+
 /**
  * Executes a shell command.
  *
- * @param {string} the command string
+ * @param commandLine the command string, or array of command and argument parts (useful if arguments have spaces).
  * @param {string=''} an optional message being displayed after the command has
  * terminated succesfully.
  * @param {Object=DEFAULT_OPTIONS} an optional object extending the default options
  */
-function sh(string, ...params) {
+function sh(commandLine, ...options) {
   let message = '';
-  let opts = DEFAULT_OPTIONS;
-  if (isString(params[0])) {
-    message = params[0];
+  const opts = extractOptions(options);
+  if (isString(options[0])) {
+    message = options[0];
   }
-  opts = extractOptions(params);
 
-  string = string.replace(/\\(\r?\n)+/gm, ' ').trim();
-  const fragments = string.split(/ +/gm);
+  const fragments = extractCommandFragments(commandLine);
   const command = fragments[0];
   const args = fragments.splice(1);
+
   console.log(`$ ${command} ${args.join(' ')}`);
   return new Promise((resolve, reject) => {
     const process = spawn(command, args, {cwd: opts.workingDir});
@@ -82,6 +82,16 @@ function extractOptions(params) {
 
   return Object.assign({}, DEFAULT_OPTIONS, params[0] || {});
 }
+
+function extractCommandFragments(command) {
+  if (typeof command === 'string') {
+    return command.replace(/\\(\r?\n)+/gm, ' ')
+        .trim()
+        .split(' ');
+  }
+  return command;
+}
+
 
 function isString(obj) {
   return obj && obj.length > 0 && typeof obj[0] === 'string';


### PR DESCRIPTION
Problem was, that the grow installation without pip does not put grow in the path, but specifies an alias to ~/bin/grow. This is not available when calling "grow" via node.
* Extra lib for grow to add ~/bin to the path
* To suport blanks in parameters sh can now be called with an array