### PR TITLE
Disallow /tests/ for robots

### DIFF
--- a/pages/static/robots/prod.txt
+++ b/pages/static/robots/prod.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
 Disallow: /shared
+Disallow: /tests/
 
 Sitemap: https://amp.dev/sitemap.xml


### PR DESCRIPTION
The tests folder that contain files to test the grow page generation should not end up in a search index
