### PR TITLE
♻️ Migrate amp-access API to amp.dev

### DIFF
--- a/examples/api/amp-access.js
+++ b/examples/api/amp-access.js
@@ -36,9 +36,9 @@ const POWER_USERS = {
 };
 const EXPIRATION_DATE = 24*60*60*1000; // 1 day in ms
 
-examples.all('/amp-access/authorization', handleAuthorization);
-examples.all('/amp-access/login', handleLogin);
-examples.all('/amp-access/logout', handleLogout);
+examples.get('/amp-access/authorization', handleAuthorization);
+examples.get('/amp-access/login', handleLogin);
+examples.get('/amp-access/logout', handleLogout);
 examples.post('/amp-access/submit', handleSubmit);
 
 function handleAuthorization(request, response) {

--- a/examples/api/amp-access.js
+++ b/examples/api/amp-access.js
@@ -35,6 +35,7 @@ const VALID_USERS = {
 const POWER_USERS = {
   'Jane@gmail.com': true,
 };
+const EXPIRATION_DATE = 24*60*60*1000; // 1 day in ms
 
 examples.all('/amp-access/authorization', handleAuthorization);
 examples.all('/amp-access/login', handleLogin);
@@ -89,7 +90,7 @@ function handleSubmit(request, response) {
     response.status(401).send('Invalid email');
     return;
   }
-  response.cookie(AMP_ACCESS_COOKIE, {email}, {expires: new Date(Date.now() + 24*60*60*1000)});
+  response.cookie(AMP_ACCESS_COOKIE, {email}, {expires: new Date(Date.now() + EXPIRATION_DATE)});
   let returnUrl = request.body.returnurl;
   if (!isValidURL(returnUrl)) {
     response.status(500).send('Invalid return URL');

--- a/examples/api/amp-access.js
+++ b/examples/api/amp-access.js
@@ -36,9 +36,9 @@ const POWER_USERS = {
   'Jane@gmail.com': true,
 };
 
-examples.get('/amp-access/authorization', handleAuthorization);
-examples.get('/amp-access/login', handleLogin);
-examples.get('/amp-access/logout', handleLogout);
+examples.all('/amp-access/authorization', handleAuthorization);
+examples.all('/amp-access/login', handleLogin);
+examples.all('/amp-access/logout', handleLogout);
 examples.post('/amp-access/submit', upload.none(), handleSubmit);
 
 function handleAuthorization(request, response) {

--- a/examples/api/amp-access.js
+++ b/examples/api/amp-access.js
@@ -15,11 +15,11 @@
  */
 'use strict';
 
-const path = require('path');
 const express = require('express');
 const cookieParser = require('cookie-parser');
 const nunjucks = require('nunjucks');
 const URL = require('url');
+const utils = require('@lib/utils');
 
 // eslint-disable-next-line new-cap
 const examples = express.Router();
@@ -68,7 +68,8 @@ function handleLogin(request, response) {
     response.status(500).send('Invalid return URL');
     return;
   }
-  const filePath = path.join(__dirname, '../static/samples/files/login.html');
+  const filePath = utils.project.absolute('/examples/static/samples/files/login.html');
+
   response.send(nunjucks.render(filePath, {returnurl: returnUrl}));
 }
 

--- a/examples/api/amp-access.js
+++ b/examples/api/amp-access.js
@@ -18,14 +18,13 @@
 const path = require('path');
 const express = require('express');
 const cookieParser = require('cookie-parser');
-const multer = require('multer');
-const upload = multer();
 const nunjucks = require('nunjucks');
 const URL = require('url');
 
 // eslint-disable-next-line new-cap
 const examples = express.Router();
 examples.use(cookieParser());
+examples.use(express.urlencoded());
 
 const AMP_ACCESS_COOKIE = 'ABE_LOGGED_IN';
 const VALID_USERS = {
@@ -40,7 +39,7 @@ const EXPIRATION_DATE = 24*60*60*1000; // 1 day in ms
 examples.all('/amp-access/authorization', handleAuthorization);
 examples.all('/amp-access/login', handleLogin);
 examples.all('/amp-access/logout', handleLogout);
-examples.post('/amp-access/submit', upload.none(), handleSubmit);
+examples.post('/amp-access/submit', handleSubmit);
 
 function handleAuthorization(request, response) {
   const cookie = request.cookies[AMP_ACCESS_COOKIE];

--- a/examples/api/amp-access.js
+++ b/examples/api/amp-access.js
@@ -63,11 +63,7 @@ function handleAuthorization(request, response) {
 }
 
 function handleLogin(request, response) {
-  const returnUrl = request.query ? request.query.return : '';
-  if (!isValidURL(returnUrl)) {
-    response.status(500).send('Invalid return URL');
-    return;
-  }
+  const returnUrl = request.query.return;
   const filePath = utils.project.absolute('/examples/static/samples/files/login.html');
 
   response.send(nunjucks.render(filePath, {returnurl: returnUrl}));

--- a/examples/api/amp-access.js
+++ b/examples/api/amp-access.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const path = require('path');
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const multer = require('multer');
+const upload = multer();
+const nunjucks = require('nunjucks');
+const URL = require('url');
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+examples.use(cookieParser());
+
+const AMP_ACCESS_COOKIE = 'ABE_LOGGED_IN';
+const VALID_USERS = {
+  'mark@gmail.com': true,
+  'jane@gmail.com': true,
+};
+const POWER_USERS = {
+  'Jane@gmail.com': true,
+};
+
+examples.get('/amp-access/authorization', handleAuthorization);
+examples.get('/amp-access/login', handleLogin);
+examples.get('/amp-access/logout', handleLogout);
+examples.post('/amp-access/submit', upload.none(), handleSubmit);
+
+function handleAuthorization(request, response) {
+  const cookie = request.cookies[AMP_ACCESS_COOKIE];
+  if (!cookie) {
+    response.json({
+      loggedIn: false,
+      powerUser: false,
+      email: '',
+      name: '',
+    });
+    return;
+  }
+  const email = cookie.email;
+  const powerUser = POWER_USERS[email];
+  response.json({
+    loggedIn: true,
+    powerUser,
+    email,
+    name: email.split('@')[0],
+  });
+}
+
+function handleLogin(request, response) {
+  const returnUrl = request.query ? request.query.return : '';
+  if (!isValidURL(returnUrl)) {
+    response.status(500).send('Invalid return URL');
+    return;
+  }
+  const filePath = path.join(__dirname, '../static/samples/files/login.html');
+  response.send(nunjucks.render(filePath, {returnurl: returnUrl}));
+}
+
+function handleLogout(request, response) {
+  let returnUrl = request.query ? request.query.return : '';
+  if (!isValidURL(returnUrl)) {
+    response.status(500).send('Invalid return URL');
+    return;
+  }
+  returnUrl += '#success=true';
+  response.clearCookie(AMP_ACCESS_COOKIE);
+  response.status(303).redirect(returnUrl);
+}
+
+function handleSubmit(request, response) {
+  const email = request.body ? request.body.email : '';
+  if (!VALID_USERS[email]) {
+    response.status(401).send('Invalid email');
+    return;
+  }
+  response.cookie(AMP_ACCESS_COOKIE, {email}, {expires: new Date(Date.now() + 24*60*60*1000)});
+  let returnUrl = request.body.returnurl;
+  if (!isValidURL(returnUrl)) {
+    response.status(500).send('Invalid return URL');
+    return;
+  }
+  returnUrl += '#success=true';
+  response.status(303).redirect(returnUrl);
+}
+
+function isValidURL(url) {
+  const a = URL.parse(url);
+  return (a.host && a.protocol && (a.protocol === 'http:' || a.protocol === 'https:'));
+}
+
+module.exports = examples;

--- a/examples/source/1.components/amp-access.html
+++ b/examples/source/1.components/amp-access.html
@@ -29,11 +29,11 @@ author: andreban
   -->
   <script id="amp-access" type="application/json">
     {
-        "authorization": "<% hosts.backend %>/components/amp-access/authorization?rid=READER_ID&url=CANONICAL_URL&ref=DOCUMENT_REFERRER&_=RANDOM",
-        "pingback": "<% hosts.backend %>/components/amp-access/authorization?rid=READER_ID&url=CANONICAL_URL&ref=DOCUMENT_REFERRER&_=RANDOM",
+        "authorization": "/documentation/examples/api/amp-access/authorization?rid=READER_ID&url=CANONICAL_URL&ref=DOCUMENT_REFERRER&_=RANDOM",
+        "pingback": "/documentation/examples/api/amp-access/authorization?rid=READER_ID&url=CANONICAL_URL&ref=DOCUMENT_REFERRER&_=RANDOM",
         "login": {
-          "sign-in": "<% hosts.backend %>/components/amp-access/login?rid=READER_ID&url=CANONICAL_URL",
-          "sign-out": "<% hosts.backend %>/components/amp-access/logout"
+          "sign-in": "/documentation/examples/api/amp-access/login?rid=READER_ID&url=CANONICAL_URL",
+          "sign-out": "/documentation/examples/api/amp-access/logout"
         },
         "authorizationFallbackResponse": {
             "error": true,

--- a/examples/source/interactivity-dynamic-content/Comment_Section/index.html
+++ b/examples/source/interactivity-dynamic-content/Comment_Section/index.html
@@ -136,11 +136,11 @@ This sample showcases how to build a comment section in AMP HTML using the [amp-
     This sample allows an user to login and logout using an email and a password. Logout is implemented by configuring a second endpoint in the login property `sign-out`, find more [here]({{g.doc('/content/amp-dev/documentation/components/reference/amp-access.md', locale=doc.locale).url.path}}#login-page).  -->
     <script id="amp-access" type="application/json">
     {
-        "authorization": "<% hosts.backend %>/components/amp-access/authorization?rid=READER_ID&url=CANONICAL_URL&ref=DOCUMENT_REFERRER&_=RANDOM",
+        "authorization": "/documentation/examples/api/amp-access/authorization?rid=READER_ID&url=CANONICAL_URL&ref=DOCUMENT_REFERRER&_=RANDOM",
         "noPingback": "true",
         "login": {
-          "sign-in": "<% hosts.backend %>/components/amp-access/login?rid=READER_ID",
-          "sign-out": "<% hosts.backend %>/components/amp-access/logout?rid=READER_ID"
+          "sign-in": "/documentation/examples/api/amp-access/login?rid=READER_ID",
+          "sign-out": "/documentation/examples/api/amp-access/logout?rid=READER_ID"
         },
         "authorizationFallbackResponse": {
             "error": true,

--- a/examples/static/samples/files/login.html
+++ b/examples/static/samples/files/login.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <title>Login</title>
+    <style>
+      body {
+          font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+      }
+      .button {
+        border-radius: 2px;
+      }
+
+      .note {
+        font-size: 0.7rem;
+        text-decoration: italic;
+        padding-top: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="main-body">
+      <h1>Login</h1>
+      <p>
+        Use mark@gmail.com or jane@gmail.com (power user) with any password
+        to perform a successful login.
+      </p>
+      <form method="post" action="submit" id="login-form" enctype="multipart/form-data">
+        <div class="label">Email:</div>
+          <input type="email" name="email" value="mark@gmail.com">
+        <div class="form-line">
+          <div class="label">Password:</div>
+          <input type="password" name="password" value="">
+        </div>
+        <input name="returnurl" type="hidden" value="{{ returnurl }}">
+        <input type="submit" value="Login" class="button">
+      </form>
+      <p class="note">Note: The login page is standalone and doesn't need to be valid AMP.</p>
+    </main>
+  </body>
+</html>

--- a/examples/static/samples/files/login.html
+++ b/examples/static/samples/files/login.html
@@ -26,7 +26,7 @@
         Use mark@gmail.com or jane@gmail.com (power user) with any password
         to perform a successful login.
       </p>
-      <form method="post" action="submit" id="login-form" enctype="multipart/form-data">
+      <form method="post" action="submit" id="login-form">
         <div class="label">Email:</div>
           <input type="email" name="email" value="mark@gmail.com">
         <div class="form-line">


### PR DESCRIPTION
Migrated the backend/amp-access.go from ampbyexample.com to amp.dev.
This updates the example [here](https://amp.dev/documentation/examples/components/amp-access/?format=websites) and [here](https://amp.dev/documentation/examples/interactivity-dynamic-content/comment_section/?format=websites).

Part of the migration/improvements in #2054.