### PR TITLE
Fix/sidebar

### DIFF
--- a/frontend/scss/components/organisms/_sidebar.scss
+++ b/frontend/scss/components/organisms/_sidebar.scss
@@ -169,3 +169,20 @@
   height: 10px;
   margin-top: 10px;
 }
+
+@mixin close-sidebar {
+  position: fixed;
+  right: 14px;
+  bottom: 14px;
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  color: color('blue-ribbon');
+  box-shadow: shadows('regular');
+  border-radius: 25px;
+  background: #fff;
+  z-index: 9999999999;
+}

--- a/frontend/scss/components/organisms/component-sidebar.scss
+++ b/frontend/scss/components/organisms/component-sidebar.scss
@@ -50,6 +50,9 @@ nav[toolbar] {
 .#{utility('ampsidebar')} {
   width: 100%;
   max-width: 90vw;
+
+  & + .close-sidebar { display: none; }
+  &[open] + .close-sidebar { @include close-sidebar; }
 }
 
 .#{organism('component-sidebar')} {

--- a/frontend/scss/components/organisms/component-sidebar.scss
+++ b/frontend/scss/components/organisms/component-sidebar.scss
@@ -51,6 +51,12 @@ nav[toolbar] {
   width: 100%;
   max-width: 90vw;
 
+  .#{molecule('format-toggle')} {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
   & + .close-sidebar { display: none; }
   &[open] + .close-sidebar { @include close-sidebar; }
 }

--- a/frontend/scss/components/organisms/sidebar.scss
+++ b/frontend/scss/components/organisms/sidebar.scss
@@ -41,6 +41,9 @@ nav[toolbar] {
 .#{utility('ampsidebar')} {
   width: 100%;
   max-width: 90vw;
+
+  & + .close-sidebar { display: none; }
+  &[open] + .close-sidebar { @include close-sidebar; }
 }
 
 .#{organism('sidebar')} {

--- a/frontend/scss/components/organisms/sidebar.scss
+++ b/frontend/scss/components/organisms/sidebar.scss
@@ -42,6 +42,12 @@ nav[toolbar] {
   width: 100%;
   max-width: 90vw;
 
+  .#{molecule('format-toggle')} {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
   & + .close-sidebar { display: none; }
   &[open] + .close-sidebar { @include close-sidebar; }
 }

--- a/frontend/templates/views/partials/component-sidebar.j2
+++ b/frontend/templates/views/partials/component-sidebar.j2
@@ -5,15 +5,12 @@
   class="ap--ampsidebar"
   layout="nodisplay"
   side="left">
+  {% include '/views/partials/format-toggle.j2' %}
   <nav toolbar="(min-width: 768px)"
     toolbar-target="ap--sidebar-content">
-
     <ul>
-
       <section class="ap-o-sidebar-section">
         <div class="ap-o-component-sidebar">
-          {% include '/views/partials/format-toggle.j2' %}
-
           <div class="nav">
             {% set components = g.collection('/content/amp-dev/documentation/components/reference').list_docs(locale=doc.locale) %}
             {% set scope = namespace(initial=components[0].title[4]) %}

--- a/frontend/templates/views/partials/component-sidebar.j2
+++ b/frontend/templates/views/partials/component-sidebar.j2
@@ -46,3 +46,4 @@
     </ul>
   </nav>
 </amp-sidebar>
+<div role="button" aria-label="{{_('close sidebar')}}" on="tap:sidebar-left.toggle" tabindex="0" class="close-sidebar">✕</div>

--- a/frontend/templates/views/partials/example-sidebar.j2
+++ b/frontend/templates/views/partials/example-sidebar.j2
@@ -5,13 +5,12 @@
   class="ap--ampsidebar"
   layout="nodisplay"
   side="left">
+  {% include '/views/partials/format-toggle.j2' %}
   <nav toolbar="(min-width: 768px)"
     toolbar-target="ap--sidebar-content">
     <ul>
       <section>
         <div class="ap-o-sidebar">
-          {% include '/views/partials/format-toggle.j2' %}
-
           <div class="nav">
             {% set categories = g.categories('/content/amp-dev/documentation/examples/documentation', locale=doc.locale) %}
             {% for category, examples in categories %}

--- a/frontend/templates/views/partials/example-sidebar.j2
+++ b/frontend/templates/views/partials/example-sidebar.j2
@@ -47,3 +47,4 @@
     </ul>
   </nav>
 </amp-sidebar>
+<div role="button" aria-label="{{_('close sidebar')}}" on="tap:sidebar-left.toggle" tabindex="0" class="close-sidebar">✕</div>

--- a/frontend/templates/views/partials/sidebar.j2
+++ b/frontend/templates/views/partials/sidebar.j2
@@ -115,3 +115,4 @@
     </ul>
   </nav>
 </amp-sidebar>
+<div role="button" aria-label="{{_('close sidebar')}}" on="tap:sidebar-left.toggle" tabindex="0" class="close-sidebar">✕</div>

--- a/frontend/templates/views/partials/sidebar.j2
+++ b/frontend/templates/views/partials/sidebar.j2
@@ -2,14 +2,13 @@
   class="ap--ampsidebar"
   layout="nodisplay"
   side="left">
+  {% include '/views/partials/format-toggle.j2' %}
   <nav toolbar="(min-width: 768px)"
     toolbar-target="ap--sidebar-content">
     <ul>
       <section class="ap-o-sidebar-section">
         {% do doc.styles.addCssFile('css/components/organisms/sidebar.css') %}
         <div class="ap-o-sidebar">
-          {% include '/views/partials/format-toggle.j2' %}
-
           <div class="nav">
             {% macro nav_tree(root, iteration=1, depth=None) -%}
             {% if not depth or iteration <= depth %}


### PR DESCRIPTION
This PR adds a 'close-sidebar' button to the mobile sidebar.
Due to the limited width of the sidebar, which would cause overflow issues, the close button will be placed next to and not within the sidebar.
Another improvement could be to move the close button to a separate file and include it in all sidebars to keep the code dry.

1. Update:
The format-toggle get sticky inside the mobile sidebar.