### PR TITLE
Allow markdown in all table tags of imported documents

### DIFF
--- a/platform/config/podspec.yaml
+++ b/platform/config/podspec.yaml
@@ -18,6 +18,7 @@ markdown:
   - kind: markdown.extensions.codehilite
     classes: True
     class_name: ap-m-code-snippet
+  - kind: markdown.extensions.extra
 
 ext:
 - extensions.inline_text_assets.InlineTextAssetsExtension:

--- a/platform/lib/pipeline/markdownDocument.js
+++ b/platform/lib/pipeline/markdownDocument.js
@@ -28,15 +28,20 @@ const LOG = new Signale({'scope': 'Markdown Documents'});
 // This expression matches a {% raw %}...{% endraw %} block
 const JINJA2_RAW_BLOCK = /\{%\s*raw\s*%\}(?:(?!\{%\s*endraw\s*%\})[\s\S])*\{%\s*endraw\s*%\}/;
 
+// This expression matches a [sourcecode] block
+const SOURCECODE_BLOCK = /\[\s*sourcecode[^\]]*\][\s\S]*?\[\s*\/\s*sourcecode\s*\]/;
+
+const INLINE_CODE_BLOCK = /`[^`]*`/;
+
 // we search for ALL code blocks, and at the same time for raw blocks
 // to ensure we do not match something that belongs to different code blocks
 // or we add raw tags to existing raw blocks
 const MARKDOWN_BLOCK_PATTERN = new RegExp(
     JINJA2_RAW_BLOCK.source
     + '|'
-    + /\[\s*sourcecode[^\]]*\][\s\S]*?\[\s*\/\s*sourcecode\s*\]/.source
+    + SOURCECODE_BLOCK.source
     + '|'
-    + /`[^`]*`/.source, 'g');
+    + INLINE_CODE_BLOCK.source, 'g');
 
 // Inside code blocks we search for mustache expressions
 // The constant 'server_for_email' and expressions with a dot or a bracket are not considered mustache
@@ -47,6 +52,15 @@ const MUSTACHE_PATTERN = new RegExp(
     + '|'
     + /\{\{(?!\s*server_for_email\s*\}\})(?:[\s\S]*?\}\})?/.source
     + ')', 'g');
+
+// Match code blocks to skip them and table tags to add the markdown attribute
+const TABLE_MARKDOWN_ATTRIB_PATTERN = new RegExp(
+    SOURCECODE_BLOCK.source
+    + '|'
+    + INLINE_CODE_BLOCK.source
+    + '|'
+    + /(<\s*table)((?:[^>](?!markdown))*>)/.source
+    , 'g');
 
 class MarkdownDocument {
   constructor(path, contents) {
@@ -157,13 +171,21 @@ class MarkdownDocument {
   }
 
 
-  _convertSyntax() {
-    this._contents = MarkdownDocument.rewriteCalloutToTip(this._contents);
-    this._contents = MarkdownDocument.rewriteCodeBlocks(this._contents);
-    this._contents = MarkdownDocument.escapeMustacheTags(this._contents);
-
-    // Replace dividers (---) as they will break front matter
-    this._contents = this._contents.replace(/\n---\n/gm, '\n***\n');
+  /**
+   * Will add the markdown="1" attribute for table tags in order to
+   * let the markdown.extensions.extra of grow evaluate markdown inside the table.
+   * Needed because often code blocks are inside the table.
+   * @param  {String} contents
+   * @return {String} The rewritten input
+   */
+  static enableMarkdownInHtmlTables(contents) {
+    return contents.replace(TABLE_MARKDOWN_ATTRIB_PATTERN, (match, p1, p2) => {
+      // only if we are not in a code block set the markdown attribute
+      if (p1) {
+        return p1 + ' markdown="1"' + p2;
+      }
+      return match;
+    });
   }
 
   /**
@@ -187,6 +209,16 @@ class MarkdownDocument {
       }
       return block;
     });
+  }
+
+  _convertSyntax() {
+    this._contents = MarkdownDocument.rewriteCalloutToTip(this._contents);
+    this._contents = MarkdownDocument.rewriteCodeBlocks(this._contents);
+    this._contents = MarkdownDocument.escapeMustacheTags(this._contents);
+    this._contents = MarkdownDocument.enableMarkdownInHtmlTables(this._contents);
+
+    // Replace dividers (---) as they will break front matter
+    this._contents = this._contents.replace(/\n---\n/gm, '\n***\n');
   }
 
   /**
@@ -239,12 +271,10 @@ class MarkdownDocument {
 
   /**
    * Removes the first heading to avoid double titles
-   * @return {String}          The rewritten input
    */
   stripInlineTitle() {
     const TITLE_PATTERN = /^#{1}\s.+/m;
     this._contents = this._contents.replace(TITLE_PATTERN, '');
-    return true;
   }
 
   /**

--- a/platform/lib/pipeline/markdownDocument.test.js
+++ b/platform/lib/pipeline/markdownDocument.test.js
@@ -1,6 +1,6 @@
 const MarkdownDocument = require('./markdownDocument.js');
 
-test('Test escape mustache tags', async (done) => {
+test('Test escape mustache tags', () => {
   const result = MarkdownDocument.escapeMustacheTags(
       'The [`link`]({{notincode}}) test `code`.\n' +
       '```html\n' +
@@ -32,7 +32,26 @@ test('Test escape mustache tags', async (done) => {
       'Test raw outside {% raw %}`{{`{% endraw %}\n' +
       'Test raw inside `{% raw %}{{{% endraw %}`'
   );
-
-  done();
 });
 
+test('Test add markdown attribute to tables', () => {
+  const content = MarkdownDocument.enableMarkdownInHtmlTables(`
+  <table><tr><td>table no attribs</td></tr></table>
+  <table width="100"><tr><td>table with attribs</td></tr></table>
+  <table markdown><tr><td>table with markdown 1</td></tr></table>
+  <table markdown="1"><tr><td>table with markdown 2</td></tr></table>
+  [sourcecode:html]
+  <table><tr><td>table in code</td></tr></table>
+  [/sourcecode]
+  Inline \`<table>\`
+  `);
+
+  expect(content.trim()).toBe(`<table markdown="1"><tr><td>table no attribs</td></tr></table>
+  <table markdown="1" width="100"><tr><td>table with attribs</td></tr></table>
+  <table markdown><tr><td>table with markdown 1</td></tr></table>
+  <table markdown="1"><tr><td>table with markdown 2</td></tr></table>
+  [sourcecode:html]
+  <table><tr><td>table in code</td></tr></table>
+  [/sourcecode]
+  Inline \`<table>\``);
+});


### PR DESCRIPTION
This addresses problems discussed in https://github.com/ampproject/docs/issues/1809 that sometimes markdown is not evaluated in table tags.