### PR TITLE
🎨 Change class name of section in examples and add styling

### DIFF
--- a/frontend/scss/components/organisms/help.scss
+++ b/frontend/scss/components/organisms/help.scss
@@ -22,7 +22,14 @@
 
 .#{organism('help')} {
 
-  padding-top: 32px;
+  padding-top: 84px;
+  padding-left: 15px;
+  padding-right: 15px;
+
+  @media (min-width: 768px) {
+    padding-left: 0;
+    padding-right: 0;
+  }
 
   &-hl {
     @include hl;
@@ -44,5 +51,12 @@
 
   &-divider {
     @include divider-header-mobile;
+  }
+}
+
+/* if the ap-o-help is inside an ap--content, it has too much padding to the top. */
+@media (min-width: 768px) {
+  .ap--content > .#{organism('help')} {
+    padding-top: 22px;
   }
 }

--- a/frontend/scss/components/organisms/help.scss
+++ b/frontend/scss/components/organisms/help.scss
@@ -21,10 +21,7 @@
 
 
 .#{organism('help')} {
-
-  padding-top: 84px;
-  padding-left: 15px;
-  padding-right: 15px;
+  padding: 84px 15px 0;
 
   @media (min-width: 768px) {
     padding-left: 0;
@@ -51,12 +48,5 @@
 
   &-divider {
     @include divider-header-mobile;
-  }
-}
-
-/* if the ap-o-help is inside an ap--content, it has too much padding to the top. */
-@media (min-width: 768px) {
-  .ap--content > .#{organism('help')} {
-    padding-top: 22px;
   }
 }

--- a/frontend/templates/views/examples/documentation.j2
+++ b/frontend/templates/views/examples/documentation.j2
@@ -205,7 +205,7 @@
 
     {% do doc.styles.addCssFile('/css/components/organisms/help.css') %}
     {% do doc.icons.useIcon('icons/external.svg') %}
-    <section class="ap--content">
+    <section class="ap--help">
       <div class="ap-o-help">
         <span class="ap-o-help-hl">{{ _('Need further explanation?') }}</span>
         <p class="ap-o-help-copy">{{ _('If the explanations on this page don\'t cover all of your questions feel free to reach out to other AMP users to discuss your exact use case.')}}</p>


### PR DESCRIPTION
Fixes #2308 Change the class name of help-section in example template and edit styling in order to display the help section correctly.