### PR TITLE
Fix mustache escaping in markdown and fix unit test lookup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -79,6 +79,7 @@ module.exports = {
   moduleNameMapper: {
     // TODO: improve: jest will not work with 'module-alias', so we have define the alias here again!
     // see https://github.com/ilearnio/module-alias/issues/46
+    '^@lib/utils$': '<rootDir>/platform/lib/utils/index.js',
     '^@lib/(.*?)(\.js)?$': '<rootDir>/platform/lib/$1.js',
   },
 
@@ -152,9 +153,9 @@ module.exports = {
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   testPathIgnorePatterns: [
     '/node_modules/',
-    'dist',
-    'build',
-    'gulpfile.js',
+    '<rootDir>/dist',
+    '<rootDir>/build',
+    '<rootDir>/gulpfile.js',
   ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files

--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -25,6 +25,29 @@ const TOC_MARKER = '[TOC]';
 // therefore have one shared one
 const LOG = new Signale({'scope': 'Markdown Documents'});
 
+// This expression matches a {% raw %}...{% endraw %} block
+const JINJA2_RAW_BLOCK = /\{%\s*raw\s*%\}(?:(?!\{%\s*endraw\s*%\})[\s\S])*\{%\s*endraw\s*%\}/;
+
+// we search for ALL code blocks, and at the same time for raw blocks
+// to ensure we do not match something that belongs to different code blocks
+// or we add raw tags to existing raw blocks
+const MARKDOWN_BLOCK_PATTERN = new RegExp(
+    JINJA2_RAW_BLOCK.source
+    + '|'
+    + /\[\s*sourcecode[^\]]*\].*?\[\s*\/\s*sourcecode\s*\]/.source
+    + '|'
+    + /`[^`]*`/.source, 'g');
+
+// Inside code blocks we search for mustache expressions
+// The constant 'server_for_email' and expressions with a dot or a bracket are not considered mustache
+// TODO: Avoid the need to distinguish between mustache and jinja2
+const MUSTACHE_PATTERN = new RegExp(
+    '('
+    + JINJA2_RAW_BLOCK.source
+    + '|'
+    + /\{\{(?!\s*server_for_email\s*\}\})(?:[\s\S]*?\}\})?/.source
+    + ')', 'g');
+
 class MarkdownDocument {
   constructor(path, contents) {
     this._contents = contents.trim();
@@ -136,12 +159,26 @@ class MarkdownDocument {
   }
 
   /**
-   * Escapes mustache style tags to not interfer with Jinja2
+   * Escapes mustache style tags in code blocks to not interfer with Jinja2
    * @param  {String} contents
    * @return {String}          The rewritten input
    */
   static escapeMustacheTags(contents) {
-    return contents.replace(/`([^{`]*)(\{\{[^`]*\}\})([^`]*)`/g, '{% raw %}`$1$2$3`{% endraw %}');
+    return contents.replace(MARKDOWN_BLOCK_PATTERN, (block) => {
+      // check for mustache tags only if we have no raw block
+      if (!block.startsWith('{')) {
+        block = block.replace(
+            MUSTACHE_PATTERN,
+            (part) => {
+              // again, only if it is a mustache block wrap it with raw
+              if (part.startsWith('{{')) {
+                part = '{% raw %}' + part + '{% endraw %}';
+              }
+              return part;
+            });
+      }
+      return block;
+    });
   }
 
   /**
@@ -167,21 +204,17 @@ class MarkdownDocument {
   }
 
   /**
-   * Rewrites code fences to python-markdown syntax while also checking
-   * if {{ }} need to be fenced to not interfer with jinja2
+   * Rewrites code fences to python-markdown syntax.
    * @param  {String} contents
    * @return {String}          The rewritten content
    */
   static rewriteCodeBlocks(contents) {
     // Rewrite code blocks in fence syntax
     contents =
-      contents.replace(/(```)(([A-z-]*)\n)(((?!```)[\s\S])+)(```\n)/gm, (match, p1, p2, p3, p4) => {
-      // Fence curly braces to not mess with Grow/jinja2
-        if (p4.indexOf('{{') > -1) {
-          p4 = '{% raw %}' + p4 + '{% endraw %}';
-        }
-        return '[sourcecode' + (p3 ? ':' + p3 : ':none') + ']\n' + p4 + '[/sourcecode]\n';
-      });
+      contents.replace(/(```)(([A-z-]*)\n)(((?!```)[\s\S])+)(```[\t ]*\n)/gm,
+          (match, p1, p2, p3, p4) => {
+            return '[sourcecode' + (p3 ? ':' + p3 : ':none') + ']\n' + p4 + '[/sourcecode]\n';
+          });
 
     return contents;
   }

--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -34,7 +34,7 @@ const JINJA2_RAW_BLOCK = /\{%\s*raw\s*%\}(?:(?!\{%\s*endraw\s*%\})[\s\S])*\{%\s*
 const MARKDOWN_BLOCK_PATTERN = new RegExp(
     JINJA2_RAW_BLOCK.source
     + '|'
-    + /\[\s*sourcecode[^\]]*\].*?\[\s*\/\s*sourcecode\s*\]/.source
+    + /\[\s*sourcecode[^\]]*\][\s\S]*?\[\s*\/\s*sourcecode\s*\]/.source
     + '|'
     + /`[^`]*`/.source, 'g');
 

--- a/platform/lib/pipeline/markdownDocument.test.js
+++ b/platform/lib/pipeline/markdownDocument.test.js
@@ -1,0 +1,34 @@
+const MarkdownDocument = require('./markdownDocument.js');
+
+test('Test escape mustache tags', async (done) => {
+  const result = MarkdownDocument.escapeMustacheTags(
+      'The [`link`]({{notincode}}) test `code`.\n' +
+      '```html\n' +
+      '<template type="amp-mustache">\n' +
+      '  <amp-img alt="{{foo}} {%raw%}{{bar}}{%endraw%} {{baz}}"></amp-img>\n' +
+      '</template>' +
+      '```\n' +
+      'Known jinja2 expression `{{server_for_email}}`.\n' +
+      '[sourcecode:css att="value"]{{foo}}[/sourcecode]\n' +
+      'Test no raw `{{`\n' +
+      'Test raw outside {% raw %}`{{`{% endraw %}\n'+
+      'Test raw inside `{% raw %}{{{% endraw %}`');
+
+  expect(result).toBe(
+      'The [`link`]({{notincode}}) test `code`.\n' +
+      '```html\n' +
+      '<template type="amp-mustache">\n' +
+      '  <amp-img alt="{% raw %}{{foo}}{% endraw %} ' +
+      '{%raw%}{{bar}}{%endraw%} {% raw %}{{baz}}{% endraw %}"></amp-img>\n' +
+      '</template>' +
+      '```\n' +
+      'Known jinja2 expression `{{server_for_email}}`.\n' +
+      '[sourcecode:css att="value"]{% raw %}{{foo}}{% endraw %}[/sourcecode]\n' +
+      'Test no raw `{% raw %}{{{% endraw %}`\n' +
+      'Test raw outside {% raw %}`{{`{% endraw %}\n' +
+      'Test raw inside `{% raw %}{{{% endraw %}`'
+  );
+
+  done();
+});
+

