### PR TITLE
Add pulsing animation to upcoming cities on roadshow map

### DIFF
--- a/frontend/scss/components/organisms/cities.scss
+++ b/frontend/scss/components/organisms/cities.scss
@@ -13,6 +13,7 @@
 
 @import 'components/atoms/_headline.scss';
 @import 'components/atoms/_text.scss';
+@import 'components/atoms/_color.scss';
 
 .#{organism('cities')} {
   margin-top: 30px;
@@ -63,6 +64,10 @@
           #{$self}-pin { z-index: 3; }
           #{$self}-tooltip { display: block; }
         }
+
+        &:nth-child(odd) #{$self}-pin-next::before {
+          animation-delay: -.75s;
+        }
       }
     }
 
@@ -73,7 +78,7 @@
       height: 100%;
       border-radius: 100%;
       box-shadow: 1px 1px 2px rgba(black,.25);
-      transform: scale(1.0001);
+      transform: scale(1.2);
       z-index: 2;
 
       &-next {
@@ -90,11 +95,16 @@
           left: 50%;
           bottom: 0;
           border-radius: 100%;
-          background-color: rgba(#fff, 0.5);
+          background-color: rgba(#fff, 0.9);
           border: 1px solid #fff;
           box-shadow: 1px 1px 2px rgba(black,.25);
           transform: translate(-50%, 10px);
-          // animation: pulsePin 2s infinite cubic-bezier(.55,0,.1,1);
+          transform-origin: center center;
+          animation: pulsePin 2s infinite ease-out;
+        }
+
+        & + #{$self}-tooltip {
+          @include color-blue-ribbon;
         }
       }
 
@@ -103,8 +113,8 @@
       }
 
       @keyframes pulsePin {
-        from { transform: scale(1); opacity: 1; }
-        to { transform: scale(1); opacity: 0; }
+        from { transform: translate(-50%, 10px) scale(0.1); opacity: 1; }
+        to { transform: translate(-50%, 10px) scale(1.5); opacity: 0; }
       }
     }
 
@@ -126,10 +136,12 @@
       top: 50%;
       transform: translate(8px, -50%);
       padding: 3px 7px;
-      font-size: 12px;
+      font-size: 14px;
       font-weight: 700;
+      font-family: 'Poppins', sans-serif;
       white-space: nowrap;
       text-transform: uppercase;
+      color: fade_out(color('charade'), 0.25);
       background: #fff;
       box-shadow: 1px 2px 5px 0 rgba(black, .25);
       border-radius: 3px;
@@ -140,7 +152,7 @@
         display: block;
         position: absolute;
         left: -6px;
-        top: 6px;
+        top: 7px;
         width: 0;
         height: 0;
         border-top: 6px solid transparent;

--- a/pages/content/amp-dev/events/amp-roadshow.html
+++ b/pages/content/amp-dev/events/amp-roadshow.html
@@ -107,7 +107,7 @@ section_links:
       {% endif %}
 
       <aside class="ap-o-cities-map-grid">
-        {% for place in doc.roadshow.nextstop %}
+        {% for place in doc.roadshow.nextstop if doc.roadshow.nextstop %}
           {% if place.coords %}
           {% set col = place.coords.split('x')[0]|int + 1 %}
           {% set row = place.coords.split('x')[1]|int + 1 %}
@@ -121,7 +121,7 @@ section_links:
           {% endif %}
         {% endfor %}
 
-        {% for place in doc.roadshow.past %}
+        {% for place in doc.roadshow.past if doc.roadshow.past %}
           {% if place.coords %}
           {% set col = place.coords.split('x')[0]|int + 1 %}
           {% set row = place.coords.split('x')[1]|int + 1 %}

--- a/pages/shared/data/roadshow.yaml
+++ b/pages/shared/data/roadshow.yaml
@@ -1,22 +1,20 @@
-nextstop:
-  - title: berlin, de
-    coords: 57x12
-    location: Google Berlin
-    time: 09:00–18:00
-    day: 7
-    month: jun
-    year: 2019
-    link: https://events.withgoogle.com/amp-roadshow-berlin/
-  - title: atlanta, usa
-    coords: 22x17
-    location: refactr.tech
-    time: 09:00–18:00
-    day: 5
-    month: jun
-    year: 2019
-    link: https://events.withgoogle.com/amp-roadshow-atlanta/
+# nextstop:
+  # - title: California, US
+  #   coords: 9x9
+  #   location: Menlo Park
+  #   time: 09:00–18:00
+  #   day: 4
+  #   month: sep
+  #   year: 1998
+  #   link: https://google.com/
 
 past:
+  - title: BERLIN
+    coords: 57x12
+    date: 2019-06-07
+  - title: ATLANTA
+    coords: 22x17
+    date: 2019-06-05
   - title: NAIROBI
     coords: 65x33
     date: 2019-03-22


### PR DESCRIPTION
With this PR we can finally complete the roadshow map changes.
It adds an animation for the upcoming cities and also moves Berlin and Atlanta to the past cities list.

@morsssss I've added placeholder content to the nextstop list and commented it out, so it is easier to fill out the needed values.