### PR TITLE
Do not build grow tests for production

### DIFF
--- a/gulpfile.js/build.js
+++ b/gulpfile.js/build.js
@@ -44,6 +44,9 @@ const test = require('./test.js');
 // The Google Cloud Storage bucket used to store build job artifacts
 const TRAVIS_GCS_PATH = 'gs://amp-dev-ci/travis/';
 
+// Path of the grow test pages for filtering in the grow podspec.yaml
+const TEST_CONTENT_PATH_REGEX = '^/tests/';
+
 
 /**
  * Cleans all directories/files that get created by any of the following
@@ -241,7 +244,14 @@ async function buildPages(done) {
   gulp.series(fetchArtifacts, buildFrontend,
       // eslint-disable-next-line prefer-arrow-callback
       async function buildGrow() {
-        config.configureGrow();
+        const options = {};
+        if (config.isTestMode()) {
+          options.include_paths = TEST_CONTENT_PATH_REGEX;
+          options.locales = 'en';
+        } else if (config.isProdMode()) {
+          options.ignore_paths = TEST_CONTENT_PATH_REGEX;
+        }
+        config.configureGrow(options);
         await grow('deploy --noconfirm --threaded');
       }, transformPages,
       // eslint-disable-next-line prefer-arrow-callback

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:local": "gulp build --env local",
     "build:staging": "gulp build --env staging",
     "build:prod": "gulp build --env production",
-    "build:grow-tests": "gulp buildForGrowTests --env test --locales en",
+    "build:grow-tests": "gulp buildForGrowTests --env test",
     "log:staging": "gcloud app logs tail -s default --project amp-dev-staging",
     "posttest": "npm run lint",
     "start:local": "cd platform && NODE_ENV=local node serve.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:local": "gulp build --env local",
     "build:staging": "gulp build --env staging",
     "build:prod": "gulp build --env production",
-    "build:grow-tests": "gulp buildForGrowTests --env test --locales en --include_paths tests",
+    "build:grow-tests": "gulp buildForGrowTests --env test --locales en",
     "log:staging": "gcloud app logs tail -s default --project amp-dev-staging",
     "posttest": "npm run lint",
     "start:local": "cd platform && NODE_ENV=local node serve.js",

--- a/platform/lib/config.js
+++ b/platform/lib/config.js
@@ -28,6 +28,7 @@ const GROW_CONFIG_DEST = utils.project.absolute('pages/podspec.yaml');
 const ENV_DEV = 'development';
 const ENV_STAGE = 'staging';
 const ENV_PROD = 'production';
+
 const AVAILABLE_LOCALES = [
   'en',
   'fr',
@@ -42,6 +43,8 @@ const AVAILABLE_LOCALES = [
   'tr',
   'zh_CN',
 ];
+
+const TEST_CONTENT_PATH_REGEX = '^/tests/';
 
 class Config {
   constructor(environment = ENV_DEV) {
@@ -167,6 +170,16 @@ class Config {
       },
     };
 
+    // The default is we do not deploy test files on prod
+    // and in test mode we deploy only the test files
+    if (!this.options.include_paths && !this.options.ignore_paths) {
+      if (this.isTestMode()) {
+        this.options.include_paths = TEST_CONTENT_PATH_REGEX;
+      } else if (this.isProdMode()) {
+        this.options.ignore_paths = TEST_CONTENT_PATH_REGEX;
+      }
+    }
+
     if (this.options.include_paths || this.options.ignore_paths) {
       const filter = {};
       if (this.options.ignore_paths) {
@@ -181,6 +194,7 @@ class Config {
       podspec.deployments[this.environment] = {
         'filter': filter,
       };
+      signale.info('Add path filter for grow ', filter);
     }
 
     podspec.localization.locales = AVAILABLE_LOCALES;

--- a/platform/lib/config.js
+++ b/platform/lib/config.js
@@ -129,13 +129,13 @@ class Config {
 
   /**
    * Builds a podspec for the current environment and writes it to the Grow pod
-   * @param {Object} settings Options to filter grow pages (optional). Can be overwritten by command line options.
+   * @param {Object} growOptions Options to filter grow pages (optional). Can be overwritten by command line options.
    * @return {undefined}
    */
-  configureGrow(settings) {
+  configureGrow(growOptions) {
     const options = {};
-    if (settings) {
-      Object.assign(options, settings);
+    if (growOptions) {
+      Object.assign(options, growOptions);
     }
     Object.assign(options, this.options);
 


### PR DESCRIPTION
The grow test contents should not be deployed on prod.
We simply exclude the path /tests/ in the grow build.

On staging the files will still be available:
https://amp-dev-staging.appspot.com/tests/examples/import
