### PR TITLE
Improve support for jinja2 code in markdown source blocks

### DIFF
--- a/pages/extensions/jinja2_optimized_codehilite/custom_html_lexer.py
+++ b/pages/extensions/jinja2_optimized_codehilite/custom_html_lexer.py
@@ -5,14 +5,13 @@
 
 import re
 
-from pygments.lexer import RegexLexer, ExtendedRegexLexer, include, bygroups, \
-    default, using
+from pygments.lexer import RegexLexer, bygroups, using
 from pygments.lexers import html
 from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
     Punctuation
 from pygments.util import looks_like_xml, html_doctype_matches
 
-from pygments.lexers.javascript import JavascriptLexer
+from custom_js_lexer import CustomJavascriptLexer
 from pygments.lexers.css import CssLexer
 
 
@@ -72,7 +71,7 @@ class CustomHtmlLexer(RegexLexer):
       (r'(<)(\s*)(/)(\s*)(script)(\s*)(>)',
        bygroups(Punctuation, Text, Punctuation, Text, Name.Tag, Text,
                 Punctuation), '#pop'),
-      (r'.+?(?=<\s*/\s*script\s*>)', using(JavascriptLexer)),
+      (r'.+?(?=<\s*/\s*script\s*>)', using(CustomJavascriptLexer)),
     ],
     'style-content': [
       (r'(<)(\s*)(/)(\s*)(style)(\s*)(>)',

--- a/pages/extensions/jinja2_optimized_codehilite/custom_js_lexer.py
+++ b/pages/extensions/jinja2_optimized_codehilite/custom_js_lexer.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""
+    pygments.lexers.javascript
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexers for JavaScript and related languages.
+
+    :copyright: Copyright 2006-2019 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import re
+
+from pygments.lexer import RegexLexer, include, default
+from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
+    Number, Punctuation, Other
+from pygments.lexers import javascript
+import pygments.unistring as uni
+
+JS_IDENT_START = ('(?:[$_' + uni.combine('Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Nl') +
+                  ']|\\\\u[a-fA-F0-9]{4})')
+JS_IDENT_PART = ('(?:[$' + uni.combine('Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Nl',
+                                       'Mn', 'Mc', 'Nd', 'Pc') +
+                 u'\u200c\u200d]|\\\\u[a-fA-F0-9]{4})')
+JS_IDENT = JS_IDENT_START + '(?:' + JS_IDENT_PART + ')*'
+
+
+class CustomJavascriptLexer(RegexLexer):
+    """
+    For JavaScript source code.
+    """
+
+    name = 'JavaScript'
+    aliases = ['js', 'javascript']
+    filenames = ['*.js', '*.jsm']
+    mimetypes = ['application/javascript', 'application/x-javascript',
+                 'text/x-javascript', 'text/javascript']
+
+    flags = re.DOTALL | re.UNICODE | re.MULTILINE
+
+    tokens = {
+        'commentsandwhitespace': [
+            (r'\s+', Text),
+            (r'<!--', Comment),
+            (r'//.*?\n', Comment.Single),
+            (r'/\*.*?\*/', Comment.Multiline)
+        ],
+        'slashstartsregex': [
+            include('commentsandwhitespace'),
+            (r'/(\\.|[^[/\\\n]|\[(\\.|[^\]\\\n])*])+/'
+             r'([gimuy]+\b|\B)', String.Regex, '#pop'),
+            (r'(?=/)', Text, ('#pop', 'badregex')),
+            default('#pop')
+        ],
+        'badregex': [
+            (r'\n', Text, '#pop')
+        ],
+        'root': [
+            (r'\{\%.*?\%\}', Text),
+            (r'\{\{.*?\}\}', Text),
+            (r'\A#! ?/.*?\n', Comment.Hashbang),  # recognized by node.js
+            (r'^(?=\s|/|<!--)', Text, 'slashstartsregex'),
+            include('commentsandwhitespace'),
+            (r'(\.\d+|[0-9]+\.[0-9]*)([eE][-+]?[0-9]+)?', Number.Float),
+            (r'0[bB][01]+', Number.Bin),
+            (r'0[oO][0-7]+', Number.Oct),
+            (r'0[xX][0-9a-fA-F]+', Number.Hex),
+            (r'[0-9]+', Number.Integer),
+            (r'\.\.\.|=>', Punctuation),
+            (r'\+\+|--|~|&&|\?|:|\|\||\\(?=\n)|'
+             r'(<<|>>>?|==?|!=?|[-<>+*%&|^/])=?', Operator, 'slashstartsregex'),
+            (r'[{(\[;,]', Punctuation, 'slashstartsregex'),
+            (r'[})\].]', Punctuation),
+            (r'(for|in|while|do|break|return|continue|switch|case|default|if|else|'
+             r'throw|try|catch|finally|new|delete|typeof|instanceof|void|yield|'
+             r'this|of)\b', Keyword, 'slashstartsregex'),
+            (r'(var|let|with|function)\b', Keyword.Declaration, 'slashstartsregex'),
+            (r'(abstract|boolean|byte|char|class|const|debugger|double|enum|export|'
+             r'extends|final|float|goto|implements|import|int|interface|long|native|'
+             r'package|private|protected|public|short|static|super|synchronized|throws|'
+             r'transient|volatile)\b', Keyword.Reserved),
+            (r'(true|false|null|NaN|Infinity|undefined)\b', Keyword.Constant),
+            (r'(Array|Boolean|Date|Error|Function|Math|netscape|'
+             r'Number|Object|Packages|RegExp|String|Promise|Proxy|sun|decodeURI|'
+             r'decodeURIComponent|encodeURI|encodeURIComponent|'
+             r'Error|eval|isFinite|isNaN|isSafeInteger|parseFloat|parseInt|'
+             r'document|this|window)\b', Name.Builtin),
+            (JS_IDENT, Name.Other),
+            (r'"(\\\\|\\"|[^"])*"', String.Double),
+            (r"'(\\\\|\\'|[^'])*'", String.Single),
+            (r'`', String.Backtick, 'interp'),
+        ],
+        'interp': [
+            (r'`', String.Backtick, '#pop'),
+            (r'\\\\', String.Backtick),
+            (r'\\`', String.Backtick),
+            (r'\$\{', String.Interpol, 'interp-inside'),
+            (r'\$', String.Backtick),
+            (r'[^`\\$]+', String.Backtick),
+        ],
+        'interp-inside': [
+            # TODO: should this include single-line comments and allow nesting strings?
+            (r'\}', String.Interpol, '#pop'),
+            include('root'),
+        ],
+        # (\\\\|\\`|[^`])*`', String.Backtick),
+    }
+
+    @staticmethod
+    def connect_hook():
+        javascript.JavascriptLexer = CustomJavascriptLexer

--- a/pages/extensions/jinja2_optimized_codehilite/jinja2_optimized_codehilite.py
+++ b/pages/extensions/jinja2_optimized_codehilite/jinja2_optimized_codehilite.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from grow import extensions
 from custom_html_lexer import CustomHtmlLexer
+from custom_js_lexer import CustomJavascriptLexer
 from custom_html_formatter import CustomHtmlFormatter
 
 
@@ -16,6 +17,8 @@ class Jinja2OptimizedCodehiliteExtension(extensions.BaseExtension):
   pass
 
 CustomHtmlLexer.connect_hook()
+
+CustomJavascriptLexer.connect_hook()
 
 CustomHtmlFormatter.connect_hook()
 

--- a/pages/extensions/jinja2_optimized_codehilite/readme.md
+++ b/pages/extensions/jinja2_optimized_codehilite/readme.md
@@ -1,0 +1,24 @@
+# amp.dev optimized code highlighting extension
+
+
+## Purpose
+
+This grow extension improves the grow code highlighting to help with included jinja2 code blocks.
+
+We need jinja2 expressions in code examples to create links and to wrap example parts not relevant for every amp format in conditions.
+
+This extension does the following:
+ * Jinja2 expressions in html and javascript blocks are treated as text blocks by the lexer.
+   This prevents generation of div tags around parts of the expression
+ * Jinja2 expressions are unescaped in the code highlight block 
+   (Needed if the expression contains quotes or angle brackets)
+
+
+## Activation
+
+This extension has to be activated in the podspec.yaml
+
+```yaml
+ext:
+  - extensions.jinja2_optimized_codehilite.Jinja2OptimizedCodehiliteExtension 
+```


### PR DESCRIPTION
This improvement is needed to correctly handle jinja2 expressions in markdown code blocks with script tags like
```html
<script type="text/plain" template="amp-mustache">
  Hello {% raw %}{{world}}{% endraw %}!
</script>
```
This code block is found here:
https://amp.dev/documentation/components/amp-mustache