### PR TITLE
Fix/sidebar

### DIFF
--- a/frontend/scss/components/atoms/sidebar-toggle.scss
+++ b/frontend/scss/components/atoms/sidebar-toggle.scss
@@ -131,9 +131,12 @@
     display: inline-block;
 
     &-label {
+      position: sticky;
+      top: 86px;
       display: flex;
       margin-top: -52px;
       margin-left: -40px;
+      padding-bottom: 26px;
     }
 
     &-input {
@@ -141,9 +144,7 @@
         &~ .ap--sidebar {
           grid-column: 1 / 2;
           nav {
-            ul {
-              display: none;
-            }
+            display: none;
           }
           svg {
             transform: rotate(180deg);

--- a/frontend/scss/components/molecules/format-toggle.scss
+++ b/frontend/scss/components/molecules/format-toggle.scss
@@ -7,14 +7,16 @@
 @import 'components/atoms/_text';
 
 .#{molecule('format-toggle')} {
-  position: relative;
+  position: sticky;
+  top: 0;
   margin: 0 10px;
   padding: 10px 0 0 0;
   max-width: 85%;
+  z-index: 12;
 
   @media (min-width: 768px) {
     padding: 0;
-    margin: 0 15px;
+    margin: 0 15px 0 0;
     max-width: 100%;
   }
 

--- a/frontend/scss/components/organisms/_sidebar.scss
+++ b/frontend/scss/components/organisms/_sidebar.scss
@@ -9,11 +9,6 @@
 @mixin sidebar {
 
   @media (min-width: 768px) {
-    position: -webkit-sticky;
-    position: sticky;
-    z-index: 1;
-    top: 118px;
-    left: auto;
     width: auto;
     min-height: 400px;
     padding-bottom: 0;
@@ -21,10 +16,6 @@
     margin-left: -10px;
     background: none;
     box-shadow: none;
-  }
-
-  @media (min-width: 1024px) {
-    top: 120px;
   }
 }
 

--- a/frontend/scss/components/organisms/component-sidebar.scss
+++ b/frontend/scss/components/organisms/component-sidebar.scss
@@ -24,15 +24,14 @@ amp-sidebar {
 }
 
 nav[toolbar] {
-  top: 36px;
-  overflow: auto;
+  top: 86px;
   -webkit-overflow-scrolling: touch;
 
   @media (min-width: 768px){
     height: 100vh;
     position: sticky;
     overflow: auto;
-    max-height: calc(100vh - 168px);
+    max-height: calc(100vh - 86px);
   }
 
   &::-webkit-scrollbar {
@@ -47,6 +46,10 @@ nav[toolbar] {
     margin: 0;
     padding: 0;
   }
+}
+
+.#{utility('sidebar')} {
+  margin-top: 10px;
 }
 
 .#{organism('component-sidebar')} {

--- a/frontend/scss/components/organisms/header.scss
+++ b/frontend/scss/components/organisms/header.scss
@@ -29,6 +29,11 @@
 
   &.mainmenuopen {
     z-index: 1004;
+
+    & ~ .#{utility('main')} {
+      max-width: 100vw;
+      overflow-x: hidden;
+    }
   }
 
   @media (min-width: 1024px) {

--- a/frontend/scss/components/organisms/sidebar.scss
+++ b/frontend/scss/components/organisms/sidebar.scss
@@ -15,15 +15,14 @@ amp-sidebar {
 }
 
 nav[toolbar] {
-  top: 36px;
-  overflow: auto;
+  top: 86px;
   -webkit-overflow-scrolling: touch;
 
   @media (min-width: 768px){
     height: 100vh;
     position: sticky;
     overflow: auto;
-    max-height: calc(100vh - 168px);
+    max-height: calc(100vh - 86px);
   }
 
   &::-webkit-scrollbar {
@@ -38,6 +37,10 @@ nav[toolbar] {
     margin: 0;
     padding: 0;
   }
+}
+
+.#{utility('sidebar')} {
+  margin-top: 10px;
 }
 
 .#{organism('sidebar')} {

--- a/frontend/scss/components/templates/_default.scss
+++ b/frontend/scss/components/templates/_default.scss
@@ -3,11 +3,6 @@
   padding-bottom: 3rem;
 }
 
-.#{utility('main')} {
-  max-width: 100vw;
-  overflow-x: hidden;
-}
-
 @mixin container {
   position: relative;
   display: flex;

--- a/frontend/templates/views/partials/component-sidebar.j2
+++ b/frontend/templates/views/partials/component-sidebar.j2
@@ -7,13 +7,10 @@
   side="left">
   <nav toolbar="(min-width: 768px)"
     toolbar-target="ap--sidebar-content">
-
+    {% include '/views/partials/format-toggle.j2' %}
     <ul>
-
       <section class="ap-o-sidebar-section">
         <div class="ap-o-component-sidebar">
-          {% include '/views/partials/format-toggle.j2' %}
-
           <div class="nav">
             {% set components = g.collection('/content/amp-dev/documentation/components/reference').list_docs(locale=doc.locale) %}
             {% set scope = namespace(initial=components[0].title[4]) %}

--- a/frontend/templates/views/partials/example-sidebar.j2
+++ b/frontend/templates/views/partials/example-sidebar.j2
@@ -7,11 +7,10 @@
   side="left">
   <nav toolbar="(min-width: 768px)"
     toolbar-target="ap--sidebar-content">
+    {% include '/views/partials/format-toggle.j2' %}
     <ul>
       <section>
         <div class="ap-o-sidebar">
-          {% include '/views/partials/format-toggle.j2' %}
-
           <div class="nav">
             {% set categories = g.categories('/content/amp-dev/documentation/examples/documentation', locale=doc.locale) %}
             {% for category, examples in categories %}

--- a/frontend/templates/views/partials/sidebar.j2
+++ b/frontend/templates/views/partials/sidebar.j2
@@ -4,12 +4,11 @@
   side="left">
   <nav toolbar="(min-width: 768px)"
     toolbar-target="ap--sidebar-content">
+    {% include '/views/partials/format-toggle.j2' %}
     <ul>
       <section class="ap-o-sidebar-section">
         {% do doc.styles.addCssFile('css/components/organisms/sidebar.css') %}
         <div class="ap-o-sidebar">
-          {% include '/views/partials/format-toggle.j2' %}
-
           <div class="nav">
             {% macro nav_tree(root, iteration=1, depth=None) -%}
             {% if not depth or iteration <= depth %}


### PR DESCRIPTION
With this PR the sidebar becomes much more usable again.
Both, the format-toggle and the sidebar-toggle stay sticky at the same height.
If you scroll inside the sidebar the format-toggle stays at its position.
Autoscrolling to an active nav-item is still working with this modification.
Also there are some bug-fixes and code and styling improvements.

Relies to #2194 and #2195 