### PR TITLE
Update AMPCS2019 page summary, FAQ and location

### DIFF
--- a/pages/content/amp-dev/events/amp-cs-2019.html
+++ b/pages/content/amp-dev/events/amp-cs-2019.html
@@ -53,7 +53,7 @@ section_links:
 
 <section class="ap--container">
   <p class="ap--content-default">
-    The AMP team and community brought their yearly Contributor Summit to New York City for 3 full days with a goal to encorage more contributors, growing community, spread knowledge of current best practicies and solidify governance changes with TSC/AC/WG face-to-face meetings.
+    The AMP Contributor Summit is our annual opportunity for the AMP open source community to meet face-to-face to discuss the latest in AMP and where AMP is going.  This technical summit consists of a mix of different formats, including talks, breakout sessions and many opportunities for informal conversations.
   </p>
 </section>
 
@@ -298,11 +298,9 @@ section_links:
         </div>
       </div>
       <div class="ap-m-conf-location-content">
-        <a class="ap-m-conf-location-content-link" href="http://forum.academyhills.com/roppongi/en/">New York City</a>
         <p class="ap-m-conf-location-content-text">
-          New York
+          New York City, New York, USA
         </p>
-        <p class="ap-m-conf-location-content-text">..and live-streamed around the world.</p>
       </div>
     </div>
   </div>
@@ -315,16 +313,15 @@ section_links:
       <div class="ap-m-faq-content">
         <p class="ap-m-faq-content-question">Does it cost anything?</p>
         <p class="ap-m-faq-content-answer">No - tickets are free of charge.</p>
-        <p class="ap-m-faq-content-question">What language will the talks be in?</p>
-        <p class="ap-m-faq-content-answer"> All talks are being simultaneously presented and streamed in English and Japanese.</p>
         <p class="ap-m-faq-content-question">Who is the event for?</p>
-        <p class="ap-m-faq-content-answer">Anyone contributing to AMP today, or wanting to contribute to the AMP project, whether it be through code, outreach or other forms of contributions.</p>
-        <p class="ap-m-faq-content-question">Does registering mean I am all set to attend?</p>
-        <p class="ap-m-faq-content-answer">Not yet. While your chances of getting a seat are pretty good, we will confirm attendees on a case-by-case basis to ensure we attract the right audience. Note that your seat is not confirmed until you receive a confirmation code.</p>
+        <p class="ap-m-faq-content-answer">Anyone contributing to AMP today, or who wants to contribute to AMP, whether it be through code, outreach or other forms of contributions.</p>
+        <p class="ap-m-faq-content-question">I'm excited about using AMP or I have questions about using AMP, is this the right conference for me?</p>
+        <p class="ap-m-faq-content-answer">This summit is a technical summit for people who are contributing to the AMP open source project in some way (whether through code, documentation or some other way) or who want to start contributing.  Our contributors often start as users of AMP because they see something that they want to make better, and if this describes you then you might consider applying to attend.  If you're looking for more information about how to use AMP but aren't yet considering contributing to AMP you may prefer to attend one of our Roadshows instead.</p>
+        <p class="ap-m-faq-content-question">Does applying mean I am all set to attend?</p>
+        <p class="ap-m-faq-content-answer">Unfortunately, we have a limited number of spaces available for the summit, so not everyone who applies will be able to attend.</p>
         <p class="ap-m-faq-content-question">When will I hear back if I have a spot?</p>
-        <p class="ap-m-faq-content-answer">We'll try to confirm you within less than a week!</p>
-        <p class="ap-m-faq-content-question">What determines if I have a spot?</p>
-        <p class="ap-m-faq-content-answer">If you contribute to AMP in some form, chances are very likely you'll get approved!</p>
+        <p class="ap-m-faq-content-answer">Our goal is to confirm within a couple of weeks from the application deadline.</p>
+</p>
       </div>
     </div>
 </section>


### PR DESCRIPTION
A few quick edits before we launch the application:
- Updating the blurb to match our summary of the summit from the blog post
- Updating the FAQ to remove AMP Conf references & make it clear who the target audience for this summit is
- Updating the location to remove AMP Conf references

/cc @vishaldodiya 