### PR TITLE
Fix format-toggle dropdown-list too wide on safari 

### DIFF
--- a/frontend/scss/components/atoms/sidebar-toggle.scss
+++ b/frontend/scss/components/atoms/sidebar-toggle.scss
@@ -147,6 +147,7 @@ $originalEasing: cubic-bezier(0,0,.21,1);
     display: inline-block;
 
     &-label {
+      position: -webkit-sticky;
       position: sticky;
       top: 138px;
       display: inline-flex;

--- a/frontend/scss/components/molecules/format-toggle.scss
+++ b/frontend/scss/components/molecules/format-toggle.scss
@@ -7,6 +7,7 @@
 @import 'components/atoms/_text';
 
 .#{molecule('format-toggle')} {
+  position: -webkit-sticky;
   position: sticky;
   top: 0;
   margin: 0 10px;
@@ -45,7 +46,7 @@
     display: flex;
     align-items: center;
     width: 100%;
-    margin-bottom: 2px;
+    margin: 0 0 2px;
     padding: 5px 8px;
     overflow: hidden;
     @include txt;

--- a/frontend/scss/components/organisms/component-sidebar.scss
+++ b/frontend/scss/components/organisms/component-sidebar.scss
@@ -29,6 +29,7 @@ nav[toolbar] {
   max-height: calc(100vh - 86px);
 
   @media (min-width: 768px){
+    position: -webkit-sticky;
     position: sticky;
   }
 

--- a/frontend/scss/components/organisms/sidebar.scss
+++ b/frontend/scss/components/organisms/sidebar.scss
@@ -20,6 +20,7 @@ nav[toolbar] {
   max-height: calc(100vh - 86px);
 
   @media (min-width: 768px){
+    position: -webkit-sticky;
     position: sticky;
   }
 

--- a/frontend/scss/components/templates/component-overview.scss
+++ b/frontend/scss/components/templates/component-overview.scss
@@ -62,6 +62,7 @@ body {
   }
 
   &-anchor-list {
+    position: -webkit-sticky;
     position: sticky;
     z-index: 2;
     top: 90px;


### PR DESCRIPTION
This was caused by missing browser prefix.
Added it there and also everywhere else it was missing.
Also adjusted auto generated margin-top, which also only appeared in safari.