### PR TITLE
:bug: Set header's sticky top value to zero

### DIFF
--- a/frontend/scss/components/organisms/header.scss
+++ b/frontend/scss/components/organisms/header.scss
@@ -37,7 +37,7 @@
   }
 
   @media (min-width: 1024px) {
-    top: -35px;
+    top: 0px;
   }
 }
 


### PR DESCRIPTION
Since the banner is gone, the header scroll's outside of the viewport