### PR TITLE
✨ List experiments on experiments page

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/experimental.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/experimental.md
@@ -14,6 +14,21 @@ are released features not yet ready for wide use, so they are protected by an **
 Developers and users can opt-in to using these features before they are fully released.
 But they should be used with caution, as they may contain bugs or have unexpected side effects.
 
+[tip type="important"]
+There is a risk that some experiments will never ship as features on the AMP Project.
+[/tip]
+
+{% set experimental_components = g.docs('/content/amp-dev/documentation/components/reference')|selectattr('experimental')|list %}
+{% if experimental_components|length %}
+The following is a list of components that are currently in experimental status and are ready to be tested by developers for first user feedback:
+
+<ul>
+{% for component in experimental_components %}
+  <li><a href="{{ component.url.path }}">{{ component.title }}</a></li>
+{% endfor %}
+</ul>
+{% endif %}
+
 ## Opt into the AMP Dev Channel
 
 The AMP Dev Channel is a way to opt a browser into using a newer version of the AMP JS libraries.
@@ -74,19 +89,14 @@ Traditionally, a feature in experimental mode can be used in development, but ca
 - The test is for a limited time.
 - The feature will likely undergo some changes after origin trials.
 
-[tip type="important"]
-There is a risk that some experiments will never ship as features on the AMP Project.
-[/tip]
-
 Origin trials present an opportunity to impliment and benifit from a new feature before it’s fully live. The feature will live on the develop's site, rather than guarded by an experiment, and feedback can directly influence the direction of the feature.
 
 ### Enable an origin trial
 
-Include the following `<meta>` tag within the `<head>` tag on each page that uses the origin trial experiment: 
-  
+Include the following `<meta>` tag within the `<head>` tag on each page that uses the origin trial experiment:
+
 ```html
-<meta name="amp-experiment-token" content="{copy your token here}"> 
+<meta name="amp-experiment-token" content="{copy your token here}">
 ```
 
 Note: `"amp-experiment-token"` is the literal string, `"amp-experiment-token"`. Not the token itself (which goes into the content attribute), or the name of the experiment.
-

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/experimental.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/experimental.md
@@ -89,7 +89,18 @@ Traditionally, a feature in experimental mode can be used in development, but ca
 - The test is for a limited time.
 - The feature will likely undergo some changes after origin trials.
 
-Origin trials present an opportunity to impliment and benifit from a new feature before it’s fully live. The feature will live on the develop's site, rather than guarded by an experiment, and feedback can directly influence the direction of the feature.
+Origin trials present an opportunity to implement and benefit from a new feature before it’s fully live. The feature will live on the developer's site, rather than guarded by an experiment, and feedback can directly influence the direction of the feature.
+
+{% set trial_components = g.docs('/content/amp-dev/documentation/components/reference')|selectattr('origin_trial')|list %}
+{% if trial_components|length %}
+Components in the following list can currently be tested via an origin trial:
+
+<ul>
+{% for component in trial_components %}
+  <li><a href="{{ component.url.path }}">{{ component.title }}</a></li>
+{% endfor %}
+</ul>
+{% endif %}
 
 ### Enable an origin trial
 


### PR DESCRIPTION
Fixes #2175. Allows component documentation pages from ampproject/amphtml to have either `experimental` and/or `origin_trial` in their frontmatter to get then listed on the [experiments page](https://amp.dev/documentation/guides-and-tutorials/learn/experimental).

Open for suggestions to rename the frontmatter keys but I thought we might need differentiation as not every experimental component is available as an original trial.

Additionally I moved "There is a risk that some experiments will never ship as features on the AMP Project." to the top of the page because I found that bit quite important 😉 

@CrystalOnScript, please feel free to give copy feedback!
