### PR TITLE
✏️ remove space in order to fix link

### DIFF
--- a/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validate_amp@es.md
+++ b/pages/content/amp-dev/documentation/guides-and-tutorials/learn/validation-workflow/validate_amp@es.md
@@ -87,7 +87,7 @@ de color.
 </table>
 
 Extensión del validador de AMP para
-[Chrome](https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc) y [Opera] (https://addons.opera.com/en-gb/extensions/details/amp-validator/).
+[Chrome](https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc) y [Opera](https://addons.opera.com/en-gb/extensions/details/amp-validator/).
 
 ### Paquetes de NPM para CI
 


### PR DESCRIPTION
fixes #2343 in validate_amp@es.md page by removing a space between the link and link-description.