### PR TITLE
Examples playground links: section separator + no link for head snippets

### DIFF
--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -191,8 +191,8 @@
         {{ markdown.convert('```html\n' + section.code + '\n```')|safe }}
       </div>
 
-      {% if not playground_disabled and doc.example.document.metadata.standaloneSnippets %}
-      <a href="{{ playground_url }}{{ section.id }}" class="ap-m-lnk ap--playground-link">
+      {% if section.inBody and not playground_disabled and doc.example.document.metadata.standaloneSnippets %}
+      <a href="{{ playground_url }}/{{ section.id }}" class="ap-m-lnk ap--playground-link">
           <div class="ap-a-ico ap-m-lnk-icon">
             <svg><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#internal"></use></svg>
           </div>


### PR DESCRIPTION
Fixes two problems with playground links
- Sections in the head will have no section preview file, so the link should not be shown
- For section preview links a / was missing before the section id
Those problems can be seen here:
https://amp.dev/documentation/examples/components/amp-accordion/?format=websites