### PR TITLE
💄Remove gradient from code-snippets

### DIFF
--- a/frontend/scss/components/molecules/code-snippet.scss
+++ b/frontend/scss/components/molecules/code-snippet.scss
@@ -24,8 +24,7 @@ Styles taken and combined from: https://raw.githubusercontent.com/richleland/pyg
   padding: 0 1em;
   color: color('white');
   line-height: 1.3em;
-  background: rgb(41,50,60);
-  background: linear-gradient(225deg, rgb(41, 50, 60) 0%, color('ebony-clay') 75%);
+  background: color('ebony-clay');
   scrollbar-width: thin;
   font-size: 0.9em;
 

--- a/frontend/scss/components/organisms/code-preview.scss
+++ b/frontend/scss/components/organisms/code-preview.scss
@@ -18,7 +18,7 @@
 
 .#{organism('code-preview')} {
   position: relative;
-  background: linear-gradient(45deg, color('river-bed'), color('ebony-clay'));
+  background: color('ebony-clay');
 
   &-reload {
     position: absolute;

--- a/playground/src/editor/editor.scss
+++ b/playground/src/editor/editor.scss
@@ -16,7 +16,7 @@
 .cm-s-monokai.CodeMirror {
   font-size: 14px;
   height: 100%;
-  background: linear-gradient(45deg, #48525c, #101923);
+  background: color('ebony-clay');
   pre {
     @include txt-mono;
     line-height: 1.25em;


### PR DESCRIPTION
fix #2284 remove background-gradient from code-snippets and add background-color: color('ebony-clay') in order to optimize reading 