### PR TITLE
Don't redirect static files to amp.dev

### DIFF
--- a/examples/static/samples/files/resizable-iframe.html
+++ b/examples/static/samples/files/resizable-iframe.html
@@ -65,7 +65,8 @@
       var message = {
         sentinel: 'amp',
         type: 'embed-size',
-        height: document.body.scrollHeight
+        height: size,
+        width: size,
       };
       console.log('post new embed-height', message);
       window.parent.postMessage(message, '*');

--- a/platform/lib/build/samplesBuilder.js
+++ b/platform/lib/build/samplesBuilder.js
@@ -218,7 +218,7 @@ class SamplesBuilder {
         'platform': platformHost,
         'api': API_HOST,
         'backend': BACKEND_HOST,
-        'preview': config.getHost(config.hosts.preview),
+        'preview': config.hosts.preview.base,
       },
     }).then((parsedSample) => {
       // parsedSample.filePath is absolute but needs to be relative in order

--- a/platform/lib/platform.js
+++ b/platform/lib/platform.js
@@ -28,9 +28,10 @@ const subdomain = require('./middleware/subdomain.js');
 const routers = {
   boilerplate: require('../../boilerplate/backend/'),
   example: {
-    sources: require('@lib/routers/example/sources.js'),
-    embeds: require('@lib/routers/example/embeds.js'),
     api: require('@examples'),
+    embeds: require('@lib/routers/example/embeds.js'),
+    sources: require('@lib/routers/example/sources.js'),
+    static: require('@lib/routers/example/static.js'),
   },
   log: require('@lib/routers/runtimeLog.js'),
   go: require('@lib/routers/go.js'),
@@ -118,6 +119,7 @@ class Platform {
     // eslint-disable-next-line new-cap
     this.server.use(subdomain.map(config.hosts.preview, express.Router().use([
       routers.example.api,
+      routers.example.static,
       routers.example.embeds,
       routers.example.sources,
     ])));

--- a/platform/lib/routers/example/static.js
+++ b/platform/lib/routers/example/static.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const express = require('express');
+const project = require('@lib/utils/project');
+
+// eslint-disable-next-line new-cap
+const staticRouter = express.Router();
+staticRouter.use('/static', express.static(project.paths.STATICS_DEST));
+
+module.exports = staticRouter;


### PR DESCRIPTION
Before, preview.amp.dev would redirect all static
files to amp.dev. Now, preview.amp.dev directly
serves these without a redirect. This will fix the amp-iframe
resizing sample as the embedded iframe is now truly hosted
from a different origin (instead of redirecting...).

This commit also fixes the resizable iframe embed to also set the
height.

Fixes #2115