### PR TITLE
♻️ Migrate amp-form API to amp.dev

### DIFF
--- a/examples/api/amp-form.js
+++ b/examples/api/amp-form.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+const multer = require('multer');
+const upload = multer();
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+
+const ERROR_CASE_AMP_FORM = 'error';
+
+examples.all('/submit-form', submitForm);
+examples.post('/submit-form-xhr', upload.none(), submitFormXHR);
+examples.post('/submit-form-input-text-xhr', upload.none(), submitFormXHRInputText);
+examples.post('/verify-form-input-text-xhr', upload.none(), verifyFormXHRInputText);
+
+function submitForm(request, response) {
+  response.redirect(303, '/static/samples/files/amp-form-success.html');
+}
+
+function submitFormXHR(request, response) {
+  response.json({
+    result: 'ok',
+  });
+}
+
+function submitFormXHRInputText(request, response) {
+  const email = request.body ? request.body.email : '';
+  const name = request.body ? request.body.name : '';
+  if (isUserTryingTheInputTextErrorDemo(name)) {
+    response.status(400);
+  }
+  response.json({
+    email,
+    name,
+  });
+}
+
+function verifyFormXHRInputText(request, response) {
+  const username = request.body ? request.body.username : '';
+  if (isUserTryingTheInputTextErrorDemo(username)) {
+    response.status(400).json({
+      verifyErrors: [
+        {
+          message: `The username ${name} is already taken`,
+          username,
+        },
+      ],
+    });
+    return;
+  }
+  response.json({
+    username,
+  });
+}
+
+function isUserTryingTheInputTextErrorDemo(name) {
+  return name === ERROR_CASE_AMP_FORM;
+}
+
+module.exports = examples;

--- a/examples/api/amp-form.js
+++ b/examples/api/amp-form.js
@@ -24,7 +24,7 @@ const examples = express.Router();
 
 const ERROR_CASE_AMP_FORM = 'error';
 
-examples.all('/submit-form', submitForm);
+examples.get('/submit-form', submitForm);
 examples.post('/submit-form-xhr', upload.none(), submitFormXHR);
 examples.post('/submit-form-input-text-xhr', upload.none(), submitFormXHRInputText);
 examples.post('/verify-form-input-text-xhr', upload.none(), verifyFormXHRInputText);

--- a/examples/source/1.components/amp-analytics.html
+++ b/examples/source/1.components/amp-analytics.html
@@ -393,7 +393,7 @@ The `amp-carousel-prev` event is issued when there is a traversal to the previou
     <form
         id="testForm"
         method="post"
-        action-xhr="/components/amp-form/submit-form-input-text-xhr"
+        action-xhr="/documentation/examples/api/submit-form-input-text-xhr"
         target="_top">
       <input type="text"
           name="name"

--- a/examples/source/1.components/amp-autocomplete.html
+++ b/examples/source/1.components/amp-autocomplete.html
@@ -128,7 +128,7 @@ preview: default
     </div>
     <form class="sample-form"
       method="post"
-      action-xhr="<% hosts.backend %>/components/amp-form/submit-form-input-text-xhr"
+      action-xhr="/documentation/examples/api/submit-form-input-text-xhr"
       target="_top">
       <div class="input-field">
         <amp-autocomplete filter="substring" min-characters="0"
@@ -170,7 +170,7 @@ preview: default
   -->
   <form class="sample-form"
     method="post"
-    action-xhr="<% hosts.backend %>/components/amp-form/submit-form-input-text-xhr"
+    action-xhr="/documentation/examples/api/submit-form-input-text-xhr"
     target="_top">
     <label>
         <span>Search for</span>
@@ -221,7 +221,7 @@ preview: default
   <div>
     <form class="sample-form"
     method="post"
-    action-xhr="<% hosts.backend %>/components/amp-form/submit-form-input-text-xhr"
+    action-xhr="/documentation/examples/api/submit-form-input-text-xhr"
     target="_top">
       <amp-autocomplete filter="substring" min-characters="0" [src]="manualFilterData" >
           <input type="text" on="input-debounced:AMP.setState({ manualFilterData: event.value.length == 0 ? 

--- a/examples/source/1.components/amp-date-picker.html
+++ b/examples/source/1.components/amp-date-picker.html
@@ -328,7 +328,7 @@ author: kul3r4
     `amp-date-picker` integrates with AMP forms. If you don't provide an input for a static picker, it will create a hidden input to submit in the form.
   -->
   <form method="post"
