### PR TITLE
Fix typo and broken links in the contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ accept your pull requests.
 1. The repo owner will respond to your issue promptly.
 1. If your proposed change is accepted, and you haven't already done so, sign a
    Contributor License Agreement (see details above).
-1. Fork the desired repo, develop and test your changes. See instructions for ["How to Build site"](README.md#how-to-build-the-site) so that you can test your changes.
+1. Fork the desired repo, develop and test your changes. See instructions for ["how to build the site"](README.md#build) so that you can test your changes.
 1. Submit a pull request.
 
-### Adding an embedded sample to a document
+## Read more
 
-If you want to improve the documentation by adding an embedded sample, see [How to: Include embedded samples in AMP docs](contributing/adding-embedded-samples-in-docs.md).
+Please also have a look at the contribution section in our project ["readme"](README.md#contributing).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The official homepage of the AMP Project.
 
 ## Contributing
 
-We welcome contributons to amp.dev.
+We welcome contributions to amp.dev.
 
 * **Bug reports and feature requests:** something missing or not working on https://amp.dev? Please file an issue [here](https://github.com/ampproject/docs/issues/new).
 * **Documentation & Guides:** see [this guide](./contributing/documentation.md) for more information on how to contribute documentation to amp.dev.


### PR DESCRIPTION
I saw that the CONTRIBUTING.md was not updated for the new repository layout.
Since the readme now has a section about contributing (which had a small typo), I did not want to repeat the things there and simply added a link to this section.
Since this file is linked by github in the "create issue" dialog I did not want do delete it.