### PR TITLE
💄 Add styling to static DayPicker in examples

### DIFF
--- a/examples/source/1.components/amp-date-picker.html
+++ b/examples/source/1.components/amp-date-picker.html
@@ -85,15 +85,6 @@ author: kul3r4
     margin-top: var(--space-1);
     width: 27px;
   }
-  
-  /* edit inline-code-preview */
-  .ap-o-code-preview .DayPicker_weekHeader {
-    top: 60px;
-  }
-
-  ul.DayPicker_weekHeader_ul.DayPicker_weekHeader_ul_1 {
-    padding-left: 0;
-  }
   </style>
 </head>
 <body>

--- a/examples/source/1.components/amp-date-picker.html
+++ b/examples/source/1.components/amp-date-picker.html
@@ -69,14 +69,6 @@ author: kul3r4
     margin-left: var(--space-2);
   }
 
-  .DayPicker_weekHeader {
-    top: 60px;
-  }
-
-  ul.DayPicker_weekHeader_ul.DayPicker_weekHeader_ul_1 {
-    padding-left: 0;
-  }
-
   #lb {
     background: var(--color-bg-light);
   }
@@ -92,6 +84,15 @@ author: kul3r4
     height: 28px;
     margin-top: var(--space-1);
     width: 27px;
+  }
+  
+  /* edit inline-code-preview */
+  .ap-o-code-preview .DayPicker_weekHeader {
+    top: 60px;
+  }
+
+  ul.DayPicker_weekHeader_ul.DayPicker_weekHeader_ul_1 {
+    padding-left: 0;
   }
   </style>
 </head>

--- a/examples/source/1.components/amp-date-picker.html
+++ b/examples/source/1.components/amp-date-picker.html
@@ -69,6 +69,14 @@ author: kul3r4
     margin-left: var(--space-2);
   }
 
+  .DayPicker_weekHeader {
+    top: 60px;
+  }
+
+  ul.DayPicker_weekHeader_ul.DayPicker_weekHeader_ul_1 {
+    padding-left: 0;
+  }
+
   #lb {
     background: var(--color-bg-light);
   }

--- a/frontend/scss/components/atoms/text.scss
+++ b/frontend/scss/components/atoms/text.scss
@@ -7,7 +7,8 @@
 @import './_color';
 
 
-.#{utility('content')} {
+.#{utility('content')},
+.#{utility('section')} {
   .intro {
     @include txt-1;
     padding: 0;
@@ -47,8 +48,8 @@
     white-space: pre-wrap;
   }
 
-  ul,
-  ol {
+  & > ul,
+  & > ol {
     @include txt;
     @include txt-p;
     padding-left: 2em;
@@ -56,6 +57,7 @@
 
     ul,
     ol {
+      padding-left: 2em;
       margin: 0;
     }
 


### PR DESCRIPTION
fixes #2351 add styling (remove padding-left) for the static dayPicker in order to let the days appear in one row above the dates.