-    action-xhr="/components/amp-form/submit-form-xhr"
+    action-xhr="/documentation/examples/api/submit-form-xhr"
     target="_top">
     <amp-date-picker
       id="form-picker"

--- a/examples/source/1.components/amp-form.html
+++ b/examples/source/1.components/amp-form.html
@@ -67,9 +67,9 @@ author: kul3r4
 
     Read [security considerations](https://github.com/ampproject/amphtml/blob/master/extensions/amp-form/amp-form.md#security-considerations) for best practices when to use `GET` or `POST`.
 
-    You can find the code for the server endpoint used in this demo at [/backend/amp-form.go](https://github.com/ampproject/amp-by-example/blob/master/backend/amp-form.go).
+    You can find the code for the server endpoint used in this demo at [/examples/api/amp-form.js](https://github.com/ampproject/docs/blob/future/examples/api/amp-form.js).
   -->
-  <form class="sample-form" method="GET" action="<% hosts.backend %>/components/amp-form/submit-form" target="_top">
+  <form class="sample-form" method="GET" action="/documentation/examples/api/submit-form" target="_top">
     <input type="search" placeholder="Search..." name="search">
     <input type="submit" value="OK">
   </form>
@@ -82,7 +82,7 @@ author: kul3r4
     The `amp-form` component displays `submit-success` or `submit-error` elements based on the response and renders the template data inside these two elements. The `submit-success` and `submit-error` elements must be direct children of `form`.
   -->
   <form class="sample-form" method="post"
-        action-xhr="<% hosts.backend %>/components/amp-form/submit-form-input-text-xhr"
+        action-xhr="/documentation/examples/api/submit-form-input-text-xhr"
         target="_top">
     <input type="text"
            name="name"
@@ -113,7 +113,7 @@ author: kul3r4
     Use `show-all-on-submit` strategy to ensure all the validation messages are shown when the user submits the form.
   -->
   <form class="sample-form" method="post"
-        action-xhr="<% hosts.backend %>/components/amp-form/submit-form-input-text-xhr"
+        action-xhr="/documentation/examples/api/submit-form-input-text-xhr"
         target="_top"
         custom-validation-reporting="show-all-on-submit">
     <input type="text" id="show-all-on-submit-name" name="name" placeholder="Name..." required pattern="\p{L}+\s\p{L}+">
@@ -144,7 +144,7 @@ author: kul3r4
   <h2 class="sample-heading">Form Custom Validation: <code>show-first-on-submit</code></h2>
   <!-- Use `show-first-on-submit` strategy to show the first validation message when the user submit the form. -->
   <form class="sample-form" method="post"
-        action-xhr="<% hosts.backend %>/components/amp-form/submit-form-input-text-xhr"
+        action-xhr="/documentation/examples/api/submit-form-input-text-xhr"
         target="_top"
         custom-validation-reporting="show-first-on-submit">
     <input type="text" id="show-first-on-submit-name"  name="name" placeholder="Name..." required pattern="\p{L}+\s\p{L}+">
@@ -175,7 +175,7 @@ author: kul3r4
   <h2 class="sample-heading">Form Custom Validation: <code>as-you-go</code></h2>
   <!-- Use `as-you-go` strategy to show validation messages as the user is interacting with the form. -->
   <form class="sample-form" method="post"
-        action-xhr="<% hosts.backend %>/components/amp-form/submit-form-input-text-xhr"
+        action-xhr="/documentation/examples/api/submit-form-input-text-xhr"
         target="_top"
         custom-validation-reporting="as-you-go">
     <input type="text" id="as-you-go-name" name="name" placeholder="Name..." required pattern="\p{L}+\s\p{L}+">
@@ -211,8 +211,8 @@ author: kul3r4
     In the `submit-error` template, you can choose how to render verification error message using the `verifyErrors` list. These will only display if the user submits the form before the asynchronous verification response completes.
   -->
   <form class="sample-form" method="post"
-        action-xhr="<% hosts.backend %>/components/amp-form/verify-form-input-text-xhr"
-        verify-xhr="<% hosts.backend %>/components/amp-form/verify-form-input-text-xhr"
+        action-xhr="/documentation/examples/api/verify-form-input-text-xhr"
+        verify-xhr="/documentation/examples/api/verify-form-input-text-xhr"
         target="_top"
         custom-validation-reporting="as-you-go">
     <input type="text" id="verification-username" name="username" placeholder="Username..." required pattern="\w+">
@@ -242,7 +242,7 @@ author: kul3r4
   <!--
     You can use either an `<input type="reset">` or the `clear` action for clearing input fields.
   -->
-  <form class="sample-form" id="formResetSample" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+  <form class="sample-form" id="formResetSample" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
     <input type="text" placeholder="Some text...">
     <input type="submit" value="OK">
     <input type="reset" value="Reset">
@@ -261,7 +261,7 @@ author: kul3r4
     }
     ```
   -->
-  <form class="sample-form hide-inputs" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-input-text-xhr" target="_top">
+  <form class="sample-form hide-inputs" method="post" action-xhr="/documentation/examples/api/submit-form-input-text-xhr" target="_top">
     <input type="text" name="name" placeholder="Name..." required>
     <input type="submit" value="Subscribe">
     <div submit-success>
@@ -276,7 +276,7 @@ author: kul3r4
   <!--
     `amp-form` supports all HTML5 form types with the exception of file and image. It's recommended to use the [`amp-date-picker`]({{g.doc('/content/amp-dev/documentation/components/reference/amp-date-picker.md', locale=doc.locale).url.path}}) component for input fields that should contain a date.
   -->
-  <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+  <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
     <input name="select-date" type="date" value="2020-12-30">
     <input type="submit" value="OK">
     <div submit-success>
@@ -291,7 +291,7 @@ author: kul3r4
     <!--
       Use `type="month"` for input fields that should contain a month.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input name="select-month" type="month" value="2020-12">
       <input type="submit" value="OK">
       <div submit-success>
@@ -306,7 +306,7 @@ author: kul3r4
     <!--
       Use `type="week"` for input fields that should contain a week.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="week" name="week_year">
       <input type="submit" value="OK">
       <div submit-success>
@@ -321,7 +321,7 @@ author: kul3r4
     <!--
       Use `type="datetime-local"` for input fields that should contain a date and time.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input name="select-datetime" type="datetime-local" value="2020-12-30T12:34:56">
       <input type="submit" value="OK">
       <div submit-success>
@@ -336,7 +336,7 @@ author: kul3r4
     <!--
       Use `type="time"` for input fields that should contain a time.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="time" name="time_now">
       <input type="submit" value="OK">
       <div submit-success>
@@ -351,7 +351,7 @@ author: kul3r4
     <!--
       Use `type="checkbox"` to let the user select ZERO or MORE options of a limited number of choices.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="checkbox" id="animal1" name="animal1" value="Cats" >
       <label for="animal1">I like cats</label>
       <input type="checkbox" id="animal2" name="animal2" value="Dogs">
@@ -369,7 +369,7 @@ author: kul3r4
     <!--
       Use `type="email"` for input fields that should contain an e-mail address.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="email" name="email" placeholder="Email..." >
       <input type="submit" value="OK">
       <div submit-success>
@@ -384,7 +384,7 @@ author: kul3r4
     <!--
       Use `type="hidden"` to define a field not visible to a user.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="hidden" name="city" value="London">
       <input type="submit" value="OK">
       <div submit-success>
@@ -399,7 +399,7 @@ author: kul3r4
     <!--
       Use `type="number"` for input fields that should contain a numeric value.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="number" name="quantity" min="1" max="5">
       <input type="submit" value="OK">
       <div submit-success>
@@ -414,7 +414,7 @@ author: kul3r4
     <!--
       Use `type="radio"` to let a user select ONLY ONE of a limited number of choices.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="radio" id="cat" name="favourite animal" value="cat" checked>
       <label for="cat">Cat</label>
       <input type="radio" id="dog" name="favourite animal" value="dog">
@@ -434,7 +434,7 @@ author: kul3r4
     <!--
       Use `type="range"` for input fields that should contain a value within a range.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="range" name="points" min="0" max="10">
       <input type="submit" value="OK">
       <div submit-success>
@@ -449,7 +449,7 @@ author: kul3r4
     <!--
       Use `type="tel"` for input fields that should contain a telephone number.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="tel" name="my_tel" placeholder="Telephone...">
       <input type="submit" value="OK">
       <div submit-success>
@@ -464,7 +464,7 @@ author: kul3r4
     <!--
       Use `type="url"` for input fields that should contain a URL address.
     -->
-    <form class="sample-form" method="post" action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+    <form class="sample-form" method="post" action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="url" placeholder="URL..." name="website">
       <input type="submit" value="OK">
       <div submit-success>
@@ -480,7 +480,7 @@ author: kul3r4
       Use `type="password"` for hidden text inputs inside secure `POST` forms.
     -->
     <form class="sample-form" method="post"
-      action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+      action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <input type="password" placeholder="Password..." name="pw">
       <input type="submit" value="OK">
       <div submit-success>
@@ -497,7 +497,7 @@ author: kul3r4
       Use `select` element for dropdowns.
     -->
     <form class="sample-form" method="post"
-      action-xhr="<% hosts.backend %>/components/amp-form/submit-form-xhr" target="_top">
+      action-xhr="/documentation/examples/api/submit-form-xhr" target="_top">
       <select name="cars" id="cars" >
         <option value="volvo">Volvo</option>
         <option value="saab">Saab</option>

--- a/examples/source/interactivity-dynamic-content/Conference_Survey_Email.html
+++ b/examples/source/interactivity-dynamic-content/Conference_Survey_Email.html
@@ -62,7 +62,7 @@ This sample demonstrates how to build an AMP-powered email that contains a simpl
 
       When the form is submitted, we display a short confirmation message to the user by using `<div submit-success>`.
     -->
-    <form method="post" action-xhr="https://ampbyexample.com/components/amp-form/submit-form-input-text-xhr">
+    <form method="post" action-xhr="/documentation/examples/api/submit-form-input-text-xhr">
       <div class="m1">
         <p>How would you rate this year's conference?</p>
 

--- a/examples/source/interactivity-dynamic-content/Multi_Page_Flow.html
+++ b/examples/source/interactivity-dynamic-content/Multi_Page_Flow.html
@@ -615,7 +615,7 @@ Here is the full example:
   -->
   <form class="stepper sliding"
         method="post"
-        action-xhr="/components/amp-form/submit-form-input-text-xhr"
+        action-xhr="/documentation/examples/api/submit-form-input-text-xhr"
         novalidate
         on="submit: AMP.setState({ slidingStepperPage: 2 });
             submit-success: AMP.setState({ slidingStepperPage: 3 });

--- a/examples/static/samples/files/amp-form-success.html
+++ b/examples/static/samples/files/amp-form-success.html
@@ -1,0 +1,28 @@
+<!---
+
+hideCode: true
+hidePreview: true
+
+--->
+
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Success</title>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>  
+  <link rel="canonical" href="<%host%>/amp-form-success/">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+</head>
+<body> 
+  <!--
+  ## Success page for amp-form
+
+  Success! Thanks for trying the amp-form demo.
+  -->
+  <!--
+  Back to [amp-form](/components/amp-form) sample.
+  -->
+</body>
+</html>

--- a/examples/static/samples/files/amp-form-success.html
+++ b/examples/static/samples/files/amp-form-success.html
@@ -18,11 +18,8 @@ hidePreview: true
 <body> 
   <!--
   ## Success page for amp-form
-
-  Success! Thanks for trying the amp-form demo.
   -->
-  <!--
-  Back to [amp-form](/components/amp-form) sample.
-  -->
+  <p>Success! Thanks for trying the amp-form demo.</p>
+  <p>Back to <a href="/documentation/examples/components/amp-form/">amp-form</a> sample.</p>
 </body>
 </html>

--- a/examples/static/samples/files/amp-form-success.html
+++ b/examples/static/samples/files/amp-form-success.html
@@ -1,10 +1,3 @@
-<!---
-
-hideCode: true
-hidePreview: true
-
---->
-
 <!doctype html>
 <html ⚡>
 <head>
@@ -15,10 +8,7 @@ hidePreview: true
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 </head>
-<body> 
-  <!--
-  ## Success page for amp-form
-  -->
+<body>
   <p>Success! Thanks for trying the amp-form demo.</p>
   <p>Back to <a href="/documentation/examples/components/amp-form/">amp-form</a> sample.</p>
 </body>


### PR DESCRIPTION
Migrated the backend/amp-form.go from ampbyexample.com to amp.dev.
This updates and/or fixes the examples [here](https://amp.dev/documentation/examples/components/amp-analytics/), [here](https://amp.dev/documentation/examples/components/amp-autocomplete/), [here](https://amp.dev/documentation/examples/components/amp-date-picker/), [here](https://amp.dev/documentation/examples/components/amp-form/), [here](https://amp.dev/documentation/examples/interactivity-dynamic-content/conference_survey_email/?format=email) and [here](https://amp.dev/documentation/examples/interactivity-dynamic-content/multi_page_flow/).

Part of the migration/improvements in #2054.