### PR TITLE
Remove amp-font from amp.dev, and don't recommend its usage any longer

### DIFF
--- a/frontend/templates/layouts/default.j2
+++ b/frontend/templates/layouts/default.j2
@@ -124,12 +124,6 @@
     {% include 'views/partials/footer.j2' %}
     {% endblock %}
 
-    {% block fonts %}
-    <amp-font layout="nodisplay" font-family="Noto Sans" timeout="3000"></amp-font>
-    <amp-font layout="nodisplay" font-family="Poppins" timeout="3000"></amp-font>
-    <amp-font layout="nodisplay" font-family="Fira Mono" timeout="3000"></amp-font>
-    {% endblock %}
-
     {# For untranslated content add hint that we might use help to translate it #}
     {% if not '@' in doc.pod_path and not doc.locale == podspec.default_locale %}
     {% do doc.styles.addCssFile('/css/components/organisms/translation-hint.css') %}

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -40,11 +40,6 @@
 <script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>
 {% endif %}
 
-{# Include amp-font #}
-{% if 'amp-font' not in doc.used_components or not inline_preview %}
-<script async custom-element="amp-font" src="https://cdn.ampproject.org/v0/amp-font-0.1.js"></script>
-{% endif %}
-
 {# Include other AMP dependencies if needed for preview #}
 {% if inline_preview %}
 {% for used_component in doc.used_components %}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/optimize_amp.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/optimize_amp.md
@@ -194,7 +194,7 @@ In Safari, there is a key difference to how service workers are implemented -- i
 
 With AMP there are a few things that you can do to optimize your font loading ([most of them are actually not specific to AMP](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization)):
 
-*   If possible, use [`amp-font` with timeout set to 0]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}#timeout) (this will only use the font if it's already in the cache). Fall back to the system font if your custom font has not been loaded yet. This is a similar behavior to [font-display: optional](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display).
+*   If possible, use [font-display: optional](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display): This will only use the font if it's already in the cache, and falls back to the system font if your custom font has not been loaded yet.
 *   Optimize your web fonts (for example, serve custom fonts using WOFF2).
 *   Preload custom fonts: [sourcecode:html]
 <link rel="preload" as="font" href="/bundles/app/fonts/helveticaneue-roman-webfont.woff2" >[/sourcecode]

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts.md
@@ -31,9 +31,7 @@ body {
 **Refresh** your page and check out your page’s new look. Also, inspect the AMP validator’s output.  There should be no errors for this external stylesheet request.
 
 [tip type="note"]
-Including a font in your document doesn’t require any additional components. Having said that, there is a component named [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}). The [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) component isn’t used to load web fonts, instead you can use it to detect whether a web font has successfully loaded or not and respond appropriately, if necessary.
-
-You can use [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) to hide your text until your font is fully loaded so that the user doesn’t see the text snap from its temporary font to its true font. In the case where the font fails to load, you might want to just reveal the temporary font instead. After all, the worst scenario would be if the user didn’t get to read any text! Learn more by reading the [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) reference documentation.
+Web fonts can be detrimental to a web site's performance, even on an otherwise fast AMP site. Use the [`font-display`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display) CSS property to optimize the loading behaviour of your fonts.
 [/tip]
 
 You've completed your AMP news article! Here's what it should look like:

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@es.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@es.md
@@ -28,12 +28,6 @@ body {
 
 **Actualice** su página y echa un vistazo a la nueva imagen de tu página. Además, inspeccione la salida del validador AMP. No debe haber errores para esta solicitud de hoja de estilo externa.
 
-[tip]
-La inclusión de una fuente en el documento no requiere ningún componente adicional. Dicho esto, hay un componente llamado [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}). El componente [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) no se utiliza para cargar fuentes web, sino que puede utilizarlo para detectar si una fuente web ha cargado correctamente o no y responder adecuadamente, si es necesario.
-
-Puede utilizar [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) para ocultar su texto hasta que su fuente esté completamente cargada para que el usuario no vea el texto de su fuente temporal a su fuente verdadera. En el caso de que la fuente no se cargue, es posible que desee revelar la fuente temporal en su lugar. Después de todo, el peor escenario sería si el usuario no llegó a leer ningún texto! Obtenga más información leyendo la documentación de referencia de [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}).
-[/tip]
-
 ¡Has completado tu artículo de noticias de AMP! Así es como debería ser:
 
 {{ image('/static/img/docs/tutorials/tut-advanced-done.png', 412, 732, align='center half', caption='Artículo completado') }}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@id.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@id.md
@@ -28,12 +28,6 @@ body {
 
 **Muat ulang** halaman dan lihat tampilan serta nuansa baru halaman Anda. Selain itu, periksa keluaran validator AMP.  Seharusnya tidak ada error untuk permintaan stylesheet eksternal ini.
 
-[tip type="note"]
-Menyertakan font di dokumen tidak memerlukan komponen tambahan apa pun. Meskipun demikian, ada komponen yang disebut [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}). Komponen [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) tidak digunakan untuk memuat font web, sebagai gantinya Anda dapat menggunakannya untuk mendeteksi apakah font web berhasil dimuat atau tidak dan memberikan respons sesuai, jika perlu.
-
-Anda dapat menggunakan [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) untuk menyembunyikan teks sampai font dimuat sepenuhnya sehingga pengguna tidak akan melihat perubahan teks dari font sementara ke font aslinya. Jika font gagal dimuat, sebaiknya Anda menampilkan font sementara. Bagaimanapun, kemungkinan terburuknya adalah jika pengguna tidak membaca teks apa pun! Pelajari lebih lanjut dengan membaca dokumentasi referensi [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}).
-[/tip]
-
 Anda telah menyelesaikan artikel berita AMP! AMP akan terlihat seperti ini:
 
 {{ image('/static/img/docs/tutorials/tut-advanced-done.png', 412, 732, align='center half', caption='Completed news article') }}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@ja.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@ja.md
