### PR TITLE
Various boilerplate generator fixes

### DIFF
--- a/boilerplate/build.js
+++ b/boilerplate/build.js
@@ -23,7 +23,6 @@ const io = require('./lib/io');
 const templates = require('./lib/templates');
 
 const DIST_DIR = 'dist';
-const AMP_PATH = 'amp';
 const INPUT_FILE = 'templates/index.html';
 
 const generatorTemplate = io.readFile(INPUT_FILE);
@@ -57,7 +56,6 @@ function initConfig() {
 async function generateOptimizedAmpFiles(output) {
   const optimized = await optimizeAmp(output);
   io.writeFile(DIST_DIR, 'index.html', optimized);
-  io.writeFile(DIST_DIR, AMP_PATH, 'index.html', output);
 }
 
 async function optimizeAmp(html) {

--- a/boilerplate/lib/templates.js
+++ b/boilerplate/lib/templates.js
@@ -38,7 +38,7 @@ Handlebars.registerHelper('scss', (scssPath) => {
         file: templatePath,
         includePaths: INCLUDE_PATHS,
       });
-      return new Handlebars.SafeString(result.css.toString());
+      return new Handlebars.SafeString(result.css.toString().replace('@charset "UTF-8";', ''));
     }
   }
   throw new Error('File not found ' + scssPath);

--- a/boilerplate/templates/index.html
+++ b/boilerplate/templates/index.html
@@ -26,7 +26,7 @@
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
       <link rel="manifest" href="/manifest.json">
       <link rel="shortcut icon" href="/static/img/favicon.png">
-      <link rel="canonical" href="https://ampbyexample.com/boilerplate/">
+      <link rel="canonical" href="https://amp.dev/boilerplate/">
       <title>AMP Boilerplate Generator</title>
       <link rel="apple-touch-icon" sizes="57x57" href="/favicons/apple-touch-icon-57x57.png">
       <link rel="apple-touch-icon" sizes="60x60" href="/favicons/apple-touch-icon-60x60.png">
@@ -39,11 +39,11 @@
       <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon-180x180.png">
       <meta name="apple-mobile-web-app-capable" content="yes">
       <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-      <meta name="apple-mobile-web-app-title" content="AMP by Example">
+      <meta name="apple-mobile-web-app-title" content="AMP Boilerplate Generator">
       <link rel="icon" type="image/png" sizes="228x228" href="/favicons/coast-228x228.png">
       <meta name="mobile-web-app-capable" content="yes">
       <meta name="theme-color" content="#ffffff">
-      <meta name="application-name" content="AMP by Example">
+      <meta name="application-name" content="AMP Boilerplate Generator">
       <link rel="yandex-tableau-widget" href="/favicons/yandex-browser-manifest.json">
       <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
       <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
@@ -188,7 +188,7 @@
       {{#options}}
       <div class="option">
         {{#checkbox}}
-        <input id="{{id}}" type="checkbox" on="change:{{id}}-values.toggleVisibility,codeSnippet.changeToLayoutContainer,AMP.setState({
+        <input id="{{id}}" type="checkbox" on="change:{{id}}-values.toggleVisibility,AMP.setState({
           config: {
             {{id}}: {
               selected: event.checked
@@ -201,7 +201,7 @@
         })">
         {{/checkbox}}
         {{#radio}}
-        <input id="{{id}}" type="radio" name="{{categoryId}}" on="change:{{id}}-values.toggleVisibility,codeSnippet.changeToLayoutContainer,AMP.setState({
+        <input id="{{id}}" type="radio" name="{{categoryId}}" on="change:{{id}}-values.toggleVisibility,AMP.setState({
           config: {
             {{#options}}
               {{id}}: {
@@ -228,7 +228,7 @@
           <div class="value">
             <label for="{{key}}">{{{label}}}</label>
             {{#valueCheckbox}}
-            <input id="{{key}}" value="{{value}}" type="checkbox" on="input-debounced:codeSnippet.changeToLayoutContainer,AMP.setState({
+            <input id="{{key}}" value="{{value}}" type="checkbox" on="input-debounced:AMP.setState({
               config: {
                 {{id}}: {
                   {{key}}: event.checked
@@ -237,7 +237,7 @@
             })">
             {{/valueCheckbox}}
             {{^valueCheckbox}}
-            <input id="{{key}}" value="{{value}}" type="text" on="input-debounced:codeSnippet.changeToLayoutContainer,AMP.setState({
+            <input id="{{key}}" value="{{value}}" type="text" on="input-debounced:AMP.setState({
               config: {
                 {{id}}: {
                   {{key}}: event.value
@@ -263,11 +263,12 @@
       <div class="ap-m-code-snippet"><pre  [hidden]="config.changed"><code>{{{initialCode}}}</code></pre></div>
       <amp-list id="codeSnippet"
                 width="auto"
-                height="3240"
+                [height]="1"
                 layout="fixed-height"
                 [src]="config"
                 single-item
-                items="config"
+                binding="always"
+                [is-layout-container]="config.changed"
                 hidden [hidden]="!config.changed">
         <template type="amp-mustache">
           {{#formats}}

--- a/boilerplate/templates/styles/main.scss
+++ b/boilerplate/templates/styles/main.scss
@@ -138,6 +138,7 @@ section {
     }
     input[type=text] {
       padding: 0 8px;
+      border: none;
     }
     input[type=checkbox] {
       margin-right: auto;


### PR DESCRIPTION
* remove ampbyexample references
* fix canonical
* don't generate second amp page
* fix amp-list not being displayed (workaround for
https://github.com/ampproject/amphtml/issues/22552).