--- a/platform/lib/pipeline/markdownDocument.test.js
+++ b/platform/lib/pipeline/markdownDocument.test.js
@@ -9,7 +9,9 @@ test('Test escape mustache tags', async (done) => {
       '</template>' +
       '```\n' +
       'Known jinja2 expression `{{server_for_email}}`.\n' +
-      '[sourcecode:css att="value"]{{foo}}[/sourcecode]\n' +
+      '[sourcecode:css att="value"]\n' +
+      '  {{foo}}\n' +
+      '[/sourcecode]\n' +
       'Test no raw `{{`\n' +
       'Test raw outside {% raw %}`{{`{% endraw %}\n'+
       'Test raw inside `{% raw %}{{{% endraw %}`');
@@ -23,7 +25,9 @@ test('Test escape mustache tags', async (done) => {
       '</template>' +
       '```\n' +
       'Known jinja2 expression `{{server_for_email}}`.\n' +
-      '[sourcecode:css att="value"]{% raw %}{{foo}}{% endraw %}[/sourcecode]\n' +
+      '[sourcecode:css att="value"]\n' +
+      '  {% raw %}{{foo}}{% endraw %}\n' +
+      '[/sourcecode]\n' +
       'Test no raw `{% raw %}{{{% endraw %}`\n' +
       'Test raw outside {% raw %}`{{`{% endraw %}\n' +
       'Test raw inside `{% raw %}{{{% endraw %}`'


### PR DESCRIPTION
The old logic to escape mustache expressions in markdown code blocks did not work well.
It could happen that the end of one code block and the start of an other where considered a code block, which caused problems by placing the {% raw %} tags wrong.
For example on the following page the link 'common attributes' is wrong:
https://amp.dev/documentation/examples/components/amp-img/#offline-fallback

This PR will fix this problem by searching for blocks and only in a second step escape the markup.
Also existing {% raw %} blocks are taken into account.
Additionally source blocks with [sourcecode] tags are supported.
Therefore the escaping logic in the `rewriteCodeBlocks` function could be removed.

Together with this the jest library and test lookup was fixed.