### PR TITLE
changed default input values and sum for calcultor

### DIFF
--- a/examples/static/samples/standalone/amp-website/index.html
+++ b/examples/static/samples/standalone/amp-website/index.html
@@ -105,11 +105,11 @@
 
   <input type="number" 
          on="input-debounced:AMP.setState({a: event.valueAsNumber})" 
-         value="1"> +
+         value="0"> +
   <input type="number" 
         on="input-debounced:AMP.setState({b: event.valueAsNumber})" 
-        value="1"> =
- <span [text]="a + b">1</span>
+        value="0"> =
+ <span [text]="a + b">0</span>
 
 </body>
 </html>


### PR DESCRIPTION
The default value for input fields is 1 and the default sum is also 1, creating misinterpretation. Since the initial value for Amp state, a and b is not set it is better we keep 0 for input fields.