### PR TITLE
Align path "optimize-and-measure" and improve redirect logic

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -79,7 +79,7 @@ module.exports = {
   moduleNameMapper: {
     // TODO: improve: jest will not work with 'module-alias', so we have define the alias here again!
     // see https://github.com/ilearnio/module-alias/issues/46
-    '^@lib/(.*)$': '<rootDir>/platform/lib/$1.js',
+    '^@lib/(.*?)(\.js)?$': '<rootDir>/platform/lib/$1.js',
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/_blueprint.yaml
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/optimize-measure/configure-analytics/_blueprint.yaml
@@ -1,7 +1,7 @@
 $view: /views/detail/docs-detail.j2
-$path: /documentation/guides-and-tutorials/optimize-measure/configure-analytics/{base}.html
+$path: /documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/{base}.html
 $localization:
-  path: /{locale}/documentation/guides-and-tutorials/optimize-measure/configure-analytics/{base}.html
+  path: /{locale}/documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/{base}.html
 $title@: Track engagement with analytics
 $title@zh: 配置分析工具
 $title@tr: Analytics›i Yapılandırın

--- a/platform/config/amp-dev-redirects.yaml
+++ b/platform/config/amp-dev-redirects.yaml
@@ -1,5 +1,7 @@
 # Redirects for amp.dev
 # External targets are possible
+# The paths specified as source will work with all configured locales.
+# Request query parameters of the original request are appended to the redirect
 #
 # The first section contains basic shortcuts
 # (For shortened deep links please use go.amp.dev/shortcut and the file 'go-links.yaml')
@@ -12,7 +14,6 @@
 # Add new entries in alphabetical order
 /ads: /about/ads
 /docs: /documentation/guides-and-tutorials/
-/documentation/guides-and-tutorials/learn/amp-email-format: /documentation/guides-and-tutorials/learn/email-spec/amp-email-format
 /email: /about/email
 /learn: /documentation/courses/
 /samples: /documentation/examples/
@@ -22,3 +23,9 @@
 ### Other redirects
 # Put here redirects for pages that have been moved, etc
 # Add new entries in alphabetical order
+/documentation/guides-and-tutorials/learn/amp-email-format: /documentation/guides-and-tutorials/learn/email-spec/amp-email-format
+/documentation/guides-and-tutorials/optimize-measure/configure-analytics/: /documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/
+/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics-vendors: /documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/analytics-vendors
+/documentation/guides-and-tutorials/optimize-measure/configure-analytics/analytics_basics: /documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/analytics_basics
+/documentation/guides-and-tutorials/optimize-measure/configure-analytics/deep_dive_analytics: /documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/deep_dive_analytics
+/documentation/guides-and-tutorials/optimize-measure/configure-analytics/use_cases: /documentation/guides-and-tutorials/optimize-and-measure/configure-analytics/use_cases

--- a/platform/lib/config.js
+++ b/platform/lib/config.js
@@ -100,6 +100,15 @@ class Config {
   }
 
   /**
+   * Returns an array with the locale ids.
+   * (e.g. 'en', 'pt_BR', ...)
+   * These locale ids are used
+   */
+  getAvailableLocales() {
+    return AVAILABLE_LOCALES.slice(0); // clone our internal array
+  }
+
+  /**
    * Builds a subdomain URL from a host object containing scheme, host, subdomain and port
    * @return {String} The full URL
    */

--- a/platform/lib/middleware/redirects.js
+++ b/platform/lib/middleware/redirects.js
@@ -50,8 +50,9 @@ function getRedirectLink(req) {
       }
     }
   }
-  if (result && req.query) {
-    result = result + '?' + url.parse(req.url).query;
+  const queryString = url.parse(req.url).query;
+  if (result && queryString) {
+    result = result + '?' + queryString;
   }
   return result;
 }

--- a/platform/lib/middleware/redirects.js
+++ b/platform/lib/middleware/redirects.js
@@ -17,6 +17,7 @@
 'use strict';
 
 const {readFileSync} = require('fs');
+const url = require('url');
 const {join} = require('path');
 const yaml = require('js-yaml');
 const config = require('@lib/config.js');
