### PR TITLE
Style and layout: Updated auto-layout table

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/develop/style_and_layout/control_layout.md
@@ -139,7 +139,7 @@ the appropriate value:
       <td data-th="Inferred layout"><code>responsive</code></td>
     </tr>
     <tr>
-      <td data-th="Rule"><code>width</code> or <code>height</code> attributes are present</td>
+      <td data-th="Rule">Both <code>width</code> and <code>height</code> attributes are present</td>
       <td data-th="Inferred layout"><code>fixed</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
This was misleading. Both `width` and `height` are needed for `layout="fixed"`.

Demo: https://jsbin.com/rujipoh/6/edit?html,console