### PR TITLE
🚑 Revert allowance of markdown in all table tags of imported documents

### DIFF
--- a/platform/config/podspec.yaml
+++ b/platform/config/podspec.yaml
@@ -18,7 +18,6 @@ markdown:
   - kind: markdown.extensions.codehilite
     classes: True
     class_name: ap-m-code-snippet
-  - kind: markdown.extensions.extra
 
 ext:
 - extensions.inline_text_assets.InlineTextAssetsExtension:

--- a/platform/lib/pipeline/markdownDocument.test.js
+++ b/platform/lib/pipeline/markdownDocument.test.js
@@ -1,6 +1,6 @@
 const MarkdownDocument = require('./markdownDocument.js');
 
-test('Test escape mustache tags', () => {
+test('Test escape mustache tags', async (done) => {
   const result = MarkdownDocument.escapeMustacheTags(
       'The [`link`]({{notincode}}) test `code`.\n' +
       '```html\n' +
@@ -32,26 +32,7 @@ test('Test escape mustache tags', () => {
       'Test raw outside {% raw %}`{{`{% endraw %}\n' +
       'Test raw inside `{% raw %}{{{% endraw %}`'
   );
+
+  done();
 });
 
-test('Test add markdown attribute to tables', () => {
-  const content = MarkdownDocument.enableMarkdownInHtmlTables(`
-  <table><tr><td>table no attribs</td></tr></table>
-  <table width="100"><tr><td>table with attribs</td></tr></table>
-  <table markdown><tr><td>table with markdown 1</td></tr></table>
-  <table markdown="1"><tr><td>table with markdown 2</td></tr></table>
-  [sourcecode:html]
-  <table><tr><td>table in code</td></tr></table>
-  [/sourcecode]
-  Inline \`<table>\`
-  `);
-
-  expect(content.trim()).toBe(`<table markdown="1"><tr><td>table no attribs</td></tr></table>
-  <table markdown="1" width="100"><tr><td>table with attribs</td></tr></table>
-  <table markdown><tr><td>table with markdown 1</td></tr></table>
-  <table markdown="1"><tr><td>table with markdown 2</td></tr></table>
-  [sourcecode:html]
-  <table><tr><td>table in code</td></tr></table>
-  [/sourcecode]
-  Inline \`<table>\``);
-});


### PR DESCRIPTION
Reverts ampproject/docs#2434 temporarily as it breaks the rendering of [tip] for a reason I can't figure out quickly.