### PR TITLE
Add tools and email-tools redirects

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -7,6 +7,7 @@
 /cors: /documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cors-requests
 /docs: /documentation/guides-and-tutorials/
 /email: /about/email
+/email-tools: /documentation/tools
 /governance: /community/governance
 /io-email: /documentation/examples/interactivity-dynamic-content/conference_survey_email/
 /learn: /documentation/courses/
@@ -18,5 +19,6 @@
 /stories: /about/stories
 /sxg: /documentation/guides-and-tutorials/optimize-and-measure/signed-exchange
 /templates: /documentation/templates/
+/tools: /documentation/tools
 /vision-mission: /about/mission-and-vision
 /websites: /about/websites


### PR DESCRIPTION
go.amp.dev/email-tools is currently the same as go.amp.dev/tools, but this will be updated when #2341 is fixed (I'm adding it now to link from slide deck).