### PR TITLE
Fix staging deploy errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,4 +100,4 @@ jobs:
     env: APP_ENV=staging
     script:
     - scripts/unbuffer.sh gulp buildFinalize
-    - gcloud app deploy --project=amp-dev-staging --quiet
+    - gcloud app deploy --project=amp-dev-staging --quiet --version=1


### PR DESCRIPTION
Auto generated versions seem to result in hitting the services quota.
Let's try always using the same version.