### PR TITLE
Use blacklist to filter locales so that sitemap is not excluded

### DIFF
--- a/platform/lib/config.test.js
+++ b/platform/lib/config.test.js
@@ -28,4 +28,34 @@ describe('config', () => {
   it('Should not be in prod mode', () => {
     expect(config.isProdMode()).toBe(false);
   });
+
+  // We use the regular project podspec for testing as long as we only use attributes that are not likely to change
+  it('Should build a grow podspec with languages, but without filter', () => {
+    const podSpec = config.buildGrowPodSpec();
+
+    expect(podSpec.localization.default_locale).toBe('en');
+
+    const allLocales = podSpec.localization.locales;
+    expect(allLocales.includes('en')).toBe(true);
+    expect(allLocales.includes('es')).toBe(true);
+    expect(allLocales.includes('fr')).toBe(true);
+
+    expect(podSpec.deployments.default.filters).toBeUndefined();
+  });
+
+  it('Should build a grow podspec with languages and filters', () => {
+    const podSpec = config.buildGrowPodSpec({locales: 'en,es'});
+
+    const allLocales = podSpec.localization.locales;
+    expect(allLocales.includes('en')).toBe(true);
+    expect(allLocales.includes('es')).toBe(true);
+    expect(allLocales.includes('fr')).toBe(true);
+
+    expect(podSpec.deployments.default.filters.type).toBe('blacklist');
+
+    const filteredlocales = podSpec.deployments.default.filters.locales;
+    expect(filteredlocales.includes('en')).toBe(false);
+    expect(filteredlocales.includes('es')).toBe(false);
+    expect(filteredlocales.includes('fr')).toBe(true);
+  });
 });


### PR DESCRIPTION
We use a locale filter in the travis build, to be able to split the build on different machines.
This PR changes the whitelist filter to a blacklist filter, because a whitelist filter will only build those locales and no sitemap.
Fixes https://github.com/ampproject/docs/issues/2327