### PR TITLE
Add trailing slash for example redirect

### DIFF
--- a/platform/config/go-links.yaml
+++ b/platform/config/go-links.yaml
@@ -27,6 +27,6 @@
 ^/c/amp-([a-z-]+)$:
   url: /documentation/components/amp-$1
   useRegex: true
-^/s/amp-([a-z-]+)$:
-  url: /documentation/examples/components/amp-$1
+^/e/amp-([a-z-]+)$:
+  url: /documentation/examples/components/amp-$1/
   useRegex: true


### PR DESCRIPTION
Temporary fix until #2180 is resolved.

Also changed from `go.amp.dev/s/...` to `go.amp.dev/e/...` since "**e**xample" makes more sense than "**s**ample" based on how we call them on the website. Open to discussion about that though.