### PR TITLE
Fix/invalid sidebar

### DIFF
--- a/frontend/scss/components/molecules/format-toggle.scss
+++ b/frontend/scss/components/molecules/format-toggle.scss
@@ -11,6 +11,7 @@
   top: 0;
   margin: 0 10px;
   padding: 10px 0 0 0;
+  width: 100%;
   max-width: 85%;
   z-index: 12;
 

--- a/frontend/scss/components/organisms/component-sidebar.scss
+++ b/frontend/scss/components/organisms/component-sidebar.scss
@@ -25,26 +25,30 @@ amp-sidebar {
 
 nav[toolbar] {
   top: 86px;
-  -webkit-overflow-scrolling: touch;
+  height: 100vh;
+  max-height: calc(100vh - 86px);
 
   @media (min-width: 768px){
-    height: 100vh;
     position: sticky;
-    overflow: auto;
-    max-height: calc(100vh - 86px);
-  }
-
-  &::-webkit-scrollbar {
-    width: 2px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: rgba(color('black'), 0.10);
   }
 
   & > ul {
+    -webkit-overflow-scrolling: touch;
     margin: 0;
     padding: 0;
+
+    @media (min-width: 768px){
+      overflow: auto;
+      max-height: 100%;
+    }
+
+    &::-webkit-scrollbar {
+      width: 2px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: rgba(color('black'), 0.10);
+    }
   }
 }
 

--- a/frontend/scss/components/organisms/sidebar.scss
+++ b/frontend/scss/components/organisms/sidebar.scss
@@ -16,26 +16,30 @@ amp-sidebar {
 
 nav[toolbar] {
   top: 86px;
-  -webkit-overflow-scrolling: touch;
+  height: 100vh;
+  max-height: calc(100vh - 86px);
 
   @media (min-width: 768px){
-    height: 100vh;
     position: sticky;
-    overflow: auto;
-    max-height: calc(100vh - 86px);
-  }
-
-  &::-webkit-scrollbar {
-    width: 2px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: rgba(color('black'), 0.10);
   }
 
   & > ul {
+    -webkit-overflow-scrolling: touch;
     margin: 0;
     padding: 0;
+
+    @media (min-width: 768px){
+      overflow: auto;
+      max-height: 100%;
+    }
+
+    &::-webkit-scrollbar {
+      width: 2px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: rgba(color('black'), 0.10);
+    }
   }
 }
 

--- a/frontend/templates/views/partials/component-sidebar.j2
+++ b/frontend/templates/views/partials/component-sidebar.j2
@@ -7,8 +7,8 @@
   side="left">
   <nav toolbar="(min-width: 768px)"
     toolbar-target="ap--sidebar-content">
-    {% include '/views/partials/format-toggle.j2' %}
     <ul>
+      {% include '/views/partials/format-toggle.j2' %}
       <section class="ap-o-sidebar-section">
         <div class="ap-o-component-sidebar">
           <div class="nav">

--- a/frontend/templates/views/partials/example-sidebar.j2
+++ b/frontend/templates/views/partials/example-sidebar.j2
@@ -7,8 +7,8 @@
   side="left">
   <nav toolbar="(min-width: 768px)"
     toolbar-target="ap--sidebar-content">
-    {% include '/views/partials/format-toggle.j2' %}
     <ul>
+      {% include '/views/partials/format-toggle.j2' %}
       <section>
         <div class="ap-o-sidebar">
           <div class="nav">

--- a/frontend/templates/views/partials/sidebar.j2
+++ b/frontend/templates/views/partials/sidebar.j2
@@ -4,8 +4,8 @@
   side="left">
   <nav toolbar="(min-width: 768px)"
     toolbar-target="ap--sidebar-content">
-    {% include '/views/partials/format-toggle.j2' %}
     <ul>
+      {% include '/views/partials/format-toggle.j2' %}
       <section class="ap-o-sidebar-section">
         {% do doc.styles.addCssFile('css/components/organisms/sidebar.css') %}
         <div class="ap-o-sidebar">


### PR DESCRIPTION
This PR fixes the validation error: "Tag 'amp-sidebar > nav' must have 1 child tags - saw 2 child tags." and rewrite the css for the sidebar to work exactly like before.