@@ -28,12 +28,6 @@ body {
 
 ページを**更新**して、新しい外観を確認します。また、AMP 検証ツールの出力をチェックして、この外部スタイルシートのリクエストに関するエラーが出ていないことを確認します。
 
-[tip type="note"]
-ドキュメントにフォントを含めるために、コンポーネントを追加する必要はありません。ただし、[`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) という名前のコンポーネントが存在します。[`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) コンポーネントはウェブフォントの読み込みには使用されません。このコンポーネントは、ウェブフォントが正しく読み込まれたかどうかを検出し、必要に応じて適切な応答を行うために使用できます。
-
-[`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) を使用して、フォントが完全に読み込まれるまでテキストを非表示にしておけば、表示中のテキストが一時的なフォントから本来のフォントに途中で切り替わることがなくなります。また、フォントを読み込めなかった場合は一時的なフォントでテキストが表示されるようにしておくことをおすすめします。そうすることで、ユーザーにテキストが何も表示されないという最悪のシナリオを回避できます。詳しくは、[`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) のリファレンス ドキュメントをご覧ください。
-[/tip]
-
 これで AMP のニュース記事は完成です。ページは次のようになります。
 
 {{ image('/static/img/docs/tutorials/tut-advanced-done.png', 412, 732, align='center half', caption='完成したニュース記事') }}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@ko.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@ko.md
@@ -28,12 +28,6 @@ body {
 
 페이지를 **새로고침**하여 바뀐 스타일을 확인해 보세요. 또한 AMP 유효성 검사 도구에서 나온 결과를 살펴보세요.  이 외부 스타일시트 요청에는 오류가 없어야 합니다.
 
-[tip type="note"]
-문서에 글꼴을 추가하는 데는 추가 구성요소가 필요하지 않습니다. 단, [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}})라는 구성요소가 있습니다. [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) 구성요소는 웹 글꼴을 로드하는 데 사용되지는 않지만, 필요한 경우 웹 글꼴이 제대로 로드되었으며 적절히 응답하는지 확인하는 데 사용할 수 있습니다.
-
-[`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}})  사용하여 글꼴이 완전히 로드될 때까지 텍스트를 숨겨서 텍스트가 임시 글꼴에서 사용하려는 글꼴로 변경되는 모습을 사용자가 보지 못하게 할 수 있습니다. 글꼴 로드에 실패하면 임시 글꼴을 대신 표시하는 것이 좋습니다. 사용자가 텍스트를 아예 읽지 못하는 최악의 상황은 방지해야 하기 때문입니다. 자세한 내용은 [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) 문서를 참조하세요.
-[/tip]
-
 이제 AMP 뉴스 기사가 완성되었습니다. 뉴스 기사는 다음과 같이 표시됩니다.
 
 {{ image('/static/img/docs/tutorials/tut-advanced-done.png', 412, 732, align='center half', caption='완성된 뉴스 기사') }}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@pt_BR.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@pt_BR.md
@@ -28,12 +28,6 @@ body {
 
 **Atualize** a página e confira a nova aparência. Além disso, inspecione a saída do validador de AMP.  Essa solicitação da folha de estilo externa não pode ter erros.
 
-[tip type="note"]
-Não são necessários componentes adicionais para incluir uma fonte no documento. Dito isso, há um componente chamado [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}). Esse componente não é usado para carregar fontes da Web, mas para detectar se determinada fonte foi carregada ou não e tomar as providências necessárias se for o caso.
-
-Você pode usar o [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) para ocultar o texto até que a fonte seja totalmente carregada. Assim, o usuário não verá a transição da fonte temporária para a final. Caso ocorra uma falha no carregamento da fonte, você tem a opção de exibir a temporária. Afinal, pior seria se o usuário não conseguisse ver o texto. Para saber mais, leia a documentação de referência do [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}).
-[/tip]
-
 Seu artigo de notícias AMP está pronto! Ele terá esta aparência:
 
 {{ image('/static/img/docs/tutorials/tut-advanced-done.png', 412, 732, align='center half', caption='Artigo de notícias concluído') }}

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@zh_CN.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/start/add_advanced/fonts@zh_CN.md
@@ -28,12 +28,6 @@ body {
 
 **刷新**网页后，您即会看到焕然一新的网页外观。此外，请检查 AMP 验证工具的输出结果。这项外部样式表请求不应有任何错误。
 
-[tip type="note"]
-向文档中添加字体并不需要使用任何其他组件。话虽如此，您仍可使用一款名为 [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) 的组件。[`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) 组件不是用于加载网页字体，而是用于检测网页字体是否已成功加载，并在必要时予以适当的响应。
-
-在您的字体加载完毕之前，您可以使用 [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) 将文字隐藏起来，这样用户就不会看到文字从临时字体转变为最终字体这一过程。如果字体未能成功加载，您可能需要改为仅显示临时字体。毕竟，用户看不到任何文字才是最糟糕的情形！要想了解详情，请参阅 [`amp-font`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-font.md', locale=doc.locale).url.path}}) 参考文档。
-[/tip]
-
 至此，您的 AMP 新闻报道便已完成了！它看起来应该会如下所示：
 
 {{ image('/static/img/docs/tutorials/tut-advanced-done.png', 412, 732, align='center half', caption='完成后的新闻报道') }}


### PR DESCRIPTION
See https://github.com/ampproject/docs/issues/2207 for context. I noticed that `font-display: swap` was already in place in our CSS, which should I think work for us.

/cc @cramforce 