### PR TITLE
Fix component version path for unit tests

### DIFF
--- a/pages/extensions/amp_example_preview/util/amp_component_versions.py
+++ b/pages/extensions/amp_example_preview/util/amp_component_versions.py
@@ -1,6 +1,8 @@
 import json
+import os
 
-COMPONENT_VERSIONS_FILE = 'extensions/amp-component-versions.json'
+COMPONENT_VERSIONS_FILE = os.path.normpath(os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), '../../amp-component-versions.json'))
 COMPONENT_VERSIONS = {}
 
 with open(COMPONENT_VERSIONS_FILE) as f:


### PR DESCRIPTION
The fix for https://github.com/ampproject/docs/issues/2410 did not work for the python unit tests.
With this PR an absolute path is used to find the file.