### PR TITLE
🚸 Use last non-merge commit message for build info

### DIFF
--- a/platform/lib/utils/git.js
+++ b/platform/lib/utils/git.js
@@ -17,5 +17,5 @@ const {execSync} = require('child_process');
 
 
 module.exports.version = execSync('git log -1 --pretty=%H').toString().trim();
-module.exports.message = execSync('git log -1 --pretty=%B').toString().trim();
+module.exports.message = execSync('git log -1 --pretty=%B --no-merges').toString().trim();
 module.exports.user = execSync('git config user.name').toString().trim();


### PR DESCRIPTION
... otherwise `whoAmI.build.commit.message` on prod would always hold "Merge branch 'future' into production-amp-dev".