### PR TITLE
♻️ Migrate housing backend to amp.dev

### DIFF
--- a/examples/source/e-commerce/Housing/api.js
+++ b/examples/source/e-commerce/Housing/api.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const express = require('express');
+
+// eslint-disable-next-line new-cap
+const examples = express.Router();
+
+examples.get('/calculate-mortgage', (request, response) => {
+  response.status(400).end();
+});
+examples.get('/calculate-mortgage-xhr', (request, response) => {
+  const mortgageForm = parseMortgageForm(request);
+  const monthlyPayment = calculateMonthlyPayment(mortgageForm);
+
+  response.json({
+    monthly_repayment: `£${monthlyPayment}`,
+  });
+});
+
+function calculateMonthlyPayment(mortgageForm = {}) {
+  const monthlyInterestRateDecimal = (mortgageForm.interest / 12) / 100;
+  const numberOfMonthlyPayments = mortgageForm.period * 12;
+  const amountBorrowed = mortgageForm.price - mortgageForm.deposit;
+  // eslint-disable-next-line max-len
+  return ((monthlyInterestRateDecimal * amountBorrowed * Math.pow((1+monthlyInterestRateDecimal), numberOfMonthlyPayments)) / (Math.pow((1+monthlyInterestRateDecimal), numberOfMonthlyPayments) - 1)).toFixed(2);
+}
+
+function parseMortgageForm(request) {
+  const price = Number(request.query.price);
+  const deposit = Number(request.query.deposit);
+  const interest = Number(request.query.annual_interest);
+  const period = Number(request.query.repayment_period);
+
+  return {
+    price,
+    deposit,
+    interest,
+    period,
+  };
+}
+
+module.exports = examples;

--- a/examples/source/e-commerce/Housing/index.html
+++ b/examples/source/e-commerce/Housing/index.html
@@ -244,7 +244,7 @@ This sample showcases how to build a housing page in AMP HTML. Explore how to us
 
     <div>
       <h2>Mortgage Calculator</h2>
-      <form method="GET" action="<% hosts.backend %>/samples_templates/housing/calculate-mortgage" action-xhr="<% hosts.backend %>/samples_templates/housing/calculate-mortgage-xhr" target="_top">
+      <form method="GET" action="calculate-mortgage" action-xhr="calculate-mortgage-xhr" target="_top">
         <div>
           <label>
               <input type="number" name="price" maxlength="10" value="2000000" required>


### PR DESCRIPTION
Migrated the backend/housing.go from ampbyexample.com to amp.dev.
It updates the example [here](https://amp.dev/documentation/examples/e-commerce/housing/?format=websites#mortgage-calculator).

Part of the migration/improvements in #2054.