### PR TITLE
Fix margin problems in important-tip and help section

### DIFF
--- a/frontend/scss/components/molecules/tip.scss
+++ b/frontend/scss/components/molecules/tip.scss
@@ -132,6 +132,10 @@ $borderSize: 5px;
       color: color('red')
     }
 
+    p {
+      margin-top: 0;
+    }
+
     .#{molecule('tip')} {
       &-content:before {
         @extend %pseudo-base;

--- a/frontend/scss/components/organisms/help.scss
+++ b/frontend/scss/components/organisms/help.scss
@@ -22,6 +22,8 @@
 
 .#{organism('help')} {
 
+  margin-top: 2rem; 
+
   &-hl {
     @include hl;
     @include hl-h2;


### PR DESCRIPTION
The p-tag of the important-tip gets a "margin-top 0" in order to let the tip appear in accordance with other tips.

the help organism gets a "margin-top: 2rem" in order to add space between it and the content section.