### PR TITLE
🚑 Make unbuffer respect gulp's exit code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,74 +30,74 @@ jobs:
     env: APP_ENV=staging
     name: Check code, import documents, build samples, playground & boilerplate
     before_script:
-    - unbuffer gulp buildSamples
-    - unbuffer gulp lintAll
+    - scripts/unbuffer.sh gulp buildSamples
+    - scripts/unbuffer.sh gulp lintAll
     script:
-    - if [ $TRAVIS_BRANCH == "future" ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then unbuffer gulp buildPrepare; fi
+    - if [ $TRAVIS_BRANCH == "future" ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then scripts/unbuffer.sh gulp buildPrepare; fi
   - stage: build
     env: APP_ENV=staging
     install: &1
     - npm ci
     - pip install grow==0.7.4 --user
     name: Build Pages (EN)
-    script: unbuffer gulp buildPages --locales en
+    script: scripts/unbuffer.sh gulp buildPages --locales en
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (FR)
-    script: unbuffer gulp buildPages --locales fr
+    script: scripts/unbuffer.sh gulp buildPages --locales fr
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (AR)
-    script: unbuffer gulp buildPages --locales ar
+    script: scripts/unbuffer.sh gulp buildPages --locales ar
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (ES)
-    script: unbuffer gulp buildPages --locales es
+    script: scripts/unbuffer.sh gulp buildPages --locales es
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (IT)
-    script: unbuffer gulp buildPages --locales it
+    script: scripts/unbuffer.sh gulp buildPages --locales it
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (ID)
-    script: unbuffer gulp buildPages --locales id
+    script: scripts/unbuffer.sh gulp buildPages --locales id
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (JA)
-    script: unbuffer gulp buildPages --locales ja
+    script: scripts/unbuffer.sh gulp buildPages --locales ja
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (KO)
-    script: unbuffer gulp buildPages --locales ko
+    script: scripts/unbuffer.sh gulp buildPages --locales ko
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (BR)
-    script: unbuffer gulp buildPages --locales pt_BR
+    script: scripts/unbuffer.sh gulp buildPages --locales pt_BR
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (RU)
-    script: unbuffer gulp buildPages --locales ru
+    script: scripts/unbuffer.sh gulp buildPages --locales ru
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (TR)
-    script: unbuffer gulp buildPages --locales tr
+    script: scripts/unbuffer.sh gulp buildPages --locales tr
   - stage: build
     env: APP_ENV=staging
     install: *1
     name: Build Pages (CN)
-    script: unbuffer gulp buildPages --locales zh_CN
+    script: scripts/unbuffer.sh gulp buildPages --locales zh_CN
   - stage: deploy
     env: APP_ENV=staging
     script:
-    - unbuffer gulp buildFinalize
+    - scripts/unbuffer.sh gulp buildFinalize
     - gcloud app deploy --project=amp-dev-staging --quiet

--- a/scripts/unbuffer.sh
+++ b/scripts/unbuffer.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# See: https://superuser.com/questions/742121/unbuffer-swallows-the-exit-status-of-killed-process/805309#805309
+
+# -*- tcl -*-
+# The next line is executed by /bin/sh, but not tcl \
+exec tclsh "$0" ${1+"$@"}
+
+package require Expect
+
+
+# -*- tcl -*-
+# Description: unbuffer stdout of a program
+# Author: Don Libes, NIST
+
+if {[string compare [lindex $argv 0] "-p"] == 0} {
+    # pipeline
+    set stty_init "-echo"
+    eval [list spawn -noecho] [lrange $argv 1 end]
+    close_on_eof -i $user_spawn_id 0
+    interact {
+	eof {
+	    # flush remaining output from child
+	    expect -timeout 1 -re .+
+	    return
+	}
+    }
+} else {
+    set stty_init "-opost"
+    set timeout -1
+    eval [list spawn -noecho] $argv
+    expect
+    set result [wait]
+    if { [llength $result] == 4 } {
+        exit [lindex $result 3]
+    } else {
+        exit 1
+    }
+}


### PR DESCRIPTION
Yesterday's staging build and tonight's production build should have never made it to the instances as building the pages finished with a non-zero exit code that is swallowed by `unbuffer`. Also see: https://superuser.com/questions/742121/unbuffer-swallows-the-exit-status-of-killed-process/805309#805309