### PR TITLE
Update allowed form input elements

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/spec/amphtml.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/spec/amphtml.md
@@ -194,7 +194,7 @@ HTML tags can be used unchanged in AMP HTML. Certain tags have equivalent custom
   </tr>
   <tr>
     <td width="30%">input elements</td>
-    <td>Mostly allowed with <a href="https://www.ampproject.org/docs/reference/components/amp-form#inputs-and-fields">exception of some input types</a>, namely, <code>&lt;input[type=image]&gt;</code>, <code>&lt;input[type=button]&gt;</code>, <code>&lt;input[type=password]&gt;</code>, <code>&lt;input[type=file]&gt;</code> are invalid. Related tags are also allowed: <code>&lt;fieldset&gt;</code>, <code>&lt;label&gt;</code></td>
+    <td>Mostly allowed with <a href="https://www.ampproject.org/docs/reference/components/amp-form#inputs-and-fields">exception of some input types</a>, namely, <code>&lt;input type=button&gt;</code>, <code>&lt;button type=image&gt;</code> are invalid. Related tags are also allowed: <code>&lt;fieldset&gt;</code>, <code>&lt;label&gt;</code></td>
   </tr>
   <tr>
     <td width="30%">button</td>


### PR DESCRIPTION
Remove `<input type=password>` and `<input type=file>` from disallowed list, since they are now allowed.

See https://amp.dev/documentation/components/amp-form#inputs-and-fields

