### PR TITLE
Allows go-links.yaml to have regex based redirects

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -24,9 +24,9 @@
 /websites: /about/websites
 
 # Regex-based entries
-/c/amp-([a-z-]+):
+^/c/amp-([a-z-]+)$:
   url: /documentation/components/amp-$1
   useRegex: true
-/s/amp-([a-z-]+):
+^/s/amp-([a-z-]+)$:
   url: /documentation/examples/components/amp-$1
   useRegex: true

--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -22,3 +22,11 @@
 /tools: /documentation/tools
 /vision-mission: /about/mission-and-vision
 /websites: /about/websites
+
+# Regex-based entries
+/c/amp-([a-z-]+):
+  url: /documentation/components/amp-$1
+  useRegex: true
+/s/amp-([a-z-]+):
+  url: /documentation/examples/components/amp-$1
+  useRegex: true

--- a/platform/lib/routers/go.test.js
+++ b/platform/lib/routers/go.test.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const request = require('supertest');
+
+const app = express();
+const router = require('./go.js');
+app.use(router);
+
+test('redirects simple golink', (done) => {
+  request(app)
+      .get('/tools')
+      .expect(302)
+      .expect('Location', /\/documentation\/tools$/, done);
+});

--- a/platform/lib/routers/go.test.js
+++ b/platform/lib/routers/go.test.js
@@ -11,3 +11,16 @@ test('redirects simple golink', (done) => {
       .expect(302)
       .expect('Location', /\/documentation\/tools$/, done);
 });
+
+test('redirects regex golink', (done) => {
+  request(app)
+      .get('/c/amp-fit-text')
+      .expect(302)
+      .expect('Location', /\/documentation\/components\/amp-fit-text$/, done);
+});
+
+test('returns 404 on invalid golink', (done) => {
+  request(app)
+      .get('/invalid')
+      .expect(404, done);
+});

--- a/platform/lib/routers/go.test.js
+++ b/platform/lib/routers/go.test.js
@@ -1,15 +1,29 @@
 const express = require('express');
 const request = require('supertest');
 
+const GO_LINKS_YAML = `
+/email: /about/email
+/websites: /about/websites
+^/c/amp-([a-z-]+)$:
+  url: /documentation/components/amp-$1
+  useRegex: true
+`;
+
+jest.mock('js-yaml');
+const yaml = require('js-yaml');
+const {safeLoad} = jest.requireActual('js-yaml');
+const goLinks = safeLoad(GO_LINKS_YAML);
+yaml.safeLoad.mockReturnValue(goLinks);
+
 const app = express();
 const router = require('./go.js');
 app.use(router);
 
 test('redirects simple golink', (done) => {
   request(app)
-      .get('/tools')
+      .get('/email')
       .expect(302)
-      .expect('Location', /\/documentation\/tools$/, done);
+      .expect('Location', /\/about\/email$/, done);
 });
 
 test('redirects regex golink', (done) => {


### PR DESCRIPTION
This PR allows `go-links.yaml` to have this syntax for "catch-all" redirects:

```yaml
/c/amp-([a-z-]+):
  url: /documentation/components/amp-$1
  useRegex: true
```

It also adds redirects for components (e.g. `go.amp.dev/c/amp-form`) and samples (e.g. `go.amp.dev/s/amp-form`) and closes #2182 and #1860.