### PR TITLE
Support inline preview for examples with [sourcecode] tags

### DIFF
--- a/pages/extensions/amp_example_preview/util/example_extractor.py
+++ b/pages/extensions/amp_example_preview/util/example_extractor.py
@@ -1,8 +1,10 @@
 import re
 from example_document import ExampleDocument
 
-EXAMPLE_PATTERN = re.compile(r'\[\s*example(\s[^\]]*)?\](.*?\n```html *\n(.*?)\n```.*?)\[\s*/\s*example\s*\]',
-                             re.IGNORECASE | re.MULTILINE | re.DOTALL)
+EXAMPLE_PATTERN = re.compile(
+  r'\[\s*example(\s[^\]]*)?\](.*?(?:\n```html *\n(.*?)\n```' +
+  r'|\[sourcecode:html\](.*?)\[/sourcecode\]).*?)\[\s*/\s*example\s*\]',
+  re.IGNORECASE | re.MULTILINE | re.DOTALL)
 
 ATTRIBUTE_PATTERN = re.compile(r'(?:^|\s+)([\w-]+)\s*=\s*"([^"]+)"')
 
@@ -35,15 +37,18 @@ class SourceCodeExtractor(object):
     while match:
       count = count + 1
 
+      # group 3 is for a ``` block, group 4 is for a [sourcecode] block
+      code_match_index = 3 if match.group(3) else 4
+
       attributes = self._get_attributes(match.group(1))
 
-      inline_example = ExampleDocument(match.group(3), attributes, count)
+      inline_example = ExampleDocument(match.group(code_match_index), attributes, count)
 
       inline_example_match = InlineExampleMatch(inline_example)
       inline_example_match.startTagStart = match.start(0)
       inline_example_match.startTagEnd = match.start(2)
-      inline_example_match.sourceBlockStart = match.start(3)
-      inline_example_match.sourceBlockEnd = match.end(3)
+      inline_example_match.sourceBlockStart = match.start(code_match_index)
+      inline_example_match.sourceBlockEnd = match.end(code_match_index)
       inline_example_match.endTagStart = match.end(2)
       inline_example_match.endTagEnd = match.end(0)
 

--- a/pages/extensions/amp_example_preview/util/example_extractor_test.py
+++ b/pages/extensions/amp_example_preview/util/example_extractor_test.py
@@ -38,6 +38,8 @@ class SourceCodeExtractorTestCase(unittest.TestCase):
     self.assertEqual(0, len(inline_example.imports))
     self.assertEqual(None, inline_example.template)
 
+    self.assertEqual('<h1>headline</h1>', inline_example.body.strip())
+
   def test_two_examples_with_positions(self):
     extractor = SourceCodeExtractor()
     matches = extractor.find_examples_in_markdown(
@@ -155,3 +157,12 @@ class SourceCodeExtractorTestCase(unittest.TestCase):
     self.assertEqual(1, len(inline_example.imports))
     self.assertEqual('amp-accordion', inline_example.imports[0].name)
     self.assertEqual(None, inline_example.template)
+
+  def test_example_with_sourcecode_tag(self):
+    extractor = SourceCodeExtractor()
+    matches = extractor.find_examples_in_markdown(
+      '\ntest [example][sourcecode:html]\n'
+      '<h1>headline</h1>[/sourcecode][/example]\n')
+
+    inline_example = matches[0].inlineExample
+    self.assertEqual('<h1>headline</h1>', inline_example.body.strip())

--- a/pages/extensions/amp_example_preview/util/preview.py
+++ b/pages/extensions/amp_example_preview/util/preview.py
@@ -2,7 +2,11 @@ import re
 import json
 from xml.sax.saxutils import escape, unescape
 
-PREVIEW_START_BEGINNING = '<!-- preview\n'
+# We enforce a new paragraph for the code block, since otherwise we cannot ensure that
+# start tag and end tag are on the same level
+# For example for a source block inside the last list item the preview end tag would be after the closing list tag
+# TODO: Support examples inside lists (see comment above)
+PREVIEW_START_BEGINNING = '\n<!-- preview\n'
 PREVIEW_END_TAG = r'<!-- /preview -->'
 PREVIEW_PATTERN = re.compile(PREVIEW_START_BEGINNING + r'(.*?)\n-->\n(.*?)' + PREVIEW_END_TAG, re.DOTALL)
 


### PR DESCRIPTION
Needed to support the imported amphtml documents, where the code blocks are converted to [sourcecode] tags