### PR TITLE
♻️ Migrate amphtml-email API to amp.dev

### DIFF
--- a/examples/source/interactivity-dynamic-content/Article_Bookmark_Email/api.js
+++ b/examples/source/interactivity-dynamic-content/Article_Bookmark_Email/api.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+const multer = require('multer');
+const upload = multer();
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+
+examples.post('/submit-form-bookmark', upload.none(), (request, response) => {
+  const id = request.body ? request.body.id : '';
+  response.json({
+    result: `Item with ID ${id} bookmarked.`,
+  });
+});
+
+module.exports = examples;

--- a/examples/source/interactivity-dynamic-content/Article_Bookmark_Email/api.js
+++ b/examples/source/interactivity-dynamic-content/Article_Bookmark_Email/api.js
@@ -16,14 +16,12 @@
 'use strict';
 
 const express = require('express');
-const multer = require('multer');
-const upload = multer();
 
 // eslint-disable-next-line new-cap
 const examples = express.Router();
 
-examples.post('/submit-form-bookmark', upload.none(), (request, response) => {
-  const id = request.body ? request.body.id : '';
+examples.post('/submit-form-bookmark', (request, response) => {
+  const id = request.query ? request.query.id : '';
   response.json({
     result: `Item with ID ${id} bookmarked.`,
   });

--- a/examples/source/interactivity-dynamic-content/Article_Bookmark_Email/index.html
+++ b/examples/source/interactivity-dynamic-content/Article_Bookmark_Email/index.html
@@ -43,6 +43,7 @@ send a request to the server without the user leaving their e-mail client.
     <h1>Sample article</h1>
     <p>This is a short summary of a sample article. The user can choose to continue reading on the website or bookmark it to their account for later.</p>
   </div>
+  
   <!--
     We show a "bookmark" button under the article, which sends a bookmark request to the server asynchronously via `amp-form`.
 
@@ -50,7 +51,7 @@ send a request to the server without the user leaving their e-mail client.
     In this example, this token is represented with `123abc`. In a real-life scenario, this hidden input field `auth_token` would contain a real server-side validated limited-use access token.
   -->
   <div>
-    <form action-xhr="<% hosts.backend %>/amphtml-email/submit-form-bookmark" method="post">
+    <form action-xhr="submit-form-bookmark" method="post">
       <input type="hidden"
               name="id"
               value="ARTICLE_UNIQUE_ID">


### PR DESCRIPTION
Migrated the backend/amphtml-email.go from ampbyexample.com to amp.dev.
This updates the example [here](https://amp.dev/documentation/examples/interactivity-dynamic-content/article_bookmark_email/?format=email).

Part of the migration/improvements in #2054.