### PR TITLE
🐛 Improve DX for local environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ You can then start developing in your local environment with the command below. 
 $ gulp develop
 ```
 
+This command prints a lot to the shell and will most probably end on `Server ready. Press ctrl-c to quit.`. This means everything went fine so far but other than stated in the logs the site is then available at [http://localhost:8080/](http://localhost:8080/). The service running on 8081 is only Grow rendering the pages.
+
 ### Maintenance
 
 #### Documents

--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -402,6 +402,9 @@ function persistBuildInfo(done) {
 }
 
 exports.clean = clean;
+exports.sass = sass;
+exports.icons = icons;
+exports.templates = templates;
 exports.importAll = importAll;
 exports.buildPlayground = buildPlayground;
 exports.buildBoilerplate = buildBoilerplate;

--- a/gulpfile.js/develop.js
+++ b/gulpfile.js/develop.js
@@ -29,21 +29,19 @@ function bootstrap(done) {
   gulp.parallel(build.buildBoilerplate, build.buildPlayground, build.importAll)(done);
 }
 
-function develop(done) {
-  gulp.series(gulp.parallel(build.buildFrontend, build.collectStatics), _run)(done);
+function develop() {
+  gulp.series(gulp.parallel(build.buildFrontend, build.collectStatics), run)();
 }
 
-function _run() {
-  signale.info('Watching icons, templates and styles ...');
-
-  samplesBuilder.build(true);
-  gulp.watch(`${project.paths.ICONS}/**/*`, build.icons);
-  gulp.watch(`${project.paths.TEMPLATES}/**/*`, build.templates);
-  gulp.watch(`${project.paths.SCSS}/**/*`, build.sass);
-
+function run() {
   config.configureGrow();
-
   grow(`run --port ${config.hosts.pages.port}`);
+
+  signale.info('Watching icons, templates, styles and samples ...');
+  samplesBuilder.build(true);
+  gulp.watch(`${project.paths.ICONS}/**/*.svg`, build.icons);
+  gulp.watch(`${project.paths.TEMPLATES}/**/*.j2`, build.templates);
+  gulp.watch(`${project.paths.SCSS}/**/*.scss`, build.sass);
 
   new Platform().start();
 }


### PR DESCRIPTION
- Gulp just fails dead-silent if the second argument to `gulp.watch` is not a valid callable which was our case as `sass`, `icons` and `templates` had never been exported from `build.js` - finding this took me longer than I'd like to admit
- Coming from the feedback in #welcome-contributors on Slack I had the feeling it might be helpful to make it clearer which port you should actually access.