### PR TITLE
Adding Sydney and Melbourne to roadshow cities

### DIFF
--- a/pages/shared/data/roadshow.yaml
+++ b/pages/shared/data/roadshow.yaml
@@ -9,7 +9,7 @@ nextstop:
     link: https://events.withgoogle.com/amp-roadshow-sydney/
   - title: melbourne
     coords: 100x44
-    location: Maritime Museum
+    location: Rendezvous Hotel
     time: 09:30–17:00
     day: 30
     month: aug

--- a/pages/shared/data/roadshow.yaml
+++ b/pages/shared/data/roadshow.yaml
@@ -1,4 +1,20 @@
 nextstop:
+  - title: sydney
+    coords: 103x42
+    location: Maritime Museum
+    time: 09:30–17:00
+    day: 27
+    month: aug
+    year: 2019
+    link: https://events.withgoogle.com/amp-roadshow-sydney/
+  - title: melbourne
+    coords: 100x44
+    location: Maritime Museum
+    time: 09:30–17:00
+    day: 30
+    month: aug
+    year: 2019
+    link: https://events.withgoogle.com/amp-roadshow-melbourne/
   - title: tel aviv
     coords: 66x22
     location: tba
@@ -64,7 +80,7 @@ past:
     coords: 89x32
     date: 2017-10-09
   - title: SYDNEY
-    coords: 103x44
+    coords: 103x41
     date: 2017-10-13
   - title: MUNICH
     coords: 56x13


### PR DESCRIPTION
I moved Sydney over a bit to accommodate Melbourne.

Note that this is the first case where we have a city twice... namely, Sydney. I hacked this by moving the old city Sydney up by a coordinate so that it would fit entirely beneath the new city Sydney. But we're going to have this problem a couple more times soon as we repeat two other cities.