@@ -27,6 +28,33 @@ const WWW_PREFIX = 'www.';
 
 const REDIRECT_LINKS_DEFINITION = join(__dirname, '../../config/amp-dev-redirects.yaml');
 const redirectLinks = yaml.safeLoad(readFileSync(REDIRECT_LINKS_DEFINITION));
+
+const AVAILABLE_LOCALES = config.getAvailableLocales();
+const LANGUAGE_PATH_PATTERN = /^\/([a-z]{2}(_[a-z]{2})?)\//;
+
+/**
+ *
+ * @param req
+ * @returns The redirect link or undefined if none was found.
+ */
+function getRedirectLink(req) {
+  let result = redirectLinks[req.path];
+  if (!result) {
+    const langMatch = req.path.match(LANGUAGE_PATH_PATTERN);
+    if (langMatch && AVAILABLE_LOCALES.findIndex(
+        (item) => langMatch[1] === item.toLowerCase()) >= 0) {
+      const noLangPath = req.path.substr(langMatch[1].length + 1);
+      result = redirectLinks[noLangPath];
+      if (result) {
+        result = '/' + langMatch[1] + result;
+      }
+    }
+  }
+  if (result && req.query) {
+    result = result + '?' + url.parse(req.url).query;
+  }
+  return result;
+}
 
 /**
  * Implements redirects:
@@ -41,7 +69,7 @@ module.exports = (req, res, next) => {
     return next();
   }
 
-  const redirectTarget = redirectLinks[req.path];
+  const redirectTarget = getRedirectLink(req);
   if (redirectTarget) {
     try {
       const targetUrl = new URL(redirectTarget, config.hosts.platform.base);

--- a/platform/lib/middleware/redirects.test.js
+++ b/platform/lib/middleware/redirects.test.js
@@ -6,8 +6,10 @@ const request = require('supertest');
 const VALID_LANGUAGE_SHORT = 'en';
 const VALID_LANGUAGE_LONG = 'pt_br';
 
-const UNIT_TEST_REDIRECTS = '/shortcut: /some/deep/link/\n' +
-    '/' + VALID_LANGUAGE_SHORT + '/old/link: /new/link/target';
+const UNIT_TEST_REDIRECTS = `
+/shortcut: /some/deep/link/
+/${VALID_LANGUAGE_SHORT}/old/link: /new/link/target
+`;
 
 jest.mock('js-yaml');
 const yaml = require('js-yaml');
@@ -30,15 +32,15 @@ test('redirect for shortcut in default language', (done) => {
 
 test('redirect for shortcut in specific short language', (done) => {
   request(app)
-      .get('/' + VALID_LANGUAGE_SHORT + '/shortcut')
-      .expect('Location', 'http://localhost:8080/' + VALID_LANGUAGE_SHORT + '/some/deep/link/')
+      .get(`/${VALID_LANGUAGE_SHORT}/shortcut`)
+      .expect('Location', `http://localhost:8080/${VALID_LANGUAGE_SHORT}/some/deep/link/`)
       .expect(302, done);
 });
 
 test('redirect for shortcut in specific long language', (done) => {
   request(app)
-      .get('/' + VALID_LANGUAGE_LONG + '/shortcut')
-      .expect('Location', 'http://localhost:8080/' + VALID_LANGUAGE_LONG + '/some/deep/link/')
+      .get(`/${VALID_LANGUAGE_LONG}/shortcut`)
+      .expect('Location', `http://localhost:8080/${VALID_LANGUAGE_LONG}/some/deep/link/`)
       .expect(302, done);
 });
 
@@ -58,14 +60,14 @@ test('redirect for shortcut in default language with param', (done) => {
 
 test('redirect for shortcut in specific short language with params', (done) => {
   request(app)
-      .get('/' + VALID_LANGUAGE_SHORT + '/shortcut?format=website&foo=bar')
-      .expect('Location', 'http://localhost:8080/' + VALID_LANGUAGE_SHORT + '/some/deep/link/?format=website&foo=bar')
+      .get(`/${VALID_LANGUAGE_SHORT}/shortcut?format=website&foo=bar`)
+      .expect('Location', `http://localhost:8080/${VALID_LANGUAGE_SHORT}/some/deep/link/?format=website&foo=bar`)
       .expect(302, done);
 });
 
 test('redirect for language specific link', (done) => {
   request(app)
-      .get('/' + VALID_LANGUAGE_SHORT + '/old/link')
+      .get(`/${VALID_LANGUAGE_SHORT}/old/link`)
       .expect('Location', 'http://localhost:8080/new/link/target')
       .expect(302, done);
 });
@@ -79,7 +81,7 @@ test('no redirect for language specific link in default language', (done) => {
 
 test('no redirect for language specific link in other language', (done) => {
   request(app)
-      .get('/' + VALID_LANGUAGE_LONG + '/old/link')
+      .get(`/${VALID_LANGUAGE_LONG}/old/link`)
       .set('x-forwarded-proto', 'https')
       .expect(404, done);
 });

--- a/platform/lib/middleware/redirects.test.js
+++ b/platform/lib/middleware/redirects.test.js
@@ -1,0 +1,85 @@
+const express = require('express');
+const request = require('supertest');
+
+// The languages used here have to be in the config.js
+// We do not mock the config, since it is not likely to change
+const VALID_LANGUAGE_SHORT = 'en';
+const VALID_LANGUAGE_LONG = 'pt_br';
+
+const UNIT_TEST_REDIRECTS = '/shortcut: /some/deep/link/\n' +
+    '/' + VALID_LANGUAGE_SHORT + '/old/link: /new/link/target';
+
+jest.mock('js-yaml');
+const yaml = require('js-yaml');
+const {safeLoad} = jest.requireActual('js-yaml');
+const unitTestRedirects = safeLoad(UNIT_TEST_REDIRECTS);
+yaml.safeLoad.mockReturnValue(unitTestRedirects);
+
+
+const app = express();
+const router = require('./redirects.js');
+app.use(router);
+
+
+test('redirect for shortcut in default language', (done) => {
+  request(app)
+      .get('/shortcut')
+      .expect('Location', 'http://localhost:8080/some/deep/link/')
+      .expect(302, done);
+});
+
+test('redirect for shortcut in specific short language', (done) => {
+  request(app)
+      .get('/' + VALID_LANGUAGE_SHORT + '/shortcut')
+      .expect('Location', 'http://localhost:8080/' + VALID_LANGUAGE_SHORT + '/some/deep/link/')
+      .expect(302, done);
+});
+
+test('redirect for shortcut in specific long language', (done) => {
+  request(app)
+      .get('/' + VALID_LANGUAGE_LONG + '/shortcut')
+      .expect('Location', 'http://localhost:8080/' + VALID_LANGUAGE_LONG + '/some/deep/link/')
+      .expect(302, done);
+});
+
+test('no redirect for shortcut in an unknown language', (done) => {
+  request(app)
+      .get('/xx/shortcut')
+      .set('x-forwarded-proto', 'https')
+      .expect(404, done);
+});
+
+test('redirect for shortcut in default language with param', (done) => {
+  request(app)
+      .get('/shortcut?format=website')
+      .expect('Location', 'http://localhost:8080/some/deep/link/?format=website')
+      .expect(302, done);
+});
+
+test('redirect for shortcut in specific short language with params', (done) => {
+  request(app)
+      .get('/' + VALID_LANGUAGE_SHORT + '/shortcut?format=website&foo=bar')
+      .expect('Location', 'http://localhost:8080/' + VALID_LANGUAGE_SHORT + '/some/deep/link/?format=website&foo=bar')
+      .expect(302, done);
+});
+
+test('redirect for language specific link', (done) => {
+  request(app)
+      .get('/' + VALID_LANGUAGE_SHORT + '/old/link')
+      .expect('Location', 'http://localhost:8080/new/link/target')
+      .expect(302, done);
+});
+
+test('no redirect for language specific link in default language', (done) => {
+  request(app)
+      .get('/old/link')
+      .set('x-forwarded-proto', 'https')
+      .expect(404, done);
+});
+
+test('no redirect for language specific link in other language', (done) => {
+  request(app)
+      .get('/' + VALID_LANGUAGE_LONG + '/old/link')
+      .set('x-forwarded-proto', 'https')
+      .expect(404, done);
+});


### PR DESCRIPTION
Fixes https://github.com/ampproject/docs/issues/2261

**Improve redirect logic:**
Before the redirect mapping did only look for the complete path
and redirected to the target when a complete match was found.
Now we also look for the path without the locale path and use the locale for the redirect.
We also append the original query parameters to support the format=websites param

That means the shortcuts amp.dev/es/docs would work